### PR TITLE
feat(launch): add Pi integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,7 +422,7 @@ jobs:
         run: go test -tags podman,containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper ./...
 
   # --------------------------------------------------------------------------
-  # E2E: `llmman launch <claude|opencode|codex|hermes|openclaw> --model
+  # E2E: `llmman launch <claude|opencode|pi|codex|hermes|openclaw> --model
   # qwen3.5:0.8b` (tests/launch_e2e.rs) against a real `llmman serve`, a
   # real pulled model, a real llama-server, and the real third-party CLIs
   # — not mocks. Mirrors the `build` job's own 5-target matrix exactly
@@ -631,7 +631,7 @@ jobs:
       # multi-line/array syntax; ubuntu/macOS already default to bash.
       #
       # Unlike hermes/mlx_lm.server (legitimately missing on some
-      # platforms), these four are plain npm packages expected to work
+      # platforms), these five are plain npm packages expected to work
       # everywhere — so install_cli fails the job, rather than letting
       # tests/launch_e2e.rs's on_path check silently skip, when one never
       # becomes a working binary.
@@ -644,7 +644,7 @@ jobs:
       # designed (npm tolerates one failed platform-tarball fetch, here
       # a registry blip, instead of failing the install), just not
       # detectable by a mere on_path/PATH check. Retrying rides that out.
-      - name: Install integration CLIs (claude, opencode, codex, openclaw)
+      - name: Install integration CLIs (claude, opencode, pi, codex, openclaw)
         shell: bash
         run: |
           failed_clis=()
@@ -678,6 +678,7 @@ jobs:
 
           install_cli "@anthropic-ai/claude-code" "@anthropic-ai/claude-code" "claude"
           install_cli "opencode-ai" "opencode-ai" "opencode"
+          install_cli "@earendil-works/pi-coding-agent" "@earendil-works/pi-coding-agent" "pi"
           install_cli "@openai/codex" "@openai/codex" "codex"
           # Pinned (not @latest): tests/launch_e2e.rs's own openclaw
           # invocation was verified against this exact release — its

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Point an integration at a model in one step. `llmman launch` starts `serve` in t
 llmman launch claude --model gemma4
 ```
 
-Run `llmman launch` with no arguments to list the supported integrations (Claude Code, OpenCode) and whether each is installed. Any extra arguments after `--` are forwarded to the integration's own CLI.
+Run `llmman launch` with no arguments to list the supported integrations (Claude Code, OpenCode, Pi, and others) and whether each is installed. Any extra arguments after `--` are forwarded to the integration's own CLI.
 
 Short names work wherever a model reference is accepted.
 

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -382,6 +382,12 @@ const INTEGRATIONS: &[Integration] = &[
         install_hint: "https://opencode.ai",
     },
     Integration {
+        name: "pi",
+        description: "Pi coding agent",
+        binary: "pi",
+        install_hint: "npm install -g --ignore-scripts @earendil-works/pi-coding-agent",
+    },
+    Integration {
         name: "codex",
         description: "OpenAI Codex CLI",
         binary: "codex",
@@ -500,6 +506,7 @@ fn launch(name: &str, model: &str, api_key: &str, extra_args: &[String]) -> anyh
     match name.to_lowercase().as_str() {
         "claude" => launch_claude(model, api_key, extra_args),
         "opencode" => launch_opencode(model, api_key, extra_args),
+        "pi" => launch_pi(model, api_key, extra_args),
         "codex" => launch_codex(model, api_key, extra_args),
         "cline" => launch_simple("cline", "cline is not installed: npm install -g cline", model, extra_args),
         "aider" => launch_aider(model, api_key, extra_args),
@@ -581,6 +588,84 @@ fn opencode_config(model: &str, api_key: &str) -> String {
         "model": format!("ollama/{model}")
     })
     .to_string()
+}
+
+/// pi: register llmman as an OpenAI-compatible provider in models.json,
+/// then select that provider's model for this launch. The config stores an
+/// environment-variable reference rather than the key itself, so a real
+/// `--provider` credential is passed per request without being persisted.
+fn launch_pi(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
+    let bin = find_on_path("pi").ok_or_else(|| {
+        anyhow::anyhow!(
+            "pi is not installed — npm install -g --ignore-scripts \
+             @earendil-works/pi-coding-agent"
+        )
+    })?;
+
+    let effective_model = if model.is_empty() { "default" } else { model };
+    write_pi_config(effective_model)?;
+
+    let mut args = vec!["--model".to_string(), format!("llmman/{effective_model}")];
+    args.extend_from_slice(extra_args);
+    exec_with_env(&bin, &args, &[("LLMMAN_PI_API_KEY", api_key)])
+}
+
+/// Matches pi's documented config-directory override before falling back to
+/// its default `~/.pi/agent` directory.
+fn pi_agent_dir() -> anyhow::Result<PathBuf> {
+    if let Ok(dir) = std::env::var("PI_CODING_AGENT_DIR") {
+        if !dir.trim().is_empty() {
+            return Ok(PathBuf::from(dir));
+        }
+    }
+    let home = dirs::home_dir().context("no home directory")?;
+    Ok(home.join(".pi").join("agent"))
+}
+
+fn write_pi_config(model: &str) -> anyhow::Result<()> {
+    let config_dir = pi_agent_dir()?;
+    std::fs::create_dir_all(&config_dir)?;
+    let config_path = config_dir.join("models.json");
+    let existing = match std::fs::read_to_string(&config_path) {
+        Ok(existing) => existing,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(e).with_context(|| format!("read {}", config_path.display())),
+    };
+    let contents = pi_config(&existing, model, &daemon::server())?;
+    std::fs::write(config_path, contents)?;
+    Ok(())
+}
+
+/// Adds/replaces only llmman's provider entry, preserving unrelated custom
+/// providers and top-level settings in an existing pi models.json.
+fn pi_config(existing: &str, model: &str, server: &str) -> anyhow::Result<String> {
+    let mut root: serde_json::Value = if existing.trim().is_empty() {
+        serde_json::json!({})
+    } else {
+        serde_json::from_str(existing).context("parse pi models.json")?
+    };
+    let root = root
+        .as_object_mut()
+        .context("pi models.json root must be an object")?;
+    let providers = root
+        .entry("providers")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .context("pi models.json providers must be an object")?;
+    providers.insert(
+        "llmman".to_string(),
+        serde_json::json!({
+            "baseUrl": format!("{server}/v1"),
+            "api": "openai-completions",
+            "apiKey": "$LLMMAN_PI_API_KEY",
+            "compat": {
+                "supportsDeveloperRole": false,
+                "supportsReasoningEffort": false
+            },
+            "models": [{ "id": model }]
+        }),
+    );
+    Ok(format!("{}\n", serde_json::to_string_pretty(&root)?))
 }
 
 /// codex: set OPENAI_API_KEY=llmman and write ~/.codex/config.toml with the
@@ -985,6 +1070,46 @@ mod tests {
             yaml_quote(r#"a "quoted" \ value"#),
             r#""a \"quoted\" \\ value""#
         );
+    }
+
+    #[test]
+    fn pi_config_preserves_other_providers_without_persisting_the_key() {
+        let existing = r#"{
+          "custom": true,
+          "providers": {
+            "other": { "baseUrl": "https://example.invalid/v1" },
+            "llmman": { "stale": true }
+          }
+        }"#;
+        let rendered = pi_config(existing, "qwen3.5:0.8b", "http://127.0.0.1:17434")
+            .expect("render pi config");
+        let parsed: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+
+        assert_eq!(parsed["custom"], true);
+        assert_eq!(
+            parsed["providers"]["other"]["baseUrl"],
+            "https://example.invalid/v1"
+        );
+        assert_eq!(
+            parsed["providers"]["llmman"]["baseUrl"],
+            "http://127.0.0.1:17434/v1"
+        );
+        assert_eq!(
+            parsed["providers"]["llmman"]["models"][0]["id"],
+            "qwen3.5:0.8b"
+        );
+        assert_eq!(
+            parsed["providers"]["llmman"]["apiKey"],
+            "$LLMMAN_PI_API_KEY"
+        );
+        assert!(parsed["providers"]["llmman"].get("stale").is_none());
+    }
+
+    #[test]
+    fn pi_config_refuses_malformed_existing_config() {
+        assert!(pi_config("not json", "model", "http://localhost").is_err());
+        assert!(pi_config("[]", "model", "http://localhost").is_err());
+        assert!(pi_config(r#"{"providers": []}"#, "model", "http://localhost").is_err());
     }
 
     fn provider(id: &str, models: &[&str]) -> Provider {

--- a/tests/launch_e2e.rs
+++ b/tests/launch_e2e.rs
@@ -5,7 +5,7 @@
 //! from the bare short name the same way `llmman launch`/`pull` always
 //! resolve one — see `shortnames::resolve_ollama_api`), a real
 //! `llama-server` backing it, and the real third-party CLI under test
-//! (`claude`, `opencode`, `codex`, `hermes`, `openclaw`) — not mocks.
+//! (`claude`, `opencode`, `pi`, `codex`, `hermes`, `openclaw`) — not mocks.
 //! That's the only way this actually verifies anything: every one of the
 //! three bugs this file's tests were written to catch (see below) only
 //! ever showed up against the real binaries, never in isolation.
@@ -785,6 +785,28 @@ fn launch_opencode_with_model() {
         "opencode",
         &["run", PROMPT, "--print-logs", "--log-level", "DEBUG"],
     );
+}
+
+#[test]
+fn launch_pi_with_model() {
+    eprintln!("[test] launch_pi_with_model: acquiring SERIAL");
+    let _guard = lock_serial();
+    eprintln!("[test] launch_pi_with_model: acquired SERIAL");
+    if !on_path("llama-server") {
+        eprintln!("skipping: llama-server not on PATH (required to serve any model)");
+        return;
+    }
+    if !on_path("pi") {
+        eprintln!(
+            "skipping: pi not on PATH — npm install -g --ignore-scripts \
+             @earendil-works/pi-coding-agent"
+        );
+        return;
+    }
+
+    // `-p <prompt>`: pi's non-interactive one-shot mode. `run_launch`
+    // supplies a fresh HOME, so this also exercises models.json creation.
+    launch_and_assert("pi", &["-p", PROMPT]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- I added Pi to the `llmman launch` integration registry and dispatch path.
- I configure Pi through its documented `models.json` custom-provider format, preserve unrelated providers, and pass provider credentials through the child environment instead of writing them to disk.
- I added focused config regression tests plus a real Pi launch case to the existing cross-platform E2E matrix.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --release --all-targets -- -D warnings`
- `cargo test --release --lib --bins` (443 passed, 3 ignored)
- I exercised the built `llmman launch pi` path against a local test daemon and verified the selected model, forwarded arguments, credential environment, and preserved Pi config.
- I verified the generated provider config with Pi 0.84.4 model discovery. I left the real model/`llama-server` Pi E2E run to the existing CI matrix because `llama-server` is not installed locally.

Fixes #330
