### PR TITLE
fix: match ollama's unload contract on the API and in llmman stop

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -2287,10 +2287,20 @@ fn unload_key(
 /// unloadable, since the `running` entry is authoritative and is consulted
 /// first.
 async fn unload_model(state: &AppState, model: &str) -> Result<(), AppError> {
-    let canonical = unload_key(state, model).map_err(AppError::bad_request)?;
-    // Wait for an in-flight load of this model to publish itself first, so
-    // it can't race ahead of this remove.
-    let _guard = acquire_load_lock(&canonical).await;
+    // Lock on the same key `ensure_model` locks on, which it computes
+    // before any pull; then resolve again under the lock, as it does
+    // after its pull. A load in flight can refine the key it finally
+    // inserts under (see its own "re-canonicalise" note), and an unload
+    // that had already fixed its key before waiting on that lock would
+    // remove the stale spelling, miss, find the freshly pulled model in
+    // the store, and answer success while the loader's entry stays.
+    let lock_key = unload_key(state, model).map_err(AppError::bad_request)?;
+    let _guard = acquire_load_lock(&lock_key).await;
+    let canonical = if crate::providers::is_remote_ref(model) {
+        lock_key
+    } else {
+        canonical_ref(&state.0.store_path, &lock_key)
+    };
     if state
         .0
         .manager
@@ -6831,6 +6841,12 @@ mod tests {
     // -- Idle-timeout auto-unload reaper --------------------------------------
 
     fn test_state() -> AppState {
+        test_state_at(std::env::temp_dir())
+    }
+
+    /// `test_state` with a real store directory, for the few tests that
+    /// need `canonical_ref` to actually resolve something.
+    fn test_state_at(store_path: PathBuf) -> AppState {
         AppState(Arc::new(Inner {
             manager: Mutex::new(ModelManager {
                 running: HashMap::new(),
@@ -6853,7 +6869,7 @@ mod tests {
             // anyway.
             max_queue: usize::MAX,
             max_loaded_models: 0,
-            store_path: std::env::temp_dir(),
+            store_path,
             cache_path: std::env::temp_dir(),
             client: Client::new(),
         }))
@@ -7761,6 +7777,71 @@ mod tests {
                 .contains_key("docker.io/ai/orphan:latest"),
             "the running entry must be gone"
         );
+    }
+
+    /// An unload that arrives while a first load of the same model is in
+    /// flight blocks on the load lock. By the time it runs, the pull has
+    /// landed and the loader has inserted under the key `canonical_ref`
+    /// now refines to, which can differ from the key both sides locked
+    /// on. Resolving before the lock and removing that stale spelling
+    /// misses the entry, finds the pulled model in the store, and reports
+    /// success with the model still loaded.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_unload_waiting_on_a_load_removes_the_key_that_load_inserted() {
+        let dir = std::env::temp_dir().join(format!(
+            "llmman-unload-race-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let state = test_state_at(dir.clone());
+
+        // What ensure_model locks on before its pull, and what unload_key
+        // resolves to against a store that does not yet hold the model.
+        let pre_pull_key = "docker.io/ai/m:latest";
+        let loading = acquire_load_lock(pre_pull_key).await;
+
+        let unloader = state.clone();
+        let unload = tokio::spawn(async move { unload_model(&unloader, "docker.io/ai/m").await });
+        // Let the unload reach the lock and park on it.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // The pull lands with the tagless spelling as the stored reference,
+        // and the loader inserts under that refined key.
+        let desc = crate::storage::oci::Descriptor {
+            media_type: "application/vnd.oci.image.manifest.v1+json".into(),
+            digest: "sha256:0000".into(),
+            size: 0,
+            annotations: None,
+        };
+        OciStore::open(&dir)
+            .unwrap()
+            .tag(desc, "docker.io/ai/m")
+            .unwrap();
+        state.0.manager.lock().await.running.insert(
+            "docker.io/ai/m".into(),
+            running_model_fixture(Some(DEFAULT_KEEP_ALIVE), Duration::ZERO, 0),
+        );
+        drop(loading);
+
+        unload
+            .await
+            .unwrap()
+            .expect("the unload must not error once the load releases the lock");
+        assert!(
+            !state
+                .0
+                .manager
+                .lock()
+                .await
+                .running
+                .contains_key("docker.io/ai/m"),
+            "the unload must remove the key the load inserted, not the one it resolved before waiting"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Pins which requests name the unload sentinel: every zero form

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -682,11 +682,11 @@ impl ModelProcess {
     /// True if the underlying child process hasn't exited on its own since
     /// this model was marked running. Nothing else ever tells `mgr.running`
     /// about a process exiting unexpectedly: every other removal is a
-    /// deliberate one — the Ollama unload signal, in both
-    /// `handle_ollama_generate` and `handle_ollama_chat`; the idle reaper
-    /// (`reap_idle_models_once`); and eviction under
-    /// `LLMMAN_MAX_LOADED_MODELS` (`evict_other_models`) — and none of them
-    /// fires on a crash. So a crash, an OOM kill, or anything else that
+    /// deliberate one — the Ollama unload signal (`unload_model`, which
+    /// both `handle_ollama_generate` and `handle_ollama_chat` route
+    /// through); the idle reaper (`reap_idle_models_once`); and eviction
+    /// under `LLMMAN_MAX_LOADED_MODELS` (`evict_other_models`) — and none
+    /// of them fires on a crash. So a crash, an OOM kill, or anything else that
     /// takes `llama-server`/vllm down on its own would otherwise keep
     /// handing out that now-dead port forever, indistinguishable from a
     /// real live one until whichever caller's request to it fails with a
@@ -2275,6 +2275,44 @@ fn unload_key(
     let resolved = crate::shortnames::resolve_ollama_api(model)?;
     let tagged = crate::storage::default_tag(&resolved);
     Ok(canonical_ref(&state.0.store_path, &tagged))
+}
+
+/// Drops `model` from `running`, or reports a 404 when llmman has no such
+/// model at all.
+///
+/// Ollama answers an unload with a plain success for a model it holds but
+/// has not loaded, and 404s only for one it has never pulled (checked
+/// against ollama 0.32.6). The local store is what separates those two
+/// cases here. A model removed from the store while still loaded stays
+/// unloadable, since the `running` entry is authoritative and is consulted
+/// first.
+async fn unload_model(state: &AppState, model: &str) -> Result<(), AppError> {
+    let canonical = unload_key(state, model).map_err(AppError::bad_request)?;
+    // Wait for an in-flight load of this model to publish itself first, so
+    // it can't race ahead of this remove.
+    let _guard = acquire_load_lock(&canonical).await;
+    if state
+        .0
+        .manager
+        .lock()
+        .await
+        .running
+        .remove(&canonical)
+        .is_some()
+    {
+        return Ok(());
+    }
+    // Nothing was loaded under that key. A provider-routed model never is,
+    // and is absent from the store by definition, so naming one is not the
+    // 404 case.
+    if crate::providers::is_remote_ref(model) {
+        return Ok(());
+    }
+    let store = OciStore::open(&state.0.store_path)?;
+    store
+        .find(&canonical)
+        .map_err(|_| AppError(anyhow!("model '{model}' not found"), StatusCode::NOT_FOUND))?;
+    Ok(())
 }
 
 /// Is `model_ref` already running and alive? See `ModelProcess::is_alive`.
@@ -4678,9 +4716,7 @@ async fn handle_ollama_chat(
     // empty message, and a `keep_alive: 0` never unloads anything.
     if req.messages.is_empty() {
         if is_explicit_unload(&req.keep_alive) {
-            let canonical = unload_key(&state, &req.model).map_err(AppError::bad_request)?;
-            let _guard = acquire_load_lock(&canonical).await;
-            state.0.manager.lock().await.running.remove(&canonical);
+            unload_model(&state, &req.model).await?;
             return Ok(Json(empty_chat_chunk(req.model, "unload")).into_response());
         }
 
@@ -4766,11 +4802,7 @@ async fn handle_ollama_generate(
     // `LLMMAN_KEEP_ALIVE=0` turned a plain preload into an eviction.
     let is_unload = req.prompt.is_empty() && is_explicit_unload(&req.keep_alive);
     if is_unload {
-        let canonical = unload_key(&state, &req.model).map_err(AppError::bad_request)?;
-        // Wait for an in-flight load of this model to publish itself first,
-        // so it can't race ahead of this remove.
-        let _guard = acquire_load_lock(&canonical).await;
-        state.0.manager.lock().await.running.remove(&canonical);
+        unload_model(&state, &req.model).await?;
         return Ok(Json(OllamaGenerateChunk {
             model: req.model,
             created_at: now_rfc3339(),
@@ -7672,6 +7704,62 @@ mod tests {
                 .running
                 .contains_key("docker.io/ai/m:latest"),
             "a tagless unload must reach the model stored under :latest"
+        );
+    }
+
+    /// The store, not `running`, separates a model llmman has no record of
+    /// from one it holds but has not loaded: ollama 404s the first and
+    /// plainly succeeds the second, and `llmman stop` renders only that
+    /// 404 as an error of its own. `test_state`'s store is an empty temp
+    /// directory, so nothing resolves in it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unloading_a_model_llmman_does_not_have_is_a_404() {
+        let state = test_state();
+        let err = unload_model(&state, "docker.io/ai/nothing-here")
+            .await
+            .expect_err("an unknown model must not report a successful unload");
+        assert_eq!(err.1, StatusCode::NOT_FOUND);
+    }
+
+    /// The 404 above is keyed on a model being absent from `running` and
+    /// from the store, and a provider-routed one is served elsewhere, so
+    /// it is in neither. Naming it in an unload still has to succeed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unloading_a_provider_routed_model_is_not_a_404() {
+        let state = test_state();
+        unload_model(&state, "llmman.provider/openrouter/qwen/qwen3-coder")
+            .await
+            .expect("a provider-routed unload must succeed");
+    }
+
+    /// A model removed from the store while it is still loaded has to stay
+    /// unloadable — `running` is consulted before the store for exactly
+    /// this case, or the 404 above would strand a live `llama-server` with
+    /// no way to stop it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_model_gone_from_the_store_but_still_loaded_unloads_without_a_404() {
+        let state = test_state();
+        {
+            let mut mgr = state.0.manager.lock().await;
+            mgr.running.insert(
+                "docker.io/ai/orphan:latest".into(),
+                running_model_fixture(Some(DEFAULT_KEEP_ALIVE), Duration::ZERO, 0),
+            );
+        }
+
+        unload_model(&state, "docker.io/ai/orphan")
+            .await
+            .expect("a loaded model must unload even with nothing in the store");
+
+        assert!(
+            !state
+                .0
+                .manager
+                .lock()
+                .await
+                .running
+                .contains_key("docker.io/ai/orphan:latest"),
+            "the running entry must be gone"
         );
     }
 

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -2263,6 +2263,15 @@ fn unload_key(
     state: &AppState,
     model: &str,
 ) -> Result<String, crate::shortnames::InvalidReference> {
+    // `ensure_model` hands a provider-routed reference straight back before
+    // reaching any of the steps below, for the reason its own comment
+    // gives: none of the aliasing, tag defaulting or store lookup applies
+    // to a model on someone else's servers. The key an unload resolves has
+    // to be built the same way, so it skips them too. Nothing observable
+    // depends on it today, since a remote target never enters `running`.
+    if crate::providers::is_remote_ref(model) {
+        return Ok(model.to_string());
+    }
     let resolved = crate::shortnames::resolve_ollama_api(model)?;
     let tagged = crate::storage::default_tag(&resolved);
     Ok(canonical_ref(&state.0.store_path, &tagged))

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -2246,35 +2246,29 @@ fn canonical_ref(store_path: &std::path::Path, model_ref: &str) -> String {
         .unwrap_or_else(|| model_ref.to_owned())
 }
 
-/// The `mgr.running` key an unload request names, resolved through the
-/// same three steps `ensure_model` uses to build the key it inserts
-/// under: `resolve_ollama_api`, then `default_tag`, then `canonical_ref`.
+/// The load-lock key for `model`: one string for every spelling of the
+/// same model, independent of what the store holds. `ensure_model` and
+/// `unload_model` both lock on it, so an unload arriving during a first
+/// load waits for that load rather than passing it.
 ///
-/// `default_tag` is the step the unload paths used to skip, on the
-/// assumption that `canonical_ref` would supply the tag from the store
-/// index. It only does so while the model is still *in* the store: once
-/// `find` misses — the model was removed after it was loaded, the index
-/// is unreadable — `canonical_ref` returns the reference untouched, so a
-/// tagless unload looked for `docker.io/ai/m` while the model ran under
-/// `docker.io/ai/m:latest`. `remove` missed, and the reply still said
-/// `"unload"`, leaving the caller believing a model it can still see in
-/// `llmman ps` had been evicted.
-fn unload_key(
-    state: &AppState,
-    model: &str,
-) -> Result<String, crate::shortnames::InvalidReference> {
-    // `ensure_model` hands a provider-routed reference straight back before
-    // reaching any of the steps below, for the reason its own comment
-    // gives: none of the aliasing, tag defaulting or store lookup applies
-    // to a model on someone else's servers. The key an unload resolves has
-    // to be built the same way, so it skips them too. Nothing observable
-    // depends on it today, since a remote target never enters `running`.
+/// Deliberately stops short of `canonical_ref`. That step reads the store,
+/// and the store changes underneath a first load: before the pull it has
+/// nothing and returns the tagged spelling, after it it returns whatever
+/// reference the pull recorded. A lock key that moved with it would let a
+/// caller resolving in that window take a different lock from the loader
+/// still holding the old one. `default_tag` alone is stable, and already
+/// folds the tagless and `:latest` spellings together, which is all the
+/// lock needs.
+///
+/// A provider-routed reference comes back untouched, as `ensure_model`
+/// returns it before any of this applies. Nothing observable depends on
+/// that today, since a remote target never enters `running`.
+fn load_identity(model: &str) -> Result<String, crate::shortnames::InvalidReference> {
     if crate::providers::is_remote_ref(model) {
         return Ok(model.to_string());
     }
     let resolved = crate::shortnames::resolve_ollama_api(model)?;
-    let tagged = crate::storage::default_tag(&resolved);
-    Ok(canonical_ref(&state.0.store_path, &tagged))
+    Ok(crate::storage::default_tag(&resolved))
 }
 
 /// Drops `model` from `running`, or reports a 404 when llmman has no such
@@ -2287,15 +2281,10 @@ fn unload_key(
 /// unloadable, since the `running` entry is authoritative and is consulted
 /// first.
 async fn unload_model(state: &AppState, model: &str) -> Result<(), AppError> {
-    // Lock on the same key `ensure_model` locks on, which it computes
-    // before any pull; then resolve again under the lock, as it does
-    // after its pull. A load in flight can refine the key it finally
-    // inserts under (see its own "re-canonicalise" note), and an unload
-    // that had already fixed its key before waiting on that lock would
-    // remove the stale spelling, miss, find the freshly pulled model in
-    // the store, and answer success while the loader's entry stays.
-    let lock_key = unload_key(state, model).map_err(AppError::bad_request)?;
+    let lock_key = load_identity(model).map_err(AppError::bad_request)?;
     let _guard = acquire_load_lock(&lock_key).await;
+    // Only now, with any load of this model excluded: the running key is
+    // the store's spelling, which a load in flight may just have changed.
     let canonical = if crate::providers::is_remote_ref(model) {
         lock_key
     } else {
@@ -2906,6 +2895,12 @@ async fn ensure_model(
     // first-pulls of e.g. "gemma4" and "gemma4:latest" take different
     // locks and both spawn a process for the same model.
     let model_ref = crate::storage::default_tag(&model_ref);
+    // Kept from before `canonical_ref`, which reads the store: this is
+    // the key the load lock is taken on, and it has to be the same string
+    // for the whole of a load even though the pull below changes what
+    // `canonical_ref` returns. See `load_identity`, which `unload_model`
+    // locks on for the same reason.
+    let load_id = model_ref.clone();
     let model_ref = canonical_ref(&state.0.store_path, &model_ref);
     let model_ref = model_ref.as_str();
 
@@ -2921,7 +2916,7 @@ async fn ensure_model(
     // See try_admit's doc comment — held for the rest of this function.
     let _queue_guard = try_admit(state.0.max_queue)?;
 
-    let _guard = acquire_load_lock(model_ref).await;
+    let _guard = acquire_load_lock(&load_id).await;
 
     // Someone else may have finished loading this model while we
     // waited for the lock above.
@@ -7799,8 +7794,8 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         let state = test_state_at(dir.clone());
 
-        // What ensure_model locks on before its pull, and what unload_key
-        // resolves to against a store that does not yet hold the model.
+        // What ensure_model locks on before its pull, and what load_identity
+        // resolves to whatever the store holds.
         let pre_pull_key = "docker.io/ai/m:latest";
         let loading = acquire_load_lock(pre_pull_key).await;
 
@@ -7840,6 +7835,70 @@ mod tests {
                 .running
                 .contains_key("docker.io/ai/m"),
             "the unload must remove the key the load inserted, not the one it resolved before waiting"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The wider window: the pull has landed but the loader, still holding
+    /// its lock, has not yet inserted into `running`. An unload resolving
+    /// through the store now gets the refined spelling and locks on that
+    /// instead, so nothing makes it wait, and the sibling test's outcome
+    /// follows before the loader's entry even exists. Locking on
+    /// `load_identity`, which does not consult the store, parks it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_unload_after_the_pull_but_before_the_insert_still_waits_for_the_load() {
+        let dir = std::env::temp_dir().join(format!(
+            "llmman-unload-postpull-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let state = test_state_at(dir.clone());
+
+        // The pull has already recorded the tagless spelling...
+        let desc = crate::storage::oci::Descriptor {
+            media_type: "application/vnd.oci.image.manifest.v1+json".into(),
+            digest: "sha256:0000".into(),
+            size: 0,
+            annotations: None,
+        };
+        OciStore::open(&dir)
+            .unwrap()
+            .tag(desc, "docker.io/ai/m")
+            .unwrap();
+        // ...and the loader still holds the lock it took before pulling.
+        let loading = acquire_load_lock(&load_identity("docker.io/ai/m").unwrap()).await;
+
+        let unloader = state.clone();
+        let unload = tokio::spawn(async move { unload_model(&unloader, "docker.io/ai/m").await });
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !unload.is_finished(),
+            "the unload must block on the load in flight, not resolve past it"
+        );
+
+        state.0.manager.lock().await.running.insert(
+            "docker.io/ai/m".into(),
+            running_model_fixture(Some(DEFAULT_KEEP_ALIVE), Duration::ZERO, 0),
+        );
+        drop(loading);
+
+        unload
+            .await
+            .unwrap()
+            .expect("the unload must succeed once the load releases");
+        assert!(
+            !state
+                .0
+                .manager
+                .lock()
+                .await
+                .running
+                .contains_key("docker.io/ai/m"),
+            "the entry the load inserted must be gone"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/cmd/stop.rs
+++ b/src/cmd/stop.rs
@@ -18,7 +18,7 @@ pub fn run(args: &StopArgs) -> anyhow::Result<()> {
     }
 
     // The reference goes to the daemon as the caller typed it: resolving
-    // it is `unload_key`'s job, and doing it here as well only invites the
+    // it is `unload_model`'s job, and doing it here as well only invites the
     // two spellings to disagree. The daemon's 404 is what distinguishes a
     // model llmman does not have from one it simply has not loaded, so
     // there is no `ps` snapshot to consult first — which also closes the

--- a/src/cmd/stop.rs
+++ b/src/cmd/stop.rs
@@ -1,25 +1,10 @@
 use clap::Args;
-use serde::Deserialize;
 
 #[derive(Args, Debug)]
 pub struct StopArgs {
     /// Model to unload
     #[arg(value_name = "MODEL")]
     pub model: String,
-}
-
-/// Wire shape of GET /api/ps's response — see `ps.rs`'s own copy of this
-/// same shape and its doc comment on why each CLI command that needs it
-/// keeps its own minimal copy instead of sharing one type with the
-/// daemon.
-#[derive(Debug, Deserialize)]
-struct PsResponse {
-    models: Vec<PsModel>,
-}
-
-#[derive(Debug, Deserialize)]
-struct PsModel {
-    name: String,
 }
 
 /// `llmman stop MODEL` — unload a running model immediately, mirroring
@@ -32,37 +17,15 @@ pub fn run(args: &StopArgs) -> anyhow::Result<()> {
         anyhow::bail!("llmman serve is not running (nothing is loaded) — nothing to stop");
     }
 
-    let reference = crate::shortnames::resolve_ollama_api(&args.model)?;
-
-    // The unload endpoint itself always reports success even when
-    // nothing by that name was running (canonical_ref falls back
-    // gracefully — see cmd::serve's own doc comment on it), so "was this
-    // model actually loaded" is checked here, against a `ps` snapshot,
-    // purely to give the same "couldn't find model to stop" error
-    // `ollama stop` gives instead of a silent, meaningless success.
-    //
-    // Both sides are compared through `default_tag` rather than as raw
-    // strings. A `ps` name is a `mgr.running` key, which `canonical_ref`
-    // took from the store's own `org.opencontainers.image.ref.name`, and
-    // `OciStore::tag` records whatever reference it was handed: `llmman
-    // cp x y` stores a tagless `y`, while a pulled model stores
-    // `y:latest`. Either spelling can therefore be the key, and the
-    // caller may type either, so an exact comparison fails one direction
-    // or the other depending on which. Normalising both is what
-    // `ref_matches_precise` already does inside the store.
-    let running: PsResponse = crate::daemon::get_json("/api/ps")?;
-    let tagged = crate::storage::default_tag(&reference);
-    let Some(found) = running
-        .models
-        .iter()
-        .find(|m| crate::storage::default_tag(&m.name) == tagged)
-    else {
+    // The reference goes to the daemon as the caller typed it: resolving
+    // it is `unload_key`'s job, and doing it here as well only invites the
+    // two spellings to disagree. The daemon's 404 is what distinguishes a
+    // model llmman does not have from one it simply has not loaded, so
+    // there is no `ps` snapshot to consult first — which also closes the
+    // window where a model could be loaded or reaped between that call and
+    // this one.
+    if !crate::daemon::unload(&args.model)? {
         anyhow::bail!("couldn't find model \"{}\" to stop", args.model);
-    };
-
-    // The `ps` name, not our own spelling of it: it is the key the daemon
-    // actually holds, so there is nothing left for the unload to resolve.
-    crate::daemon::unload(&found.name)?;
-    println!("Stopped {}", found.name);
+    }
     Ok(())
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -993,18 +993,27 @@ pub fn ensure_model_pulled(reference: &str) -> anyhow::Result<()> {
 /// reads this exact shape as an immediate-unload request, mirroring real
 /// Ollama's own `ollama stop` (`cmd/cmd.go`'s `loadOrUnloadModel`). Used
 /// by `llmman stop`.
-pub fn unload(reference: &str) -> anyhow::Result<()> {
+///
+/// `Ok(false)` reports the daemon's 404, i.e. it holds no model by that
+/// name — the one outcome `llmman stop` renders as its own error rather
+/// than a transport failure. `Ok(true)` covers both a model that was
+/// loaded and one that simply was not, which the unload does not
+/// distinguish, matching ollama.
+pub fn unload(reference: &str) -> anyhow::Result<bool> {
     let resp = reqwest::blocking::Client::new()
         .post(format!("{}/api/generate", server()))
         .json(&serde_json::json!({"model": reference, "keep_alive": 0}))
         .send()
         .with_context(|| format!("request /api/generate (unload) for {reference}"))?;
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(false);
+    }
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().unwrap_or_default();
         anyhow::bail!("stop {reference}: server returned {status}: {body}");
     }
-    Ok(())
+    Ok(true)
 }
 
 /// A plain `GET {server()}{path}` returning the parsed JSON body — for


### PR DESCRIPTION
Follow-up to #329.

`unload_key` now returns a provider-routed reference untouched, the one step it still did not share with `ensure_model`. The unload handlers route through a new `unload_model`, which drops the running entry if there is one and otherwise consults the store: a model llmman has no record of gets a 404, a model it holds but has not loaded gets the usual success. That is ollama's contract (checked against 0.32.6), and running is consulted first so a model removed from the store while still loaded stays unloadable. `llmman stop` sends the unload directly and turns the 404 into its error, which removes the ps round trip and the window between the two calls, and it prints nothing on success like `ollama stop`.