### PR TITLE
 fix: resolve a digest reference to the stored model

### DIFF
--- a/src/cmd/cp.rs
+++ b/src/cmd/cp.rs
@@ -33,14 +33,41 @@ pub fn run(args: &CpArgs) -> anyhow::Result<()> {
     let store = OciStore::open(&store_root)?;
 
     let desc = store.find(&source)?;
+    // A destination spelled as a digest names content, and the store
+    // answers such a reference by content (see `OciStore::find`): a
+    // pointer there holding some other digest would be passed over by a
+    // lookup for the digest it is named for and answer only for the one
+    // it holds, so it is refused.
+    check_digest_destination(&args.destination, &desc.digest)?;
     store.tag(desc, &args.destination)?;
     println!("copied '{}' to '{}'", args.source, args.destination);
     Ok(())
 }
 
+/// Refuses a `<name>@<digest>` destination whose digest is not `actual`,
+/// the copied descriptor's. A tag, or the matching digest in either
+/// case, passes.
+fn check_digest_destination(destination: &str, actual: &str) -> anyhow::Result<()> {
+    match crate::storage::split_ref_digest(destination).1 {
+        Some(digest) if !digest.eq_ignore_ascii_case(actual) => anyhow::bail!(
+            "destination {destination} names digest {digest}, but the source's is {actual}"
+        ),
+        _ => Ok(()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A digest-shaped destination has to name the content being copied.
+    #[test]
+    fn a_digest_destination_must_match_the_copied_digest() {
+        assert!(check_digest_destination("docker.io/ai/m:v9", "sha256:aaaa").is_ok());
+        assert!(check_digest_destination("docker.io/ai/m@sha256:aaaa", "sha256:aaaa").is_ok());
+        assert!(check_digest_destination("docker.io/ai/m@sha256:AAAA", "sha256:aaaa").is_ok());
+        assert!(check_digest_destination("docker.io/ai/m@sha256:bbbb", "sha256:aaaa").is_err());
+    }
 
     #[test]
     fn cp_rejects_an_invalid_destination_before_writing() {

--- a/src/cmd/rm.rs
+++ b/src/cmd/rm.rs
@@ -40,8 +40,10 @@ pub fn run(args: &RmArgs) -> anyhow::Result<()> {
     let mut any_removed = false;
     for reference in &refs {
         match store.remove(reference) {
-            Ok(()) => {
-                println!("Removed {}", reference);
+            // The stored reference, not the one given: for a digest that
+            // is the tag it was held under.
+            Ok(removed) => {
+                println!("Removed {}", removed);
                 any_removed = true;
             }
             Err(e) => {

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -2257,8 +2257,19 @@ fn canonical_ref(store_path: &std::path::Path, model_ref: &str) -> String {
 /// reference the pull recorded. A lock key that moved with it would let a
 /// caller resolving in that window take a different lock from the loader
 /// still holding the old one. `default_tag` alone is stable, and already
-/// folds the tagless and `:latest` spellings together, which is all the
-/// lock needs.
+/// folds the tagless and `:latest` spellings together.
+///
+/// A `@digest` suffix is dropped first, and only from the lock key: the
+/// reference the store is asked about keeps it, so `find` can match it by
+/// content. `default_tag` sees the `:` inside `sha256:…` as a tag and
+/// leaves such a reference alone, so `m@sha256:…` and `m:latest` for one
+/// stored model took two locks and could both load. Which tag a digest
+/// sits under is something only the store knows, so the fold guesses
+/// `:latest`: a digest of a model stored as `m:v9` shares its lock with
+/// `m:latest`, not with `m:v9`. Once through the lock the store resolves
+/// it, so what remains is a first load of `m:v9` and one of its digest
+/// arriving together. The cost the other way is one load waiting behind
+/// another that names different content.
 ///
 /// A provider-routed reference comes back untouched, as `ensure_model`
 /// returns it before any of this applies. Nothing observable depends on
@@ -2268,7 +2279,8 @@ fn load_identity(model: &str) -> Result<String, crate::shortnames::InvalidRefere
         return Ok(model.to_string());
     }
     let resolved = crate::shortnames::resolve_ollama_api(model)?;
-    Ok(crate::storage::default_tag(&resolved))
+    let (without_digest, _) = crate::storage::split_ref_digest(&resolved);
+    Ok(crate::storage::default_tag(without_digest))
 }
 
 /// Drops `model` from `running`, or reports a 404 when llmman has no such
@@ -2285,10 +2297,16 @@ async fn unload_model(state: &AppState, model: &str) -> Result<(), AppError> {
     let _guard = acquire_load_lock(&lock_key).await;
     // Only now, with any load of this model excluded: the running key is
     // the store's spelling, which a load in flight may just have changed.
+    // Resolved from the reference with its `@digest` kept, the two steps
+    // `ensure_model` takes before its own `canonical_ref`, and not from
+    // the lock key: that has folded the digest onto `:latest`, which is
+    // not where the store holds a model tagged otherwise.
     let canonical = if crate::providers::is_remote_ref(model) {
         lock_key
     } else {
-        canonical_ref(&state.0.store_path, &lock_key)
+        let resolved =
+            crate::shortnames::resolve_ollama_api(model).map_err(AppError::bad_request)?;
+        canonical_ref(&state.0.store_path, &crate::storage::default_tag(&resolved))
     };
     if state
         .0
@@ -2889,18 +2907,20 @@ async fn ensure_model(
         ));
     }
 
+    // The key the load lock below is taken on, fixed before `canonical_ref`
+    // reads the store: it has to be the same string for the whole of a
+    // load even though the pull below changes what `canonical_ref`
+    // returns. See `load_identity`, which `unload_model` locks on for the
+    // same reason; the two have to agree, or an unload by one spelling
+    // passes a load by another.
+    let load_id = load_identity(model_ref).map_err(AppError::bad_request)?;
     let model_ref =
         crate::shortnames::resolve_ollama_api(model_ref).map_err(AppError::bad_request)?;
-    // Default the tag before the lock below: otherwise two concurrent
-    // first-pulls of e.g. "gemma4" and "gemma4:latest" take different
-    // locks and both spawn a process for the same model.
+    // Default the tag before the store lookups: otherwise "gemma4" and
+    // "gemma4:latest" reach the store, and the pull, as two spellings. A
+    // `@digest` stays on, unlike in the lock key, so `find` can resolve
+    // it to whatever tag holds that content.
     let model_ref = crate::storage::default_tag(&model_ref);
-    // Kept from before `canonical_ref`, which reads the store: this is
-    // the key the load lock is taken on, and it has to be the same string
-    // for the whole of a load even though the pull below changes what
-    // `canonical_ref` returns. See `load_identity`, which `unload_model`
-    // locks on for the same reason.
-    let load_id = model_ref.clone();
     let model_ref = canonical_ref(&state.0.store_path, &model_ref);
     let model_ref = model_ref.as_str();
 
@@ -7776,6 +7796,64 @@ mod tests {
         );
     }
 
+    /// An unload by digest of a model stored, and loaded, under a tag
+    /// other than `:latest`. The running key comes from the digest
+    /// spelling itself; resolving the lock key instead, which folds the
+    /// digest onto `:latest`, looked for a tag the model is not under and
+    /// reported it missing with the process still up.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_unload_by_digest_reaches_the_entry_stored_under_another_tag() {
+        let dir = std::env::temp_dir().join(format!(
+            "llmman-unload-digest-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let state = test_state_at(dir.clone());
+        let desc = crate::storage::oci::Descriptor {
+            media_type: "application/vnd.oci.image.manifest.v1+json".into(),
+            digest: "sha256:a1b2".into(),
+            size: 0,
+            annotations: None,
+        };
+        OciStore::open(&dir)
+            .unwrap()
+            .tag(desc, "docker.io/ai/m-tagged:v9")
+            .unwrap();
+        state.0.manager.lock().await.running.insert(
+            "docker.io/ai/m-tagged:v9".into(),
+            running_model_fixture(Some(DEFAULT_KEEP_ALIVE), Duration::ZERO, 0),
+        );
+
+        unload_model(&state, "docker.io/ai/m-tagged@sha256:a1b2")
+            .await
+            .expect("the digest spelling must unload the model loaded under its tag");
+        assert!(
+            !state
+                .0
+                .manager
+                .lock()
+                .await
+                .running
+                .contains_key("docker.io/ai/m-tagged:v9"),
+            "the entry under the tag must be gone"
+        );
+
+        // Stored but no longer loaded is a plain success, as for a tag.
+        unload_model(&state, "docker.io/ai/m-tagged@sha256:a1b2")
+            .await
+            .expect("a stored model must unload without a 404 whether or not it is loaded");
+        // A digest nothing in the store carries is the missing-model case.
+        let err = unload_model(&state, "docker.io/ai/m-tagged@sha256:ffff")
+            .await
+            .expect_err("a digest the store does not hold must be a 404");
+        assert_eq!(err.1, StatusCode::NOT_FOUND);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// An unload that arrives while a first load of the same model is in
     /// flight blocks on the load lock. By the time it runs, the pull has
     /// landed and the loader has inserted under the key `canonical_ref`
@@ -7837,6 +7915,83 @@ mod tests {
                 .running
                 .contains_key("docker.io/ai/m"),
             "the unload must remove the key the load inserted, not the one it resolved before waiting"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `m@sha256:…`, `m` and `m:latest` name one stored model and must
+    /// share a load lock; the digest form used to keep its own because
+    /// `default_tag` reads the `:` inside the digest as a tag.
+    #[test]
+    fn load_identity_folds_the_digest_spelling_onto_the_tag_spelling() {
+        let latest = load_identity("docker.io/ai/m:latest").unwrap();
+        assert_eq!(load_identity("docker.io/ai/m").unwrap(), latest);
+        assert_eq!(
+            load_identity("docker.io/ai/m@sha256:0000000000000000").unwrap(),
+            latest
+        );
+        assert_eq!(
+            load_identity("docker.io/ai/m:v9@sha256:0000000000000000").unwrap(),
+            "docker.io/ai/m:v9"
+        );
+    }
+
+    /// The load side of that fold: a load by digest waits on the lock a
+    /// load by tag holds, and once through it takes the process that load
+    /// started rather than starting its own. With `ensure_model` keying
+    /// its lock on the digest spelling, as it did before it went through
+    /// `load_identity`, nothing here would block.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_load_by_digest_waits_on_the_tag_spellings_lock_and_takes_its_process() {
+        let dir = std::env::temp_dir().join(format!(
+            "llmman-load-digest-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let state = test_state_at(dir.clone());
+        // The pull by tag has landed...
+        let desc = crate::storage::oci::Descriptor {
+            media_type: "application/vnd.oci.image.manifest.v1+json".into(),
+            digest: "sha256:d16e".into(),
+            size: 0,
+            annotations: None,
+        };
+        OciStore::open(&dir)
+            .unwrap()
+            .tag(desc, "docker.io/ai/m-digest:latest")
+            .unwrap();
+        // ...and that load still holds its lock.
+        let loading =
+            acquire_load_lock(&load_identity("docker.io/ai/m-digest:latest").unwrap()).await;
+
+        let loader = state.clone();
+        let load = tokio::spawn(async move {
+            ensure_model(&loader, "docker.io/ai/m-digest@sha256:d16e", None).await
+        });
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !load.is_finished(),
+            "a load by digest must wait on the lock the tag spelling holds"
+        );
+
+        state.0.manager.lock().await.running.insert(
+            "docker.io/ai/m-digest:latest".into(),
+            running_model_fixture(Some(DEFAULT_KEEP_ALIVE), Duration::ZERO, 0),
+        );
+        drop(loading);
+
+        let (model_ref, target, _guard) = load
+            .await
+            .unwrap()
+            .expect("the load by digest must succeed once the lock releases");
+        assert_eq!(model_ref, "docker.io/ai/m-digest:latest");
+        assert!(
+            matches!(target, Target::Local(0)),
+            "the process the tag spelling started must be the one handed back"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -8929,26 +9084,29 @@ mod tests {
     /// (see `ensure_model`'s `default_tag` call).
     #[test]
     fn ensure_model_key_pipeline_converges_aliases_before_the_lock() {
-        let tagless = crate::storage::default_tag(
-            &crate::shortnames::resolve_ollama_api("regression-test-model").unwrap(),
-        );
-        let tagged = crate::storage::default_tag(
-            &crate::shortnames::resolve_ollama_api("regression-test-model:latest").unwrap(),
-        );
+        let tagless = load_identity("regression-test-model").unwrap();
+        let tagged = load_identity("regression-test-model:latest").unwrap();
+        let digest = load_identity("regression-test-model@sha256:0000").unwrap();
         assert_eq!(
             tagless, tagged,
             "tagless and :latest aliases must resolve to one key"
         );
+        assert_eq!(
+            tagless, digest,
+            "the digest spelling must resolve to the same key"
+        );
 
         let a = load_lock(&tagless);
         let b = load_lock(&tagged);
+        let c = load_lock(&digest);
         assert!(
-            Arc::ptr_eq(&a, &b),
-            "both aliases must take the same load lock"
+            Arc::ptr_eq(&a, &b) && Arc::ptr_eq(&a, &c),
+            "all three aliases must take the same load lock"
         );
 
         drop(a);
         drop(b);
+        drop(c);
         release_load_lock(&tagless);
     }
 

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -690,8 +690,9 @@ impl ModelProcess {
     /// takes `llama-server`/vllm down on its own would otherwise keep
     /// handing out that now-dead port forever, indistinguishable from a
     /// real live one until whichever caller's request to it fails with a
-    /// bare connection error; `check_running` is what drops the entry, the
-    /// moment this returns false. `try_wait` is non-blocking either way:
+    /// bare connection error; `check_running` and `check_running_by_digest`
+    /// are what drop the entry, the moment this returns false. `try_wait`
+    /// is non-blocking either way:
     /// `Ok(None)` (still running) is the overwhelmingly common case this
     /// needs to stay cheap for.
     fn is_alive(&mut self) -> bool {
@@ -2272,8 +2273,9 @@ fn canonical_ref(store_path: &std::path::Path, model_ref: &str) -> String {
 /// key allows itself, and a pull by digest does not move it: what such a
 /// pull writes is a digest-named entry, which folds the same way as the
 /// nothing there before. A pull by tag landing the same content while a
-/// load of its digest is in flight does move it, and leaves two loads of
-/// one model, as before this read.
+/// load of its digest is in flight does move it; the load that then
+/// takes the other lock pulls the same bytes again and, on finding the
+/// process the first started (`check_running_by_digest`), uses that.
 ///
 /// A provider-routed reference comes back untouched, as `ensure_model`
 /// returns it before any of this applies. Nothing observable depends on
@@ -2356,20 +2358,29 @@ async fn unload_model(state: &AppState, model: &str) -> Result<(), AppError> {
     if crate::providers::is_remote_ref(model) {
         return Ok(());
     }
-    // The store may have lost the tag since the load (`rm` on a loaded
-    // model), in which case `canonical_ref` handed the reference back as
-    // given, digest and all, and the key the model runs under is not to
-    // be had from the store. The digest still names the content, and each
-    // `running` entry records its own, so the one with that digest in the
-    // same repository is it, the spelled tag first when several hold it.
-    if let (base, Some(digest)) = crate::storage::split_ref_digest(&canonical) {
+    // The key may not be the one the content runs under. The store may
+    // have lost the tag since the load (`rm` on a loaded model), so that
+    // `canonical_ref` handed the reference back as given, digest and all;
+    // or the content may run under the digest-named key a load by digest
+    // registered (see `check_running_by_digest`) while this spelling is
+    // the tag. Either way the digest names the content, from the
+    // reference itself or from the store's entry for it, and each
+    // `running` entry records its own, so the one with that digest in
+    // the same repository is it, the spelled tag first when several hold
+    // it.
+    let stored = OciStore::open(&state.0.store_path)?.find(&canonical).ok();
+    let (base, digest) = crate::storage::split_ref_digest(&canonical);
+    let digest = digest
+        .map(str::to_owned)
+        .or_else(|| stored.as_ref().map(|d| d.digest.clone()));
+    if let Some(digest) = digest {
         let spelled = crate::storage::default_tag(base);
         let mut mgr = state.0.manager.lock().await;
         let key = mgr
             .running
             .iter()
             .filter(|(key, m)| {
-                m.digest.eq_ignore_ascii_case(digest)
+                m.digest.eq_ignore_ascii_case(&digest)
                     && crate::storage::repo_name(key) == crate::storage::repo_name(base)
             })
             .map(|(key, _)| key.clone())
@@ -2379,10 +2390,12 @@ async fn unload_model(state: &AppState, model: &str) -> Result<(), AppError> {
             return Ok(());
         }
     }
-    let store = OciStore::open(&state.0.store_path)?;
-    store
-        .find(&canonical)
-        .map_err(|_| AppError(anyhow!("model '{model}' not found"), StatusCode::NOT_FOUND))?;
+    if stored.is_none() {
+        return Err(AppError(
+            anyhow!("model '{model}' not found"),
+            StatusCode::NOT_FOUND,
+        ));
+    }
     Ok(())
 }
 
@@ -2406,6 +2419,47 @@ async fn check_running(state: &AppState, model_ref: &str) -> Option<(u16, Activi
         mgr.running.remove(model_ref);
     }
     None
+}
+
+/// `check_running` by content rather than by key: the entry in
+/// `model_ref`'s repository whose manifest digest is `digest`, claimed
+/// the same way, with its own key returned so the caller answers under
+/// the name the process is registered by.
+///
+/// The order this is for: from an empty store, a load by digest takes
+/// the shared lock first (see `load_identity`), pulls, and registers
+/// under the digest-named reference that pull records; the load by tag
+/// waiting on the lock then wakes with its own key, finds nothing under
+/// it, pulls the same manifest again under the tag, and without this
+/// would start a second server for content already served. The other
+/// order, tag first, is what `load_identity` settles by reading the
+/// store before the lock.
+async fn check_running_by_digest(
+    state: &AppState,
+    model_ref: &str,
+    digest: &str,
+) -> Option<(String, u16, ActivityGuard)> {
+    let repo = crate::storage::repo_name(model_ref);
+    let mut mgr = state.0.manager.lock().await;
+    let key = mgr
+        .running
+        .iter()
+        .find(|(key, m)| {
+            crate::storage::repo_name(key) == repo && m.digest.eq_ignore_ascii_case(digest)
+        })
+        .map(|(key, _)| key.clone())?;
+    let m = mgr.running.get_mut(&key)?;
+    if !m.process.is_alive() {
+        eprintln!(
+            "[llmman] {key} was marked running on port {} but its process has exited — reloading",
+            m.port
+        );
+        mgr.running.remove(&key);
+        return None;
+    }
+    m.in_flight += 1;
+    let port = m.port;
+    Some((key.clone(), port, ActivityGuard::new(state, &key)))
 }
 
 /// Evicts every currently-running model other than `model_ref` that
@@ -3022,12 +3076,11 @@ async fn ensure_model(
         return Ok((model_ref.to_string(), Target::Local(port), guard));
     }
 
-    let model_path = resolve_model(&state.0.store_path, &state.0.cache_path, model_ref)
-        .with_context(|| format!("resolve model {model_ref}"))?;
-    // Best-effort — used only to populate `llmman ps`'s ID/SIZE columns;
-    // resolve_model above already established the model exists, so a
-    // failure here (e.g. a race with a concurrent `rm`) just means those
-    // columns show as empty/zero rather than failing the whole request.
+    // Best-effort — used to populate `llmman ps`'s ID/SIZE columns and
+    // for the check right below; `resolve_model` after them establishes
+    // the model exists, so a failure here (e.g. a race with a concurrent
+    // `rm`) just means those columns show as empty/zero rather than
+    // failing the whole request.
     let (digest, size) = OciStore::open(&state.0.store_path)
         .and_then(|s| {
             s.find(model_ref).map(|d| {
@@ -3036,6 +3089,16 @@ async fn ensure_model(
             })
         })
         .unwrap_or_default();
+    // The content may be running already under a key this spelling does
+    // not resolve to; see `check_running_by_digest`'s doc comment for the
+    // order that produces one.
+    if !digest.is_empty() {
+        if let Some((key, port, guard)) = check_running_by_digest(state, model_ref, &digest).await {
+            return Ok((key, Target::Local(port), guard));
+        }
+    }
+    let model_path = resolve_model(&state.0.store_path, &state.0.cache_path, model_ref)
+        .with_context(|| format!("resolve model {model_ref}"))?;
     let context_shift = supports_context_shift(model_ref);
     // See enforce_max_loaded_models's doc comment — held for the rest
     // of this function.
@@ -7954,6 +8017,66 @@ mod tests {
             .await
             .expect_err("nothing running or stored with it is the 404 case");
         assert_eq!(err.1, StatusCode::NOT_FOUND);
+    }
+
+    /// Digest first: the load by digest registered the process under the
+    /// digest-named key its pull recorded, and the tag's own pull has
+    /// landed since. A load and an unload by the tag must both reach that
+    /// process, by content, rather than start or strand a second one.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_tag_reaches_the_process_a_load_by_digest_registered() {
+        let dir = std::env::temp_dir().join(format!(
+            "llmman-digest-first-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let state = test_state_at(dir.clone());
+        let desc = |digest: &str| crate::storage::oci::Descriptor {
+            media_type: "application/vnd.oci.image.manifest.v1+json".into(),
+            digest: digest.into(),
+            size: 0,
+            annotations: None,
+        };
+        let store = OciStore::open(&dir).unwrap();
+        store
+            .tag(desc("sha256:df01"), "docker.io/ai/m-df@sha256:df01")
+            .unwrap();
+        store
+            .tag(desc("sha256:df01"), "docker.io/ai/m-df:latest")
+            .unwrap();
+        {
+            let mut running = running_model_fixture(Some(DEFAULT_KEEP_ALIVE), Duration::ZERO, 0);
+            running.digest = "sha256:df01".into();
+            state
+                .0
+                .manager
+                .lock()
+                .await
+                .running
+                .insert("docker.io/ai/m-df@sha256:df01".into(), running);
+        }
+
+        let (key, target, guard) = ensure_model(&state, "docker.io/ai/m-df", None)
+            .await
+            .expect("the tag must find the running content rather than load again");
+        assert_eq!(key, "docker.io/ai/m-df@sha256:df01");
+        assert!(matches!(target, Target::Local(0)));
+        drop(guard);
+
+        unload_model(&state, "docker.io/ai/m-df:latest")
+            .await
+            .expect("the tag must unload the process running under the digest key");
+        assert!(
+            state.0.manager.lock().await.running.is_empty(),
+            "the digest-keyed entry must be gone"
+        );
+        // Stored and not running: a plain success, as for any tag.
+        unload_model(&state, "docker.io/ai/m-df").await.unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// An unload that arrives while a first load of the same model is in

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -2259,28 +2259,58 @@ fn canonical_ref(store_path: &std::path::Path, model_ref: &str) -> String {
 /// still holding the old one. `default_tag` alone is stable, and already
 /// folds the tagless and `:latest` spellings together.
 ///
-/// A `@digest` suffix is dropped first, and only from the lock key: the
+/// A `@digest` suffix is dropped from the key, and only from the key: the
 /// reference the store is asked about keeps it, so `find` can match it by
 /// content. `default_tag` sees the `:` inside `sha256:…` as a tag and
 /// leaves such a reference alone, so `m@sha256:…` and `m:latest` for one
-/// stored model took two locks and could both load. Which tag a digest
-/// sits under is something only the store knows, so the fold guesses
-/// `:latest`: a digest of a model stored as `m:v9` shares its lock with
-/// `m:latest`, not with `m:v9`. Once through the lock the store resolves
-/// it, so what remains is a first load of `m:v9` and one of its digest
-/// arriving together. The cost the other way is one load waiting behind
-/// another that names different content.
+/// stored model took two locks and could both load. Which tag the content
+/// sits under is the store's to say, so for a digest reference the store
+/// is read once here, before the lock (`stored_tag_for_digest`): content
+/// stored as `m:v9` locks as `m:v9`, alongside a load of that tag, and
+/// content the store lacks, or holds only under a digest-named entry of
+/// its own, folds onto `:latest`. That is the one read of the store this
+/// key allows itself, and a pull by digest does not move it: what such a
+/// pull writes is a digest-named entry, which folds the same way as the
+/// nothing there before. A pull by tag landing the same content while a
+/// load of its digest is in flight does move it, and leaves two loads of
+/// one model, as before this read.
 ///
 /// A provider-routed reference comes back untouched, as `ensure_model`
 /// returns it before any of this applies. Nothing observable depends on
 /// that today, since a remote target never enters `running`.
-fn load_identity(model: &str) -> Result<String, crate::shortnames::InvalidReference> {
+fn load_identity(
+    store_path: &std::path::Path,
+    model: &str,
+) -> Result<String, crate::shortnames::InvalidReference> {
     if crate::providers::is_remote_ref(model) {
         return Ok(model.to_string());
     }
     let resolved = crate::shortnames::resolve_ollama_api(model)?;
-    let (without_digest, _) = crate::storage::split_ref_digest(&resolved);
+    let (without_digest, digest) = crate::storage::split_ref_digest(&resolved);
+    if digest.is_some() {
+        if let Some(tag) = stored_tag_for_digest(store_path, &resolved) {
+            return Ok(tag);
+        }
+    }
     Ok(crate::storage::default_tag(without_digest))
+}
+
+/// The tag the store holds `reference`'s content under, for a reference
+/// carrying a digest: `m:v9` for `m@sha256:…` stored as `m:v9`. `None`
+/// otherwise: no digest, nothing stored, or stored only as the
+/// digest-named entry a pull by digest records. See `load_identity` for
+/// what the distinction is for.
+fn stored_tag_for_digest(store_path: &std::path::Path, reference: &str) -> Option<String> {
+    crate::storage::split_ref_digest(reference).1?;
+    let desc = OciStore::open(store_path).ok()?.find(reference).ok()?;
+    let stored = desc
+        .annotations
+        .as_ref()?
+        .get("org.opencontainers.image.ref.name")?;
+    crate::storage::split_ref_digest(stored)
+        .1
+        .is_none()
+        .then(|| crate::storage::default_tag(stored))
 }
 
 /// Drops `model` from `running`, or reports a 404 when llmman has no such
@@ -2293,7 +2323,7 @@ fn load_identity(model: &str) -> Result<String, crate::shortnames::InvalidRefere
 /// unloadable, since the `running` entry is authoritative and is consulted
 /// first.
 async fn unload_model(state: &AppState, model: &str) -> Result<(), AppError> {
-    let lock_key = load_identity(model).map_err(AppError::bad_request)?;
+    let lock_key = load_identity(&state.0.store_path, model).map_err(AppError::bad_request)?;
     let _guard = acquire_load_lock(&lock_key).await;
     // Only now, with any load of this model excluded: the running key is
     // the store's spelling, which a load in flight may just have changed.
@@ -2913,7 +2943,7 @@ async fn ensure_model(
     // returns. See `load_identity`, which `unload_model` locks on for the
     // same reason; the two have to agree, or an unload by one spelling
     // passes a load by another.
-    let load_id = load_identity(model_ref).map_err(AppError::bad_request)?;
+    let load_id = load_identity(&state.0.store_path, model_ref).map_err(AppError::bad_request)?;
     let model_ref =
         crate::shortnames::resolve_ollama_api(model_ref).map_err(AppError::bad_request)?;
     // Default the tag before the store lookups: otherwise "gemma4" and
@@ -7921,24 +7951,79 @@ mod tests {
 
     /// `m@sha256:…`, `m` and `m:latest` name one stored model and must
     /// share a load lock; the digest form used to keep its own because
-    /// `default_tag` reads the `:` inside the digest as a tag.
+    /// `default_tag` reads the `:` inside the digest as a tag. With the
+    /// store empty the digest folds onto `:latest`.
     #[test]
     fn load_identity_folds_the_digest_spelling_onto_the_tag_spelling() {
-        let latest = load_identity("docker.io/ai/m:latest").unwrap();
-        assert_eq!(load_identity("docker.io/ai/m").unwrap(), latest);
+        let store = std::env::temp_dir();
+        let latest = load_identity(&store, "docker.io/ai/m:latest").unwrap();
+        assert_eq!(load_identity(&store, "docker.io/ai/m").unwrap(), latest);
         assert_eq!(
-            load_identity("docker.io/ai/m@sha256:0000000000000000").unwrap(),
+            load_identity(&store, "docker.io/ai/m@sha256:0000000000000000").unwrap(),
             latest
         );
         assert_eq!(
-            load_identity("docker.io/ai/m:v9@sha256:0000000000000000").unwrap(),
+            load_identity(&store, "docker.io/ai/m:v9@sha256:0000000000000000").unwrap(),
             "docker.io/ai/m:v9"
         );
     }
 
-    /// The load side of that fold: a load by digest waits on the lock a
-    /// load by tag holds, and once through it takes the process that load
-    /// started rather than starting its own. With `ensure_model` keying
+    /// With the content in the store under a tag, a digest locks as that
+    /// tag, whatever tag it spells itself; content the store holds only
+    /// under a digest-named entry, or not at all, still folds.
+    #[test]
+    fn load_identity_takes_the_tag_the_store_holds_a_digest_under() {
+        let dir = std::env::temp_dir().join(format!(
+            "llmman-identity-store-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let store = OciStore::open(&dir).unwrap();
+        let desc = |digest: &str| crate::storage::oci::Descriptor {
+            media_type: "application/vnd.oci.image.manifest.v1+json".into(),
+            digest: digest.into(),
+            size: 0,
+            annotations: None,
+        };
+        store
+            .tag(desc("sha256:aaaa"), "docker.io/ai/m-key:v9")
+            .unwrap();
+        store
+            .tag(desc("sha256:bbbb"), "docker.io/ai/m-key@sha256:bbbb")
+            .unwrap();
+
+        assert_eq!(
+            load_identity(&dir, "docker.io/ai/m-key@sha256:aaaa").unwrap(),
+            "docker.io/ai/m-key:v9"
+        );
+        assert_eq!(
+            load_identity(&dir, "docker.io/ai/m-key:latest@sha256:aaaa").unwrap(),
+            "docker.io/ai/m-key:v9",
+            "the tag the content is under wins over the one spelled"
+        );
+        assert_eq!(
+            load_identity(&dir, "docker.io/ai/m-key@sha256:bbbb").unwrap(),
+            "docker.io/ai/m-key:latest",
+            "a digest-named entry is what a pull by digest writes; it folds"
+        );
+        assert_eq!(
+            load_identity(&dir, "docker.io/ai/m-key@sha256:ffff").unwrap(),
+            "docker.io/ai/m-key:latest"
+        );
+        assert_eq!(
+            load_identity(&dir, "docker.io/ai/m-key:v9").unwrap(),
+            "docker.io/ai/m-key:v9"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The load side of that key: a load by digest waits on the lock a
+    /// load by tag holds, `:v9` here, not `:latest`, and once through it
+    /// takes the process that load started rather than starting its own.
+    /// With `ensure_model` keying
     /// its lock on the digest spelling, as it did before it went through
     /// `load_identity`, nothing here would block.
     #[tokio::test(flavor = "multi_thread")]
@@ -7962,11 +8047,11 @@ mod tests {
         };
         OciStore::open(&dir)
             .unwrap()
-            .tag(desc, "docker.io/ai/m-digest:latest")
+            .tag(desc, "docker.io/ai/m-digest:v9")
             .unwrap();
         // ...and that load still holds its lock.
         let loading =
-            acquire_load_lock(&load_identity("docker.io/ai/m-digest:latest").unwrap()).await;
+            acquire_load_lock(&load_identity(&dir, "docker.io/ai/m-digest:v9").unwrap()).await;
 
         let loader = state.clone();
         let load = tokio::spawn(async move {
@@ -7979,7 +8064,7 @@ mod tests {
         );
 
         state.0.manager.lock().await.running.insert(
-            "docker.io/ai/m-digest:latest".into(),
+            "docker.io/ai/m-digest:v9".into(),
             running_model_fixture(Some(DEFAULT_KEEP_ALIVE), Duration::ZERO, 0),
         );
         drop(loading);
@@ -7988,7 +8073,7 @@ mod tests {
             .await
             .unwrap()
             .expect("the load by digest must succeed once the lock releases");
-        assert_eq!(model_ref, "docker.io/ai/m-digest:latest");
+        assert_eq!(model_ref, "docker.io/ai/m-digest:v9");
         assert!(
             matches!(target, Target::Local(0)),
             "the process the tag spelling started must be the one handed back"
@@ -8027,7 +8112,7 @@ mod tests {
             .tag(desc, "docker.io/ai/m")
             .unwrap();
         // ...and the loader still holds the lock it took before pulling.
-        let loading = acquire_load_lock(&load_identity("docker.io/ai/m").unwrap()).await;
+        let loading = acquire_load_lock(&load_identity(&dir, "docker.io/ai/m").unwrap()).await;
 
         let unloader = state.clone();
         let unload = tokio::spawn(async move { unload_model(&unloader, "docker.io/ai/m").await });
@@ -9084,9 +9169,10 @@ mod tests {
     /// (see `ensure_model`'s `default_tag` call).
     #[test]
     fn ensure_model_key_pipeline_converges_aliases_before_the_lock() {
-        let tagless = load_identity("regression-test-model").unwrap();
-        let tagged = load_identity("regression-test-model:latest").unwrap();
-        let digest = load_identity("regression-test-model@sha256:0000").unwrap();
+        let store = std::env::temp_dir();
+        let tagless = load_identity(&store, "regression-test-model").unwrap();
+        let tagged = load_identity(&store, "regression-test-model:latest").unwrap();
+        let digest = load_identity(&store, "regression-test-model@sha256:0000").unwrap();
         assert_eq!(
             tagless, tagged,
             "tagless and :latest aliases must resolve to one key"

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -2321,7 +2321,8 @@ fn stored_tag_for_digest(store_path: &std::path::Path, reference: &str) -> Optio
 /// against ollama 0.32.6). The local store is what separates those two
 /// cases here. A model removed from the store while still loaded stays
 /// unloadable, since the `running` entry is authoritative and is consulted
-/// first.
+/// first: by its key, and by the digest it records when the key cannot be
+/// had from the store any more.
 async fn unload_model(state: &AppState, model: &str) -> Result<(), AppError> {
     let lock_key = load_identity(&state.0.store_path, model).map_err(AppError::bad_request)?;
     let _guard = acquire_load_lock(&lock_key).await;
@@ -2354,6 +2355,29 @@ async fn unload_model(state: &AppState, model: &str) -> Result<(), AppError> {
     // 404 case.
     if crate::providers::is_remote_ref(model) {
         return Ok(());
+    }
+    // The store may have lost the tag since the load (`rm` on a loaded
+    // model), in which case `canonical_ref` handed the reference back as
+    // given, digest and all, and the key the model runs under is not to
+    // be had from the store. The digest still names the content, and each
+    // `running` entry records its own, so the one with that digest in the
+    // same repository is it, the spelled tag first when several hold it.
+    if let (base, Some(digest)) = crate::storage::split_ref_digest(&canonical) {
+        let spelled = crate::storage::default_tag(base);
+        let mut mgr = state.0.manager.lock().await;
+        let key = mgr
+            .running
+            .iter()
+            .filter(|(key, m)| {
+                m.digest.eq_ignore_ascii_case(digest)
+                    && crate::storage::repo_name(key) == crate::storage::repo_name(base)
+            })
+            .map(|(key, _)| key.clone())
+            .min_by_key(|key| *key != spelled);
+        if let Some(key) = key {
+            mgr.running.remove(&key);
+            return Ok(());
+        }
     }
     let store = OciStore::open(&state.0.store_path)?;
     store
@@ -7882,6 +7906,54 @@ mod tests {
             .expect_err("a digest the store does not hold must be a 404");
         assert_eq!(err.1, StatusCode::NOT_FOUND);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The store has lost the entry while the model runs (`rm` on a loaded
+    /// model), so the digest cannot be resolved to the key it runs under;
+    /// the digest each `running` entry records is what finds it, the
+    /// spelled tag first when two entries hold the same content.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_unload_by_digest_reaches_a_loaded_model_the_store_has_lost() {
+        let state = test_state();
+        let running = |digest: &str| {
+            let mut m = running_model_fixture(Some(DEFAULT_KEEP_ALIVE), Duration::ZERO, 0);
+            m.digest = digest.into();
+            m
+        };
+        {
+            let mut mgr = state.0.manager.lock().await;
+            mgr.running
+                .insert("docker.io/ai/m-gone:v8".into(), running("sha256:a1b2"));
+            mgr.running
+                .insert("docker.io/ai/m-gone:v9".into(), running("sha256:a1b2"));
+            mgr.running
+                .insert("docker.io/ai/other:v9".into(), running("sha256:a1b2"));
+        }
+
+        unload_model(&state, "docker.io/ai/m-gone:v9@sha256:A1B2")
+            .await
+            .expect("the digest must reach the model running under its lost tag");
+        let keys = |mgr: &ModelManager| {
+            let mut k: Vec<String> = mgr.running.keys().cloned().collect();
+            k.sort();
+            k
+        };
+        assert_eq!(
+            keys(&*state.0.manager.lock().await),
+            ["docker.io/ai/m-gone:v8", "docker.io/ai/other:v9"],
+            "the spelled tag goes first; the other tag and the other repository stay"
+        );
+        unload_model(&state, "docker.io/ai/m-gone@sha256:a1b2")
+            .await
+            .expect("with no spelled tag, the remaining entry with the digest is it");
+        assert_eq!(
+            keys(&*state.0.manager.lock().await),
+            ["docker.io/ai/other:v9"]
+        );
+        let err = unload_model(&state, "docker.io/ai/m-gone@sha256:a1b2")
+            .await
+            .expect_err("nothing running or stored with it is the 404 case");
+        assert_eq!(err.1, StatusCode::NOT_FOUND);
     }
 
     /// An unload that arrives while a first load of the same model is in

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,4 +1,4 @@
 pub mod gc;
 pub mod oci;
 pub mod repair;
-pub use oci::{default_tag, split_ref_digest, OciStore};
+pub use oci::{default_tag, repo_name, split_ref_digest, OciStore};

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,4 +1,4 @@
 pub mod gc;
 pub mod oci;
 pub mod repair;
-pub use oci::{default_tag, OciStore};
+pub use oci::{default_tag, split_ref_digest, OciStore};

--- a/src/storage/oci.rs
+++ b/src/storage/oci.rs
@@ -633,7 +633,7 @@ pub fn split_ref_digest(reference: &str) -> (&str, Option<&str>) {
 /// all give `docker.io/ai/m`. The tag is cut by the rule
 /// `ref_path_segments` lays paths out with, a `:` after the last `/`, so
 /// a host port stays.
-fn repo_name(reference: &str) -> &str {
+pub fn repo_name(reference: &str) -> &str {
     let (base, _) = split_ref_digest(reference);
     let last_slash = base.rfind('/').map_or(0, |i| i + 1);
     match base[last_slash..].find(':') {

--- a/src/storage/oci.rs
+++ b/src/storage/oci.rs
@@ -344,7 +344,16 @@ impl OciStore {
             // Present but unparsable is a broken store, not a typo —
             // surface that error rather than falling through to "not
             // found".
-            return self.read_ref(reference);
+            let desc = self.read_ref(reference)?;
+            // A digest reference names content, and the pointer at its
+            // path answers for it only while it holds that content. One
+            // that holds another digest, from a `cp` of an older llmman
+            // to a digest-shaped destination or from a hand edit, is
+            // passed over, and the lookup by content below decides.
+            match split_ref_digest(reference).1 {
+                Some(digest) if !desc.digest.eq_ignore_ascii_case(digest) => {}
+                _ => return Ok(desc),
+            }
         }
         let refs = self.list_refs();
         matching_index(&refs, reference)
@@ -397,8 +406,11 @@ impl OciStore {
     }
 
     /// Remove the same single entry `find` would return for `reference`
-    /// (see `find`'s own doc comment on its fast path and fallback).
-    /// Does not GC blobs.
+    /// (see `find`'s own doc comment on its fast path and fallback), with
+    /// one difference: the pointer at the reference's own path goes
+    /// whatever digest it holds, since a pointer `find` passes over for
+    /// holding other content is exactly what `rm` has to be able to take
+    /// away. Does not GC blobs.
     pub fn remove(&self, reference: &str) -> anyhow::Result<()> {
         if self.remove_ref(reference).is_ok() {
             return Ok(());
@@ -951,6 +963,41 @@ mod tests {
         assert_eq!(repo_name("docker.io/ai/m:v9@sha256:aa"), "docker.io/ai/m");
         assert_eq!(repo_name("localhost:5000/m"), "localhost:5000/m");
         assert_eq!(repo_name("localhost:5000/m:v1"), "localhost:5000/m");
+    }
+
+    /// A pointer at a digest-shaped path that holds another digest is not
+    /// what a lookup by that digest gets; the content decides, and the
+    /// pointer itself can still be removed by name.
+    #[test]
+    fn find_passes_over_a_digest_named_pointer_holding_other_content() {
+        let dir = temp_store_dir("digest-pointer");
+        let store = OciStore::open(&dir).unwrap();
+        let mut lying = desc_with_ref("unused");
+        lying.digest = "sha256:aaaa".into();
+        store.tag(lying, "docker.io/ai/m@sha256:bbbb").unwrap();
+
+        assert!(store.find("docker.io/ai/m@sha256:bbbb").is_err());
+        assert_eq!(
+            store.find("docker.io/ai/m@sha256:aaaa").unwrap().digest,
+            "sha256:aaaa",
+            "by content, the pointer is the entry for the digest it holds"
+        );
+        let mut real = desc_with_ref("unused");
+        real.digest = "sha256:bbbb".into();
+        store.tag(real, "docker.io/ai/m:v9").unwrap();
+        assert_eq!(
+            store
+                .find("docker.io/ai/m@sha256:bbbb")
+                .unwrap()
+                .annotations
+                .unwrap()["org.opencontainers.image.ref.name"],
+            "docker.io/ai/m:v9"
+        );
+        store.remove("docker.io/ai/m@sha256:bbbb").unwrap();
+        assert!(store.find("docker.io/ai/m@sha256:aaaa").is_err());
+        assert!(store.find("docker.io/ai/m:v9").is_ok());
+
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 
     /// Same branch through `find`: stored under a tag, looked up by digest.

--- a/src/storage/oci.rs
+++ b/src/storage/oci.rs
@@ -618,6 +618,14 @@ fn ref_matches_precise(desc: &Descriptor, reference: &str) -> bool {
 /// stored names, which reach `ref_matches_precise` from the annotation
 /// and not through that parser.
 pub fn split_ref_digest(reference: &str) -> (&str, Option<&str>) {
+    // The same guard as `default_tag`: an absolute path or a URI is
+    // opaque to `shortnames::validate_reference`, so an `@` in its last
+    // component is part of the name, not a digest, and splitting it
+    // would let `s3://bucket/model@sha256:…` resolve to a stored
+    // `s3://bucket/model` of that digest instead of importing the key.
+    if reference.starts_with('/') || reference.contains("://") {
+        return (reference, None);
+    }
     let last_slash = reference.rfind('/').map_or(0, |i| i + 1);
     match reference[last_slash..].find('@') {
         Some(offset) => {
@@ -648,16 +656,19 @@ pub fn repo_name(reference: &str) -> &str {
 /// One manifest can sit under several tags, so a digest reference can
 /// match more than one entry. The tag the reference spells (`:latest`
 /// when it spells none) wins: `m:v9@<digest>` with `m:v9` and `m:latest`
-/// both at that digest picks `m:v9`. Between tags it does not spell, the
-/// first in the order `list_refs` walks the tree wins, which is readdir
-/// order and not sorted, so a `remove` by such a reference takes one
-/// entry per call and does not choose which.
+/// both at that digest picks `m:v9`, and a stored name with no tag
+/// counts as `:latest`, as it does everywhere else in this store.
+/// Between tags it does not spell, the first in the order `list_refs`
+/// walks the tree wins, which is readdir order and not sorted, so a
+/// `remove` by such a reference takes one entry per call and does not
+/// choose which.
 fn matching_index(manifests: &[Descriptor], reference: &str) -> Option<usize> {
     let (base, digest) = split_ref_digest(reference);
     if digest.is_some() {
         let spelled = default_tag(base);
         let own_tag = manifests.iter().position(|m| {
-            ref_matches_precise(m, reference) && stored_ref_name(m) == Some(spelled.as_str())
+            ref_matches_precise(m, reference)
+                && stored_ref_name(m).is_some_and(|stored| default_tag(stored) == spelled)
         });
         if own_tag.is_some() {
             return own_tag;
@@ -901,6 +912,17 @@ mod tests {
             matching_index(&manifests, "docker.io/ai/m@sha256:bbbb"),
             None
         );
+
+        // A tagless stored name is `:latest` here too, ahead of `:v9`
+        // whatever order the tree is walked in.
+        let mut tagless = desc_with_ref("docker.io/ai/m");
+        tagless.digest = "sha256:aaaa".into();
+        let mut v9 = desc_with_ref("docker.io/ai/m:v9");
+        v9.digest = "sha256:aaaa".into();
+        assert_eq!(
+            matching_index(&[v9, tagless], "docker.io/ai/m@sha256:aaaa"),
+            Some(1)
+        );
     }
 
     #[test]
@@ -916,6 +938,15 @@ mod tests {
         assert_eq!(
             split_ref_digest("docker.io/ai/m:v9"),
             ("docker.io/ai/m:v9", None)
+        );
+        // Opaque sources keep their `@`, as `default_tag` keeps their `:`.
+        assert_eq!(
+            split_ref_digest("s3://bucket/model@sha256:aa"),
+            ("s3://bucket/model@sha256:aa", None)
+        );
+        assert_eq!(
+            split_ref_digest("/models/m@sha256:aa"),
+            ("/models/m@sha256:aa", None)
         );
         assert_eq!(repo_name("docker.io/ai/m:v9@sha256:aa"), "docker.io/ai/m");
         assert_eq!(repo_name("localhost:5000/m"), "localhost:5000/m");

--- a/src/storage/oci.rs
+++ b/src/storage/oci.rs
@@ -572,15 +572,30 @@ fn classify_model_layer(rel_path: &str) -> &'static str {
 
 /// True if the descriptor's ref annotation matches `reference` precisely
 /// — exact match, tag-only match (a bare `reference` against a stored
-/// `"reg/repo:tag"`), or tagless match (`reference` with an implicit
-/// `:latest` appended). The tag-only branch is unambiguous only when
-/// `reference` is a bare tag that's unique across stored tags — two
-/// different repos sharing the same tag (e.g. both `:0.8b`) can still
-/// both match here.
+/// `"reg/repo:tag"`), tagless match (`reference` with an implicit
+/// `:latest` appended), or, for a `reference` carrying `@<digest>`, a
+/// digest match (the branch below says what that compares). The tag-only
+/// branch is unambiguous only when `reference` is a bare tag that's
+/// unique across stored tags — two different repos sharing the same tag
+/// (e.g. both `:0.8b`) can still both match here. A digest match is
+/// ambiguous across the tags of one repository in the same way, and
+/// `matching_index` is what settles that.
 fn ref_matches_precise(desc: &Descriptor, reference: &str) -> bool {
     let Some(stored) = stored_ref_name(desc) else {
         return false;
     };
+
+    // `<name>[:tag]@<digest>` names content, not a tag: it matches the
+    // stored model with that manifest digest under the same repository,
+    // whatever tag it was stored under. Without this a digest reference
+    // for a model already in the store was "not found", and the daemon
+    // pulled the same bytes again under a second reference and started a
+    // second server for them. The hex is compared without regard to case
+    // because `shortnames::validate_reference` accepts either while the
+    // store records lowercase, so an uppercase spelling matched nothing.
+    if let (base, Some(digest)) = split_ref_digest(reference) {
+        return desc.digest.eq_ignore_ascii_case(digest) && repo_name(stored) == repo_name(base);
+    }
 
     if stored == reference || tag_from_ref(stored) == reference {
         return true;
@@ -594,9 +609,60 @@ fn ref_matches_precise(desc: &Descriptor, reference: &str) -> bool {
     false
 }
 
+/// Splits `<name>[:tag]@<digest>` into the part before `@` and the digest.
+/// The `@` has to follow the last `/`, so a host or namespace component
+/// cannot be mistaken for one; a reference without a digest comes back
+/// whole. `shortnames::parse_registry_ref` splits at the first `@`
+/// instead; the two agree on any reference it has accepted, since no
+/// part before the model admits an `@`. This one is also applied to
+/// stored names, which reach `ref_matches_precise` from the annotation
+/// and not through that parser.
+pub fn split_ref_digest(reference: &str) -> (&str, Option<&str>) {
+    let last_slash = reference.rfind('/').map_or(0, |i| i + 1);
+    match reference[last_slash..].find('@') {
+        Some(offset) => {
+            let at = last_slash + offset;
+            (&reference[..at], Some(&reference[at + 1..]))
+        }
+        None => (reference, None),
+    }
+}
+
+/// The repository part of a reference: everything before a tag or digest,
+/// so `docker.io/ai/m:v9`, `docker.io/ai/m` and `docker.io/ai/m@sha256:…`
+/// all give `docker.io/ai/m`. The tag is cut by the rule
+/// `ref_path_segments` lays paths out with, a `:` after the last `/`, so
+/// a host port stays.
+fn repo_name(reference: &str) -> &str {
+    let (base, _) = split_ref_digest(reference);
+    let last_slash = base.rfind('/').map_or(0, |i| i + 1);
+    match base[last_slash..].find(':') {
+        Some(offset) => &base[..last_slash + offset],
+        None => base,
+    }
+}
+
 /// The index of the entry in `manifests` that `find`/`remove` should
 /// treat as matching `reference`, or `None`.
+///
+/// One manifest can sit under several tags, so a digest reference can
+/// match more than one entry. The tag the reference spells (`:latest`
+/// when it spells none) wins: `m:v9@<digest>` with `m:v9` and `m:latest`
+/// both at that digest picks `m:v9`. Between tags it does not spell, the
+/// first in the order `list_refs` walks the tree wins, which is readdir
+/// order and not sorted, so a `remove` by such a reference takes one
+/// entry per call and does not choose which.
 fn matching_index(manifests: &[Descriptor], reference: &str) -> Option<usize> {
+    let (base, digest) = split_ref_digest(reference);
+    if digest.is_some() {
+        let spelled = default_tag(base);
+        let own_tag = manifests.iter().position(|m| {
+            ref_matches_precise(m, reference) && stored_ref_name(m) == Some(spelled.as_str())
+        });
+        if own_tag.is_some() {
+            return own_tag;
+        }
+    }
     manifests
         .iter()
         .position(|m| ref_matches_precise(m, reference))
@@ -789,6 +855,90 @@ mod tests {
         assert!(ref_matches_precise(&d, "docker.io/ai/qwen3.5:0.8b"));
         assert!(!ref_matches_precise(&d, "docker.io/ai/qwen3.5:1.5b"));
         assert!(!ref_matches_precise(&d, "docker.io/ai/other:0.8b"));
+    }
+
+    /// Pins the digest branch of `ref_matches_precise` (see its own
+    /// comment for why it exists): same digest and same repository match
+    /// regardless of tag, and a different digest or repository does not.
+    #[test]
+    fn ref_matches_precise_resolves_a_digest_reference_by_content() {
+        let mut d = desc_with_ref("docker.io/ai/m:v9");
+        d.digest = "sha256:aaaa".into();
+        assert!(ref_matches_precise(&d, "docker.io/ai/m@sha256:aaaa"));
+        assert!(ref_matches_precise(&d, "docker.io/ai/m:latest@sha256:aaaa"));
+        assert!(!ref_matches_precise(&d, "docker.io/ai/m@sha256:bbbb"));
+        assert!(!ref_matches_precise(&d, "docker.io/ai/other@sha256:aaaa"));
+        // A tag beside the digest does not narrow the match: the grammar
+        // in docker/distribution's `reference.go` allows both, and there
+        // the digest is what names content. `matching_index` is where the
+        // tag counts, as a tie-breaker.
+        assert!(ref_matches_precise(&d, "docker.io/ai/m:other@sha256:aaaa"));
+        assert!(ref_matches_precise(&d, "docker.io/ai/m@sha256:AAAA"));
+    }
+
+    /// Two tags at one digest: the spelled tag is chosen, and without one
+    /// the first entry is. See `matching_index`'s doc comment.
+    #[test]
+    fn matching_index_prefers_the_tag_a_digest_reference_spells() {
+        let mut latest = desc_with_ref("docker.io/ai/m:latest");
+        latest.digest = "sha256:aaaa".into();
+        let mut v9 = desc_with_ref("docker.io/ai/m:v9");
+        v9.digest = "sha256:aaaa".into();
+        let manifests = [latest, v9];
+        assert_eq!(
+            matching_index(&manifests, "docker.io/ai/m:v9@sha256:aaaa"),
+            Some(1)
+        );
+        assert_eq!(
+            matching_index(&manifests, "docker.io/ai/m@sha256:aaaa"),
+            Some(0)
+        );
+        assert_eq!(
+            matching_index(&manifests, "docker.io/ai/m:v8@sha256:aaaa"),
+            Some(0)
+        );
+        assert_eq!(
+            matching_index(&manifests, "docker.io/ai/m@sha256:bbbb"),
+            None
+        );
+    }
+
+    #[test]
+    fn split_ref_digest_only_splits_after_the_last_slash() {
+        assert_eq!(
+            split_ref_digest("docker.io/ai/m@sha256:aa"),
+            ("docker.io/ai/m", Some("sha256:aa"))
+        );
+        assert_eq!(
+            split_ref_digest("docker.io/ai/m:v9@sha256:aa"),
+            ("docker.io/ai/m:v9", Some("sha256:aa"))
+        );
+        assert_eq!(
+            split_ref_digest("docker.io/ai/m:v9"),
+            ("docker.io/ai/m:v9", None)
+        );
+        assert_eq!(repo_name("docker.io/ai/m:v9@sha256:aa"), "docker.io/ai/m");
+        assert_eq!(repo_name("localhost:5000/m"), "localhost:5000/m");
+        assert_eq!(repo_name("localhost:5000/m:v1"), "localhost:5000/m");
+    }
+
+    /// Same branch through `find`: stored under a tag, looked up by digest.
+    #[test]
+    fn find_resolves_a_digest_reference_to_the_tagged_entry() {
+        let dir = temp_store_dir("digest-find");
+        let store = OciStore::open(&dir).unwrap();
+        let mut d = desc_with_ref("unused");
+        d.digest = "sha256:cafe".into();
+        store.tag(d, "docker.io/ai/m:latest").unwrap();
+
+        let found = store.find("docker.io/ai/m@sha256:cafe").unwrap();
+        assert_eq!(
+            found.annotations.unwrap()["org.opencontainers.image.ref.name"],
+            "docker.io/ai/m:latest"
+        );
+        assert!(store.find("docker.io/ai/m@sha256:dead").is_err());
+
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 
     #[test]

--- a/src/storage/oci.rs
+++ b/src/storage/oci.rs
@@ -406,23 +406,53 @@ impl OciStore {
     }
 
     /// Remove the same single entry `find` would return for `reference`
-    /// (see `find`'s own doc comment on its fast path and fallback), with
-    /// one difference: the pointer at the reference's own path goes
-    /// whatever digest it holds, since a pointer `find` passes over for
-    /// holding other content is exactly what `rm` has to be able to take
-    /// away. Does not GC blobs.
-    pub fn remove(&self, reference: &str) -> anyhow::Result<()> {
+    /// (see `find`'s own doc comment on its fast path and fallback), and
+    /// say which: the stored reference that went, since for a digest
+    /// that is a tag the caller did not spell. Two differences from
+    /// `find`: the pointer at the reference's own path goes whatever
+    /// digest it holds, since a pointer `find` passes over for holding
+    /// other content is exactly what `rm` has to be able to take away;
+    /// and a digest held by several tags is refused with the tags listed,
+    /// the way `docker rmi` refuses an image several tags point at,
+    /// unless the reference spells one of them (`m:v9@sha256:…`), rather
+    /// than taking whichever the tree is walked to first. A bare
+    /// `m@sha256:…` spells no tag here, even though `find` reads it as
+    /// `:latest` for a lookup: a removal takes the explicit form. Does not
+    /// GC blobs.
+    pub fn remove(&self, reference: &str) -> anyhow::Result<String> {
         if self.remove_ref(reference).is_ok() {
-            return Ok(());
+            return Ok(reference.to_owned());
         }
         let refs = self.list_refs();
+        let (base, digest) = split_ref_digest(reference);
+        if digest.is_some() {
+            // `default_tag` leaves a reference alone only when it already
+            // carries a tag: that is the spelled one.
+            let spelled = (default_tag(base) == base).then_some(base);
+            let held_by: Vec<&str> = refs
+                .iter()
+                .filter(|m| ref_matches_precise(m, reference))
+                .filter_map(stored_ref_name)
+                .collect();
+            if held_by.len() > 1
+                && !held_by
+                    .iter()
+                    .any(|s| spelled.is_some_and(|t| default_tag(s) == t))
+            {
+                return Err(anyhow!(
+                    "{reference} is held by more than one tag: {}; name the tag to remove",
+                    held_by.join(", ")
+                ));
+            }
+        }
         let Some(i) = matching_index(&refs, reference) else {
             return Err(anyhow!("image not found: {}", reference));
         };
         let Some(name) = stored_ref_name(&refs[i]) else {
             return Err(anyhow!("image not found: {}", reference));
         };
-        self.remove_ref(name)
+        self.remove_ref(name)?;
+        Ok(name.to_owned())
     }
 
     // ------------------------------------------------------------------
@@ -605,6 +635,10 @@ fn ref_matches_precise(desc: &Descriptor, reference: &str) -> bool {
     // second server for them. The hex is compared without regard to case
     // because `shortnames::validate_reference` accepts either while the
     // store records lowercase, so an uppercase spelling matched nothing.
+    // Unlike the tag branches below, this one has no tag-only fallback: a
+    // bare `m@sha256:…` against a stored `docker.io/ai/m:v9` misses on the
+    // repository. Latent today, since each caller resolves a reference
+    // through `shortnames::resolve_ollama_api` before it gets here.
     if let (base, Some(digest)) = split_ref_digest(reference) {
         return desc.digest.eq_ignore_ascii_case(digest) && repo_name(stored) == repo_name(base);
     }
@@ -671,9 +705,9 @@ pub fn repo_name(reference: &str) -> &str {
 /// both at that digest picks `m:v9`, and a stored name with no tag
 /// counts as `:latest`, as it does everywhere else in this store.
 /// Between tags it does not spell, the first in the order `list_refs`
-/// walks the tree wins, which is readdir order and not sorted, so a
-/// `remove` by such a reference takes one entry per call and does not
-/// choose which.
+/// walks the tree wins, which is readdir order and not sorted; `remove`
+/// refuses that case rather than take one (see its doc comment), `find`
+/// answers with it.
 fn matching_index(manifests: &[Descriptor], reference: &str) -> Option<usize> {
     let (base, digest) = split_ref_digest(reference);
     if digest.is_some() {
@@ -996,6 +1030,57 @@ mod tests {
         store.remove("docker.io/ai/m@sha256:bbbb").unwrap();
         assert!(store.find("docker.io/ai/m@sha256:aaaa").is_err());
         assert!(store.find("docker.io/ai/m:v9").is_ok());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// A digest held by several tags: the removal is refused with every
+    /// holder listed, a bare `m@sha256:…` included even with `:latest`
+    /// among them, unless the reference spells one of the tags; then that
+    /// one goes and is named. Nothing goes in readdir order.
+    #[test]
+    fn remove_by_digest_names_what_went_and_refuses_an_ambiguous_one() {
+        let dir = temp_store_dir("digest-remove");
+        let store = OciStore::open(&dir).unwrap();
+        let desc = |digest: &str| {
+            let mut d = desc_with_ref("unused");
+            d.digest = digest.into();
+            d
+        };
+        store.tag(desc("sha256:aaaa"), "docker.io/ai/m:v8").unwrap();
+        store.tag(desc("sha256:aaaa"), "docker.io/ai/m:v9").unwrap();
+        store
+            .tag(desc("sha256:aaaa"), "docker.io/ai/m:latest")
+            .unwrap();
+
+        let err = store.remove("docker.io/ai/m@sha256:aaaa").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            [
+                "docker.io/ai/m:v8",
+                "docker.io/ai/m:v9",
+                "docker.io/ai/m:latest"
+            ]
+            .iter()
+            .all(|t| msg.contains(t)),
+            "{msg}"
+        );
+        assert!(store.find("docker.io/ai/m:latest").is_ok());
+
+        assert_eq!(
+            store.remove("docker.io/ai/m:latest@sha256:aaaa").unwrap(),
+            "docker.io/ai/m:latest"
+        );
+        assert_eq!(
+            store.remove("docker.io/ai/m:v9@sha256:aaaa").unwrap(),
+            "docker.io/ai/m:v9"
+        );
+        assert_eq!(
+            store.remove("docker.io/ai/m@sha256:aaaa").unwrap(),
+            "docker.io/ai/m:v8",
+            "one holder left is not ambiguous, and the name that went is reported"
+        );
+        assert!(store.remove("docker.io/ai/m@sha256:aaaa").is_err());
 
         std::fs::remove_dir_all(&dir).unwrap();
     }


### PR DESCRIPTION
Follow-up to #353.

The first follow-on there described `m@sha256:…` and `m:latest` taking two load locks. Reproducing it found the store underneath: `ref_matches_precise` compared names only, so a digest reference never matched a stored model. `find` said "not found", and the daemon pulled the same bytes again under a second reference and started a second `llama-server` for them, no race involved. It now matches `<name>[:tag]@<digest>` by manifest digest under the same repository, whatever tag holds it. That changes what `rm`, `/api/delete`, `show`, `canonical_ref`, and the pull decision resolve a digest to; with several tags at one digest, the spelled tag wins, and `rm` takes one entry per call.

`load_identity` folds a `@digest` onto the tag spelling, and `ensure_model` now takes its lock key from it too, so the digest and `:latest` spellings share one lock while the reference the store is asked about keeps the digest. What remains is a first load of `m:v9` and one of its digest arriving together, since which tag a digest sits under is not known before the store is read.

`daemon::unload` read any 404 as "no such model". It now checks for the `{"error":"model '…' not found"}` envelope and reports any other 404 with its status and body.