### PR TITLE
feat(launch): add Factory Droid integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -716,6 +716,7 @@ jobs:
           install_cli "@anthropic-ai/claude-code" "@anthropic-ai/claude-code" "claude"
           install_cli "opencode-ai" "opencode-ai" "opencode"
           install_cli "@openai/codex" "@openai/codex" "codex"
+          install_cli "droid@0.208.1" "droid" "droid"
           # Pinned (not @latest): tests/launch_e2e.rs's qwen test relies on
           # this release's tool set under --safe-mode and on the
           # report_findings schema it excludes by name; a newer release can

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,6 +2032,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tar",
+ "tempfile",
  "tokio",
  "tokio-util",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ flate2     = "1"
 zip        = { version = "2", default-features = false, features = ["deflate"] }
 libloading = "0.8"
 multer     = "3"
+tempfile   = "3"
 
 # Real Xet-protocol downloads for HuggingFace files too large for the
 # plain-HTTP path to reliably serve — see src/xet_fetch.rs. Its

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Point an integration at a model in one step. `llmman launch` starts `serve` in t
 llmman launch claude --model gemma4
 ```
 
-Run `llmman launch` with no arguments to list the supported integrations (Claude Code, OpenCode) and whether each is installed. Any extra arguments after `--` are forwarded to the integration's own CLI.
+Run `llmman launch` with no arguments to list the supported integrations (Claude Code, OpenCode, Factory Droid, and others) and whether each is installed. Any extra arguments after `--` are forwarded to the integration's own CLI.
 
 Short names work wherever a model reference is accepted.
 
@@ -305,4 +305,3 @@ Uses [`github.com/podman-container-tools/container-libs`](https://github.com/pod
 ```
 cargo build --release --no-default-features --features podman
 ```
-

--- a/README.md
+++ b/README.md
@@ -253,8 +253,7 @@ The API key is read from the variable models.dev names for that provider
 and travels per request, never to disk. `droid` and `hermes` are the
 exceptions: llmman configures them through files on disk, so they can't
 carry a key. `llmman serve` needs the variable in its own environment
-instead. That
-fallback is only used for a daemon bound to loopback, and never for a
+instead. That fallback is only used for a daemon bound to loopback, and never for a
 browser request from another site. It bounds the blast radius rather
 than authenticating anyone, so on a shared machine prefer an integration
 that sends its own key. `cline`, `kimi`, `copilot` and `openclaw` can't be

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ running on your own machine, or at any hosted provider, in one command.
 No subscription, no rewiring, no vendor's idea of which model you should use.
 </p>
 
-```
+```sh
 llmman launch claude --model gemma4
 ```
 
@@ -26,13 +26,13 @@ on your machine. No Anthropic API key, no subscription, nothing leaves the box.
 
 **Linux, macOS:**
 
-```
+```sh
 curl -fsSL https://raw.githubusercontent.com/llmmanorg/llmman/main/install.sh | sh
 ```
 
 **Windows (PowerShell):**
 
-```
+```powershell
 irm https://raw.githubusercontent.com/llmmanorg/llmman/main/install.ps1 | iex
 ```
 
@@ -211,7 +211,7 @@ starts. They're documented in [docs/configuration.md](docs/configuration.md).
 
 Point an integration at a model in one step. `llmman launch` starts `serve` in the background if it isn't already running (preloading the requested model), then sets the right environment variables and execs the integration:
 
-```
+```sh
 llmman launch claude --model gemma4
 ```
 

--- a/README.md
+++ b/README.md
@@ -250,9 +250,10 @@ one place integrations are configured, whether a model is local or
 hosted, and both usable from the same session.
 
 The API key is read from the variable models.dev names for that provider
-and travels per request, never to disk. `hermes` is the exception: llmman
-configures it through a file on disk, so it can't carry a key and
-`llmman serve` needs the variable in its own environment instead. That
+and travels per request, never to disk. `droid` and `hermes` are the
+exceptions: llmman configures them through files on disk, so they can't
+carry a key. `llmman serve` needs the variable in its own environment
+instead. That
 fallback is only used for a daemon bound to loopback, and never for a
 browser request from another site. It bounds the blast radius rather
 than authenticating anyone, so on a shared machine prefer an integration

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -626,9 +626,8 @@ fn write_droid_config(model: &str) -> anyhow::Result<String> {
 }
 
 /// Adds or replaces llmman's one owned entry and returns Droid's positional
-/// custom-model ID. An explicit marker (`apiKey: "llmman"` plus the ID prefix)
-/// distinguishes this entry from the user's own models without persisting a
-/// real provider credential.
+/// custom-model ID. A dedicated boolean marker distinguishes this entry from
+/// similarly named user models without persisting a real provider credential.
 fn update_droid_settings(
     existing: &str,
     model: &str,
@@ -649,11 +648,13 @@ fn update_droid_settings(
             return false;
         };
         entry
-            .get("id")
-            .and_then(serde_json::Value::as_str)
-            .is_some_and(|id| id.starts_with("custom:llmman-"))
-            || (entry.get("displayName").and_then(serde_json::Value::as_str) == Some("llmman")
-                && entry.get("apiKey").and_then(serde_json::Value::as_str) == Some("llmman"))
+            .get("llmmanManaged")
+            .and_then(serde_json::Value::as_bool)
+            == Some(true)
+            && entry
+                .get("id")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|id| id.starts_with("custom:llmman-"))
     });
     let index = owned.unwrap_or(models.len());
     let custom_model_id = format!("custom:llmman-{index}");
@@ -669,6 +670,7 @@ fn update_droid_settings(
     entry.insert("maxOutputTokens".into(), 64_000.into());
     entry.insert("id".into(), custom_model_id.clone().into());
     entry.insert("index".into(), index.into());
+    entry.insert("llmmanManaged".into(), true.into());
 
     if let Some(i) = owned {
         models[i] = serde_json::Value::Object(entry);
@@ -1156,6 +1158,7 @@ mod tests {
         assert_eq!(model["maxOutputTokens"], 64_000);
         assert_eq!(model["id"], id);
         assert_eq!(model["index"], 0);
+        assert_eq!(model["llmmanManaged"], true);
     }
 
     #[test]
@@ -1190,6 +1193,7 @@ mod tests {
                     "apiKey": "llmman",
                     "id": "custom:llmman-1",
                     "index": 1,
+                    "llmmanManaged": true,
                     "futureField": "preserved"
                 }
             ]
@@ -1206,6 +1210,31 @@ mod tests {
         assert_eq!(parsed["customModels"][1]["model"], "new");
         assert_eq!(parsed["customModels"][1]["baseUrl"], "http://new/v1");
         assert_eq!(parsed["customModels"][1]["futureField"], "preserved");
+    }
+
+    #[test]
+    fn droid_settings_do_not_overwrite_a_similarly_named_user_model() {
+        let existing = r#"{
+            "customModels": [{
+                "model": "user-model",
+                "displayName": "llmman",
+                "apiKey": "llmman",
+                "id": "custom:llmman-0",
+                "index": 0
+            }]
+        }"#;
+        let (settings, id) =
+            update_droid_settings(existing, "managed-model", "http://localhost/v1").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&settings).unwrap();
+
+        assert_eq!(id, "custom:llmman-1");
+        assert_eq!(parsed["customModels"][0]["model"], "user-model");
+        assert_eq!(
+            parsed["customModels"][0]["llmmanManaged"],
+            serde_json::Value::Null
+        );
+        assert_eq!(parsed["customModels"][1]["model"], "managed-model");
+        assert_eq!(parsed["customModels"][1]["llmmanManaged"], true);
     }
 
     #[test]

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -595,9 +595,8 @@ fn strip_legacy_llmman_profile(existing: &str) -> String {
 fn launch_droid(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
     let bin = find_on_path("droid").ok_or_else(|| anyhow::anyhow!("droid is not installed"))?;
     let effective_model = if model.is_empty() { "default" } else { model };
-    let custom_model_id = write_droid_config(effective_model)?;
-    let args = droid_args(&custom_model_id, extra_args);
-    exec_with_env(&bin, &args, &[])
+    write_droid_config(effective_model)?;
+    exec_with_env(&bin, extra_args, &[])
 }
 
 /// Writes the modern Factory settings format documented at
@@ -609,29 +608,106 @@ fn write_droid_config(model: &str) -> anyhow::Result<String> {
     std::fs::create_dir_all(&config_dir)?;
     let config_path = config_dir.join("settings.json");
 
+    // Serialize cooperating llmman launches before reading and replacing settings.
+    let lock = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(config_dir.join("settings.llmman.lock"))?;
+    lock.lock()?;
+
     let existing = match std::fs::read_to_string(&config_path) {
         Ok(contents) => contents,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => "{}".to_string(),
         Err(err) => return Err(err).with_context(|| format!("read {}", config_path.display())),
     };
     let base_url = format!("{}/v1", daemon::server());
-    let (contents, custom_model_id) = update_droid_settings(&existing, model, &base_url)
-        .with_context(|| format!("parse {}", config_path.display()))?;
+    let (contents, custom_model_id) = update_droid_settings_with_capabilities(
+        &existing,
+        model,
+        &base_url,
+        droid_image_support(model),
+    )
+    .with_context(|| format!("parse {}", config_path.display()))?;
 
     if existing != contents {
-        std::fs::write(&config_path, contents)
-            .with_context(|| format!("write {}", config_path.display()))?;
+        save_droid_settings(&config_path, &existing, &contents)?;
     }
     Ok(custom_model_id)
 }
 
-/// Adds or replaces llmman's one owned entry and returns Droid's positional
-/// custom-model ID. A dedicated boolean marker distinguishes this entry from
-/// similarly named user models without persisting a real provider credential.
+// Provider metadata currently does not expose modalities. Preserve Droid's
+// default for unknown capabilities instead of declaring such a model text-only.
+fn droid_image_support(model: &str) -> Option<bool> {
+    let reference = crate::shortnames::resolve_ollama_api(model).ok()?;
+    let store_path = crate::default_store().ok()?;
+    let store = crate::storage::OciStore::open(&store_path).ok()?;
+    let desc = store.find(&reference).ok()?;
+    let manifest = store.read_manifest(&desc.digest).ok()?;
+    let raw = crate::hf::oci::read_blob(&store_path, &manifest.config.digest).ok()?;
+    let config: serde_json::Value = serde_json::from_slice(&raw).ok()?;
+    let inputs = config
+        .pointer("/config/capabilities/inputTypes")?
+        .as_array()?;
+    Some(inputs.iter().any(|input| input.as_str() == Some("image")))
+}
+
+fn save_droid_settings(
+    path: &std::path::Path,
+    expected: &str,
+    contents: &str,
+) -> anyhow::Result<()> {
+    use std::io::Write;
+    let parent = path
+        .parent()
+        .context("Factory settings have no parent directory")?;
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(m) => {
+            anyhow::ensure!(m.is_file(), "Factory settings must be a regular file");
+            Some(m)
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => return Err(e.into()),
+    };
+    let mut staged = tempfile::NamedTempFile::new_in(parent)?;
+    if let Some(m) = &metadata {
+        staged.as_file().set_permissions(m.permissions())?;
+    }
+    staged.write_all(contents.as_bytes())?;
+    staged.as_file().sync_all()?;
+    if metadata.is_some() {
+        anyhow::ensure!(
+            std::fs::read_to_string(path)? == expected,
+            "Factory settings changed concurrently; retry launch"
+        );
+        let mut backup = tempfile::NamedTempFile::new_in(parent)?;
+        backup.write_all(expected.as_bytes())?;
+        backup.as_file().sync_all()?;
+        backup.persist(path.with_extension("json.bak"))?;
+    } else {
+        staged.persist_noclobber(path)?;
+        return Ok(());
+    }
+    staged.persist(path)?;
+    Ok(())
+}
+
+#[cfg(test)]
 fn update_droid_settings(
     existing: &str,
     model: &str,
     base_url: &str,
+) -> anyhow::Result<(String, String)> {
+    update_droid_settings_with_capabilities(existing, model, base_url, Some(false))
+}
+
+/// Match ownership by the reserved placeholder key; do not add private schema fields.
+fn update_droid_settings_with_capabilities(
+    existing: &str,
+    model: &str,
+    base_url: &str,
+    supports_images: Option<bool>,
 ) -> anyhow::Result<(String, String)> {
     let mut settings: serde_json::Value = serde_json::from_str(existing)?;
     let root = settings
@@ -647,14 +723,8 @@ fn update_droid_settings(
         let Some(entry) = entry.as_object() else {
             return false;
         };
-        entry
-            .get("llmmanManaged")
-            .and_then(serde_json::Value::as_bool)
-            == Some(true)
-            && entry
-                .get("id")
-                .and_then(serde_json::Value::as_str)
-                .is_some_and(|id| id.starts_with("custom:llmman-"))
+        entry.get("apiKey").and_then(serde_json::Value::as_str)
+            == Some(providers::PLACEHOLDER_API_KEY)
     });
     let index = owned.unwrap_or(models.len());
     let custom_model_id = format!("custom:llmman-{index}");
@@ -665,12 +735,16 @@ fn update_droid_settings(
     entry.insert("model".into(), model.into());
     entry.insert("displayName".into(), "llmman".into());
     entry.insert("baseUrl".into(), base_url.into());
-    entry.insert("apiKey".into(), "llmman".into());
+    entry.insert("apiKey".into(), providers::PLACEHOLDER_API_KEY.into());
     entry.insert("provider".into(), "generic-chat-completion-api".into());
     entry.insert("maxOutputTokens".into(), 64_000.into());
     entry.insert("id".into(), custom_model_id.clone().into());
     entry.insert("index".into(), index.into());
-    entry.insert("llmmanManaged".into(), true.into());
+    entry.remove("llmmanManaged");
+    if let Some(images) = supports_images {
+        entry.insert("supportsImages".into(), images.into());
+        entry.insert("noImageSupport".into(), (!images).into());
+    }
 
     if let Some(i) = owned {
         models[i] = serde_json::Value::Object(entry);
@@ -678,15 +752,23 @@ fn update_droid_settings(
         models.push(serde_json::Value::Object(entry));
     }
 
+    let defaults = root
+        .entry("sessionDefaultSettings")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .context("Factory sessionDefaultSettings must be a JSON object")?;
+    defaults.insert("model".into(), custom_model_id.clone().into());
+    if !matches!(
+        defaults
+            .get("reasoningEffort")
+            .and_then(serde_json::Value::as_str),
+        Some("none" | "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "dynamic")
+    ) {
+        defaults.insert("reasoningEffort".into(), "none".into());
+    }
     let mut rendered = serde_json::to_string_pretty(&settings)?;
     rendered.push('\n');
     Ok((rendered, custom_model_id))
-}
-
-fn droid_args(custom_model_id: &str, extra_args: &[String]) -> Vec<String> {
-    let mut args = vec!["--model".to_string(), custom_model_id.to_string()];
-    args.extend_from_slice(extra_args);
-    args
 }
 
 /// aider: set OPENAI_API_KEY and OPENAI_BASE_URL.
@@ -1158,7 +1240,10 @@ mod tests {
         assert_eq!(model["maxOutputTokens"], 64_000);
         assert_eq!(model["id"], id);
         assert_eq!(model["index"], 0);
-        assert_eq!(model["llmmanManaged"], true);
+        assert!(model.get("llmmanManaged").is_none());
+        assert_eq!(parsed["sessionDefaultSettings"]["model"], id);
+        assert_eq!(parsed["sessionDefaultSettings"]["reasoningEffort"], "none");
+        assert_eq!(model["supportsImages"], false);
     }
 
     #[test]
@@ -1218,7 +1303,7 @@ mod tests {
             "customModels": [{
                 "model": "user-model",
                 "displayName": "llmman",
-                "apiKey": "llmman",
+                "apiKey": "user-owned-key",
                 "id": "custom:llmman-0",
                 "index": 0
             }]
@@ -1234,7 +1319,7 @@ mod tests {
             serde_json::Value::Null
         );
         assert_eq!(parsed["customModels"][1]["model"], "managed-model");
-        assert_eq!(parsed["customModels"][1]["llmmanManaged"], true);
+        assert!(parsed["customModels"][1].get("llmmanManaged").is_none());
     }
 
     #[test]
@@ -1250,15 +1335,38 @@ mod tests {
     }
 
     #[test]
-    fn droid_launch_args_select_our_model_before_forwarded_args() {
-        let extra = vec![
-            "--auto".to_string(),
-            "high".to_string(),
-            "fix it".to_string(),
-        ];
+    fn droid_settings_preserve_valid_effort_and_set_image_support() {
+        let existing =
+            r#"{"sessionDefaultSettings":{"reasoningEffort":"low","autonomyLevel":"off"}}"#;
+        let (settings, _) = update_droid_settings_with_capabilities(
+            existing,
+            "vision",
+            "http://localhost/v1",
+            Some(true),
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&settings).unwrap();
+        assert_eq!(v["customModels"][0]["supportsImages"], true);
+        assert_eq!(v["customModels"][0]["noImageSupport"], false);
+        assert_eq!(v["sessionDefaultSettings"]["reasoningEffort"], "low");
+        assert_eq!(v["sessionDefaultSettings"]["autonomyLevel"], "off");
+    }
+
+    #[test]
+    fn droid_settings_backup_and_concurrent_change_guard() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        save_droid_settings(&path, "{}", "{\"theme\":\"dark\"}").unwrap();
+        assert!(!path.with_extension("json.bak").exists());
+        save_droid_settings(&path, "{\"theme\":\"dark\"}", "{\"theme\":\"light\"}").unwrap();
         assert_eq!(
-            droid_args("custom:llmman-3", &extra),
-            ["--model", "custom:llmman-3", "--auto", "high", "fix it"]
+            std::fs::read_to_string(path.with_extension("json.bak")).unwrap(),
+            "{\"theme\":\"dark\"}"
+        );
+        assert!(save_droid_settings(&path, "{}", "{}").is_err());
+        assert_eq!(
+            std::fs::read_to_string(path).unwrap(),
+            "{\"theme\":\"light\"}"
         );
     }
 

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -702,7 +702,20 @@ fn update_droid_settings(
     update_droid_settings_with_capabilities(existing, model, base_url, Some(false))
 }
 
-/// Match ownership by the reserved placeholder key; do not add private schema fields.
+/// Match ownership by Factory-visible fields, not the placeholder key alone.
+fn is_llmman_droid_entry(entry: &serde_json::Map<String, serde_json::Value>) -> bool {
+    entry.get("apiKey").and_then(serde_json::Value::as_str) == Some(providers::PLACEHOLDER_API_KEY)
+        && entry.get("displayName").and_then(serde_json::Value::as_str) == Some("llmman")
+        && entry
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|id| id.starts_with("custom:llmman-"))
+        && entry
+            .get("index")
+            .and_then(serde_json::Value::as_u64)
+            .is_some()
+}
+
 fn update_droid_settings_with_capabilities(
     existing: &str,
     model: &str,
@@ -719,13 +732,9 @@ fn update_droid_settings_with_capabilities(
         .as_array_mut()
         .context("Factory customModels must be a JSON array")?;
 
-    let owned = models.iter().position(|entry| {
-        let Some(entry) = entry.as_object() else {
-            return false;
-        };
-        entry.get("apiKey").and_then(serde_json::Value::as_str)
-            == Some(providers::PLACEHOLDER_API_KEY)
-    });
+    let owned = models
+        .iter()
+        .position(|entry| entry.as_object().is_some_and(is_llmman_droid_entry));
     let index = owned.unwrap_or(models.len());
     let custom_model_id = format!("custom:llmman-{index}");
 
@@ -744,6 +753,9 @@ fn update_droid_settings_with_capabilities(
     if let Some(images) = supports_images {
         entry.insert("supportsImages".into(), images.into());
         entry.insert("noImageSupport".into(), (!images).into());
+    } else {
+        entry.remove("supportsImages");
+        entry.remove("noImageSupport");
     }
 
     if let Some(i) = owned {
@@ -1298,6 +1310,27 @@ mod tests {
     }
 
     #[test]
+    fn droid_settings_do_not_overwrite_user_model_with_placeholder_key() {
+        let existing = r#"{
+            "customModels": [{
+                "model": "user-model",
+                "displayName": "Personal",
+                "apiKey": "llmman",
+                "id": "custom:user-0",
+                "index": 0
+            }]
+        }"#;
+        let (settings, id) =
+            update_droid_settings(existing, "managed-model", "http://localhost/v1").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&settings).unwrap();
+
+        assert_eq!(id, "custom:llmman-1");
+        assert_eq!(parsed["customModels"][0]["model"], "user-model");
+        assert_eq!(parsed["customModels"][0]["displayName"], "Personal");
+        assert_eq!(parsed["customModels"][1]["model"], "managed-model");
+    }
+
+    #[test]
     fn droid_settings_do_not_overwrite_a_similarly_named_user_model() {
         let existing = r#"{
             "customModels": [{
@@ -1350,6 +1383,31 @@ mod tests {
         assert_eq!(v["customModels"][0]["noImageSupport"], false);
         assert_eq!(v["sessionDefaultSettings"]["reasoningEffort"], "low");
         assert_eq!(v["sessionDefaultSettings"]["autonomyLevel"], "off");
+    }
+
+    #[test]
+    fn droid_settings_clear_stale_image_flags_when_capability_is_unknown() {
+        let existing = r#"{
+            "customModels": [{
+                "model": "vision",
+                "displayName": "llmman",
+                "baseUrl": "http://old/v1",
+                "apiKey": "llmman",
+                "provider": "generic-chat-completion-api",
+                "id": "custom:llmman-0",
+                "index": 0,
+                "supportsImages": true,
+                "noImageSupport": false
+            }]
+        }"#;
+        let (settings, _) =
+            update_droid_settings_with_capabilities(existing, "unknown", "http://new/v1", None)
+                .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&settings).unwrap();
+
+        assert_eq!(v["customModels"][0]["model"], "unknown");
+        assert!(v["customModels"][0].get("supportsImages").is_none());
+        assert!(v["customModels"][0].get("noImageSupport").is_none());
     }
 
     #[test]

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -152,7 +152,7 @@ const PROVIDER_UNSUPPORTED: &[(&str, &str)] = &[
 /// a credential, which this feature promises not to do. They rely on
 /// `llmman serve` having the variable itself — which it only uses for a
 /// daemon nobody else can reach (see `reachable_only_locally`).
-const PROVIDER_NEEDS_DAEMON_KEY: &[&str] = &["hermes"];
+const PROVIDER_NEEDS_DAEMON_KEY: &[&str] = &["droid", "hermes"];
 
 fn check_provider_supported(integration: &str) -> anyhow::Result<()> {
     let name = integration.to_lowercase();
@@ -303,6 +303,11 @@ const INTEGRATIONS: &[Integration] = &[
         binary: "codex",
     },
     Integration {
+        name: "droid",
+        description: "Factory Droid CLI",
+        binary: "droid",
+    },
+    Integration {
         name: "cline",
         description: "Cline",
         binary: "cline",
@@ -411,6 +416,7 @@ fn launch(name: &str, model: &str, api_key: &str, extra_args: &[String]) -> anyh
         "claude" => launch_claude(model, api_key, extra_args),
         "opencode" => launch_opencode(model, api_key, extra_args),
         "codex" => launch_codex(model, api_key, extra_args),
+        "droid" => launch_droid(model, extra_args),
         "cline" => launch_simple("cline", model, extra_args),
         "aider" => launch_aider(model, api_key, extra_args),
         "copilot" | "copilot-cli" => launch_copilot(model, extra_args),
@@ -580,6 +586,105 @@ fn strip_legacy_llmman_profile(existing: &str) -> String {
         out.push('\n');
     }
     out
+}
+
+/// droid: add one llmman-owned custom model to Factory's shared settings,
+/// then select that exact entry on launch. The placeholder key is deliberate:
+/// local models need no secret, while provider-routed launches require the
+/// loopback daemon to hold the real key (see `PROVIDER_NEEDS_DAEMON_KEY`).
+fn launch_droid(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
+    let bin = find_on_path("droid").ok_or_else(|| anyhow::anyhow!("droid is not installed"))?;
+    let effective_model = if model.is_empty() { "default" } else { model };
+    let custom_model_id = write_droid_config(effective_model)?;
+    let args = droid_args(&custom_model_id, extra_args);
+    exec_with_env(&bin, &args, &[])
+}
+
+/// Writes the modern Factory settings format documented at
+/// <https://docs.factory.ai/model-independence/byok>. The parsed JSON object is
+/// retained so unrelated user settings and custom models survive unchanged.
+fn write_droid_config(model: &str) -> anyhow::Result<String> {
+    let home = dirs::home_dir().context("no home directory")?;
+    let config_dir = home.join(".factory");
+    std::fs::create_dir_all(&config_dir)?;
+    let config_path = config_dir.join("settings.json");
+
+    let existing = match std::fs::read_to_string(&config_path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => "{}".to_string(),
+        Err(err) => return Err(err).with_context(|| format!("read {}", config_path.display())),
+    };
+    let base_url = format!("{}/v1", daemon::server());
+    let (contents, custom_model_id) = update_droid_settings(&existing, model, &base_url)
+        .with_context(|| format!("parse {}", config_path.display()))?;
+
+    if existing != contents {
+        std::fs::write(&config_path, contents)
+            .with_context(|| format!("write {}", config_path.display()))?;
+    }
+    Ok(custom_model_id)
+}
+
+/// Adds or replaces llmman's one owned entry and returns Droid's positional
+/// custom-model ID. An explicit marker (`apiKey: "llmman"` plus the ID prefix)
+/// distinguishes this entry from the user's own models without persisting a
+/// real provider credential.
+fn update_droid_settings(
+    existing: &str,
+    model: &str,
+    base_url: &str,
+) -> anyhow::Result<(String, String)> {
+    let mut settings: serde_json::Value = serde_json::from_str(existing)?;
+    let root = settings
+        .as_object_mut()
+        .context("Factory settings must be a JSON object")?;
+    let models = root
+        .entry("customModels")
+        .or_insert_with(|| serde_json::Value::Array(Vec::new()))
+        .as_array_mut()
+        .context("Factory customModels must be a JSON array")?;
+
+    let owned = models.iter().position(|entry| {
+        let Some(entry) = entry.as_object() else {
+            return false;
+        };
+        entry
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|id| id.starts_with("custom:llmman-"))
+            || (entry.get("displayName").and_then(serde_json::Value::as_str) == Some("llmman")
+                && entry.get("apiKey").and_then(serde_json::Value::as_str) == Some("llmman"))
+    });
+    let index = owned.unwrap_or(models.len());
+    let custom_model_id = format!("custom:llmman-{index}");
+
+    let mut entry = owned
+        .and_then(|i| models[i].as_object().cloned())
+        .unwrap_or_default();
+    entry.insert("model".into(), model.into());
+    entry.insert("displayName".into(), "llmman".into());
+    entry.insert("baseUrl".into(), base_url.into());
+    entry.insert("apiKey".into(), "llmman".into());
+    entry.insert("provider".into(), "generic-chat-completion-api".into());
+    entry.insert("maxOutputTokens".into(), 64_000.into());
+    entry.insert("id".into(), custom_model_id.clone().into());
+    entry.insert("index".into(), index.into());
+
+    if let Some(i) = owned {
+        models[i] = serde_json::Value::Object(entry);
+    } else {
+        models.push(serde_json::Value::Object(entry));
+    }
+
+    let mut rendered = serde_json::to_string_pretty(&settings)?;
+    rendered.push('\n');
+    Ok((rendered, custom_model_id))
+}
+
+fn droid_args(custom_model_id: &str, extra_args: &[String]) -> Vec<String> {
+    let mut args = vec!["--model".to_string(), custom_model_id.to_string()];
+    args.extend_from_slice(extra_args);
+    args
 }
 
 /// aider: set OPENAI_API_KEY and OPENAI_BASE_URL.
@@ -1032,6 +1137,99 @@ mod tests {
         assert_eq!(
             qwen_args("m:latest", &user_camel),
             ["--model", "m:latest", "--authType", "openai"]
+        );
+    }
+
+    #[test]
+    fn droid_settings_create_a_selectable_llmman_model() {
+        let (settings, id) = update_droid_settings("{}", "qwen3.5:0.8b", "http://localhost/v1")
+            .expect("valid settings");
+        let parsed: serde_json::Value = serde_json::from_str(&settings).unwrap();
+        let model = &parsed["customModels"][0];
+
+        assert_eq!(id, "custom:llmman-0");
+        assert_eq!(model["model"], "qwen3.5:0.8b");
+        assert_eq!(model["displayName"], "llmman");
+        assert_eq!(model["baseUrl"], "http://localhost/v1");
+        assert_eq!(model["apiKey"], "llmman");
+        assert_eq!(model["provider"], "generic-chat-completion-api");
+        assert_eq!(model["maxOutputTokens"], 64_000);
+        assert_eq!(model["id"], id);
+        assert_eq!(model["index"], 0);
+    }
+
+    #[test]
+    fn droid_settings_preserve_unrelated_data_and_append_ours() {
+        let existing = r#"{
+            "theme": "dark",
+            "customModels": [{
+                "model": "other",
+                "displayName": "Other",
+                "customField": {"keep": true}
+            }]
+        }"#;
+        let (settings, id) =
+            update_droid_settings(existing, "model/with:specials", "http://localhost/v1").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&settings).unwrap();
+
+        assert_eq!(parsed["theme"], "dark");
+        assert_eq!(parsed["customModels"][0]["customField"]["keep"], true);
+        assert_eq!(parsed["customModels"][1]["model"], "model/with:specials");
+        assert_eq!(parsed["customModels"][1]["index"], 1);
+        assert_eq!(id, "custom:llmman-1");
+    }
+
+    #[test]
+    fn droid_settings_replace_only_our_entry_and_are_idempotent() {
+        let existing = r#"{
+            "customModels": [
+                {"model": "other", "displayName": "Other"},
+                {
+                    "model": "old",
+                    "displayName": "llmman",
+                    "apiKey": "llmman",
+                    "id": "custom:llmman-1",
+                    "index": 1,
+                    "futureField": "preserved"
+                }
+            ]
+        }"#;
+        let (once, id) = update_droid_settings(existing, "new", "http://new/v1").unwrap();
+        let (twice, second_id) = update_droid_settings(&once, "new", "http://new/v1").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&twice).unwrap();
+
+        assert_eq!(id, "custom:llmman-1");
+        assert_eq!(second_id, id);
+        assert_eq!(once, twice);
+        assert_eq!(parsed["customModels"].as_array().unwrap().len(), 2);
+        assert_eq!(parsed["customModels"][0]["model"], "other");
+        assert_eq!(parsed["customModels"][1]["model"], "new");
+        assert_eq!(parsed["customModels"][1]["baseUrl"], "http://new/v1");
+        assert_eq!(parsed["customModels"][1]["futureField"], "preserved");
+    }
+
+    #[test]
+    fn droid_settings_reject_corruption_instead_of_overwriting_it() {
+        assert!(update_droid_settings("{broken", "model", "http://localhost/v1").is_err());
+        assert!(update_droid_settings("[]", "model", "http://localhost/v1").is_err());
+        assert!(update_droid_settings(
+            r#"{"customModels":"not-an-array"}"#,
+            "model",
+            "http://localhost/v1"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn droid_launch_args_select_our_model_before_forwarded_args() {
+        let extra = vec![
+            "--auto".to_string(),
+            "high".to_string(),
+            "fix it".to_string(),
+        ];
+        assert_eq!(
+            droid_args("custom:llmman-3", &extra),
+            ["--model", "custom:llmman-3", "--auto", "high", "fix it"]
         );
     }
 

--- a/tests/launch_e2e.rs
+++ b/tests/launch_e2e.rs
@@ -835,26 +835,7 @@ fn launch_droid_with_model() {
         return;
     }
     // No --model override: this verifies the persisted session-default selection.
-    let home = fresh_home("droid");
-    std::fs::create_dir_all(home.join(".factory")).unwrap();
-    std::fs::write(
-        home.join(".factory/settings.json"),
-        r#"{"cloudSessionSync":false}"#,
-    )
-    .unwrap();
-    let output = run_launch(&home, "droid", &["exec", PROMPT])
-        .unwrap_or_else(|_| panic!("Droid launch timed out"));
-    assert!(
-        output.status.success(),
-        "Droid rejected the launch: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stdout)
-            .to_lowercase()
-            .contains("pong"),
-        "Droid did not return the expected model response"
-    );
+    launch_and_assert("droid", &["exec", PROMPT]);
 }
 
 #[test]

--- a/tests/launch_e2e.rs
+++ b/tests/launch_e2e.rs
@@ -828,6 +828,36 @@ fn launch_hermes_with_model() {
 }
 
 #[test]
+fn launch_droid_with_model() {
+    let _guard = lock_serial();
+    if !on_path("llama-server") || !on_path("droid") {
+        eprintln!("skipping Droid E2E: requires llama-server and droid on PATH");
+        return;
+    }
+    // No --model override: this verifies the persisted session-default selection.
+    let home = fresh_home("droid");
+    std::fs::create_dir_all(home.join(".factory")).unwrap();
+    std::fs::write(
+        home.join(".factory/settings.json"),
+        r#"{"cloudSessionSync":false}"#,
+    )
+    .unwrap();
+    let output = run_launch(&home, "droid", &["exec", PROMPT])
+        .unwrap_or_else(|_| panic!("Droid launch timed out"));
+    assert!(
+        output.status.success(),
+        "Droid rejected the launch: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout)
+            .to_lowercase()
+            .contains("pong"),
+        "Droid did not return the expected model response"
+    );
+}
+
+#[test]
 fn launch_openclaw_with_model() {
     eprintln!("[test] launch_openclaw_with_model: acquiring SERIAL");
     let _guard = lock_serial();


### PR DESCRIPTION
Add Factory Droid to `llmman launch`, backed by the local daemon. The launcher preserves unrelated Factory settings and selects the managed model through `sessionDefaultSettings`, without a Droid `--model` override. Managed entries are identified by the placeholder credential plus the expected llmman display name, ID prefix and numeric index, so an unrelated model using the same dummy key is preserved.

Settings updates use a backup, atomic replacement and a lock between cooperating llmman launches. Image flags follow model capabilities; both flags are removed when capabilities are unknown. The workflow installs pinned Droid 0.208.1 and exercises the real CLI through the suite's existing retry/tolerant response helper.

Validation on macOS arm64 for `e56b1a0`:

- `cargo fmt --all -- --check` and `git diff --check` passed.
- `cargo test --release --lib cmd::launch::tests --offline`: 22 passed, including preservation of a user model with the placeholder key and removal of stale image flags.
- `cargo test --release --test launch_e2e launch_droid_with_model --offline -- --nocapture --test-threads=1`: 1 passed with real Droid 0.208.1, CI-pinned llama.cpp b10293 and qwen3.5:0.8b. Warm-up succeeded; the Droid invocation completed in 15.29 seconds. The shared helper tolerates stochastic response wording, so this is not a strict content or cross-platform guarantee.

This PR is ready for upstream platform checks and maintainer review. The full library/binary suite and Clippy were not rerun locally for this follow-up.

Closes #345
