### PR TITLE
feat(launch): write qwen's settings.json and find its installs

### DIFF
--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -1085,7 +1085,8 @@ fn sort_node_versions_newest_first(names: &mut [String]) {
 }
 
 /// `$QWEN_HOME` if set, else `~/.qwen`: `Storage.getGlobalQwenDir` in
-/// Qwen Code's `packages/core/src/config/storage.ts`.
+/// Qwen Code's `packages/core/src/config/storage.ts`. Qwen Code can also
+/// take it from `~/.qwen/.env`; that is left to the user's shell.
 fn qwen_home() -> anyhow::Result<PathBuf> {
     let home = || dirs::home_dir().context("no home directory");
     match std::env::var("QWEN_HOME").ok().filter(|d| !d.is_empty()) {

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -900,16 +900,38 @@ fn launch_qwen(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Res
     write_qwen_settings(model)?;
 
     let base_url = format!("{}/v1", daemon::server());
-    exec_with_env(
-        &bin,
-        &qwen_args(model, extra_args),
-        &[
-            ("OPENAI_BASE_URL", base_url.as_str()),
-            ("OPENAI_API_KEY", api_key),
-            (QWEN_ENV_KEY, api_key),
-            ("OPENAI_MODEL", model),
-        ],
-    )
+    let mut env = vec![
+        ("OPENAI_BASE_URL", base_url.as_str()),
+        ("OPENAI_API_KEY", api_key),
+        (QWEN_ENV_KEY, api_key),
+        ("OPENAI_MODEL", model),
+    ];
+    // A shim the fallback found is a `#!/usr/bin/env node` script whose
+    // `node` sits beside it, so its directory goes on the child's `PATH`.
+    let path = path_with_dir_prepended(bin.parent(), &std::env::var_os("PATH").unwrap_or_default())
+        .map(|p| p.to_string_lossy().into_owned());
+    if let Some(path) = &path {
+        env.push(("PATH", path.as_str()));
+    }
+    exec_with_env(&bin, &qwen_args(model, extra_args), &env)
+}
+
+/// `path_var` with `dir` in front, or `None` when it is there already or
+/// there is no `dir`. Empty components go: one is how an unset `PATH`
+/// arrives, and on POSIX it means the working directory.
+fn path_with_dir_prepended(
+    dir: Option<&Path>,
+    path_var: &std::ffi::OsStr,
+) -> Option<std::ffi::OsString> {
+    let dir = dir?;
+    let mut components: Vec<PathBuf> = std::env::split_paths(path_var)
+        .filter(|d| !d.as_os_str().is_empty())
+        .collect();
+    if components.iter().any(|d| d == dir) {
+        return None;
+    }
+    components.insert(0, dir.to_path_buf());
+    std::env::join_paths(components).ok()
 }
 
 /// The value of the last `--model`/`-m` after `--`, as a word or
@@ -963,10 +985,7 @@ fn find_qwen() -> Option<PathBuf> {
 /// what ollama's `cmd/launch/qwen.go` probes, `~/.cargo/bin`, macOS's
 /// `~/Library/Application Support/qwen/bin`, and on Windows npm's global
 /// directory under both `%APPDATA%` and `%LOCALAPPDATA%`,
-/// `%LOCALAPPDATA%\Programs\qwen` and `%APPDATA%\qwen\bin`. What nvm
-/// holds is a `#!/usr/bin/env node` shim whose `node` is on `PATH` only
-/// in an nvm-sourced shell, so a launch from another shell fails at exec
-/// rather than here.
+/// `%LOCALAPPDATA%\Programs\qwen` and `%APPDATA%\qwen\bin`.
 fn qwen_fallback_paths() -> Vec<PathBuf> {
     let home = dirs::home_dir();
     let mut paths = Vec::new();
@@ -1415,6 +1434,51 @@ mod tests {
             assert!(check_model_flag(id, Some("m"), None, &forwarded).is_ok());
         }
         assert!(check_model_flag("claude", None, None, &none).is_ok());
+    }
+
+    /// The found directory goes in front of `PATH` only when it is not
+    /// there, with no empty component either way.
+    #[test]
+    fn path_with_dir_prepended_only_when_it_is_missing() {
+        let path_var =
+            std::env::join_paths([PathBuf::from("/usr/bin"), PathBuf::from("/bin")]).unwrap();
+        assert_eq!(
+            path_with_dir_prepended(Some(Path::new("/usr/bin")), &path_var),
+            None
+        );
+        assert_eq!(
+            path_with_dir_prepended(Some(Path::new("/opt/nvm/bin")), &path_var),
+            Some(
+                std::env::join_paths([
+                    PathBuf::from("/opt/nvm/bin"),
+                    PathBuf::from("/usr/bin"),
+                    PathBuf::from("/bin"),
+                ])
+                .unwrap()
+            )
+        );
+        assert_eq!(path_with_dir_prepended(None, &path_var), None);
+        assert_eq!(
+            path_with_dir_prepended(Some(Path::new("/opt/nvm/bin")), std::ffi::OsStr::new("")),
+            Some(std::ffi::OsString::from("/opt/nvm/bin"))
+        );
+        let gappy = std::env::join_paths([
+            PathBuf::from("/usr/bin"),
+            PathBuf::from(""),
+            PathBuf::from("/bin"),
+        ])
+        .unwrap();
+        assert_eq!(
+            path_with_dir_prepended(Some(Path::new("/opt/nvm/bin")), &gappy),
+            Some(
+                std::env::join_paths([
+                    PathBuf::from("/opt/nvm/bin"),
+                    PathBuf::from("/usr/bin"),
+                    PathBuf::from("/bin"),
+                ])
+                .unwrap()
+            )
+        );
     }
 
     /// The last forwarded model wins, in either spelling; none is none.

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -395,7 +395,7 @@ const INTEGRATIONS: &[Integration] = &[
 fn print_integrations() {
     println!("Available integrations:\n");
     for i in INTEGRATIONS {
-        if find_on_path(i.binary).is_some() {
+        if find_integration_binary(i).is_some() {
             println!("  {:<12} {}", i.name, i.description);
         } else {
             println!("  {:<12} {} (not installed)", i.name, i.description);
@@ -437,6 +437,17 @@ fn find_on_path(binary: &str) -> Option<PathBuf> {
         }
     }
     None
+}
+
+/// The binary `launch` will run for `i`, so the listing does not report
+/// as missing what the launcher would find: `PATH`, then what the
+/// launcher knows.
+fn find_integration_binary(i: &Integration) -> Option<PathBuf> {
+    match i.name {
+        "opencode" => find_opencode(),
+        "qwen" => find_qwen(),
+        _ => find_on_path(i.binary),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -503,18 +514,22 @@ fn launch_claude(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::R
 /// opencode: pass a JSON config via OPENCODE_CONFIG_CONTENT pointing at our
 /// /v1 endpoint, matching exactly what ollama launch does.
 fn launch_opencode(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
-    let bin = find_on_path("opencode").or_else(|| {
-        dirs::home_dir().and_then(|h| {
-            let p = h.join(".opencode").join("bin").join("opencode");
-            p.exists().then_some(p)
-        })
-    });
-    let bin = bin.ok_or_else(|| anyhow::anyhow!("opencode is not installed"))?;
+    let bin = find_opencode().ok_or_else(|| anyhow::anyhow!("opencode is not installed"))?;
 
     let effective_model = if model.is_empty() { "default" } else { model };
     let config = opencode_config(effective_model, api_key);
 
     exec_with_env(&bin, extra_args, &[("OPENCODE_CONFIG_CONTENT", &config)])
+}
+
+/// `PATH`, then opencode's own installer target, `~/.opencode/bin`.
+fn find_opencode() -> Option<PathBuf> {
+    find_on_path("opencode").or_else(|| {
+        dirs::home_dir().and_then(|h| {
+            let p = h.join(".opencode").join("bin").join("opencode");
+            p.exists().then_some(p)
+        })
+    })
 }
 
 fn opencode_config(model: &str, api_key: &str) -> String {
@@ -873,7 +888,7 @@ fn launch_openclaw(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
 /// required; `check_model_flag` refuses a launch without one before the
 /// daemon starts.
 fn launch_qwen(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
-    let bin = find_on_path("qwen").ok_or_else(|| anyhow::anyhow!("qwen is not installed"))?;
+    let bin = find_qwen().ok_or_else(|| anyhow::anyhow!("qwen is not installed"))?;
     // After the lookup, so nothing is written for an integration that is
     // not there; `check_model_flag` has made sure there is a model. A
     // file that cannot be merged into is left alone and the launch goes
@@ -911,6 +926,105 @@ fn qwen_args(model: &str, extra_args: &[String]) -> Vec<String> {
     }
     args.extend_from_slice(extra_args);
     args
+}
+
+/// `PATH`, then the installers' own targets; see `qwen_fallback_paths`.
+fn find_qwen() -> Option<PathBuf> {
+    find_on_path("qwen").or_else(|| qwen_fallback_paths().into_iter().find(|p| p.is_file()))
+}
+
+/// Where a Qwen Code install lands that a process without the user's
+/// login shell does not see: the standalone installer's `~/.local/bin`,
+/// the `~/.npm-global` prefix its older npm installer set, nvm's newest
+/// node that has it, Homebrew's prefixes, `/usr/local/bin`, and on
+/// Windows npm's `%APPDATA%\npm` and the standalone installer's
+/// `%LOCALAPPDATA%\qwen-code\bin`. Ollama's `cmd/launch/qwen.go` checks
+/// a similar list. What nvm holds is a `#!/usr/bin/env node` shim whose
+/// `node` is on `PATH` only in an nvm-sourced shell, so a launch from
+/// another shell fails at exec rather than here.
+fn qwen_fallback_paths() -> Vec<PathBuf> {
+    let home = dirs::home_dir();
+    let mut paths = Vec::new();
+    if cfg!(windows) {
+        // Blank counts as unset, or the candidate would be relative.
+        let roaming = std::env::var_os("APPDATA")
+            .filter(|d| !d.is_empty())
+            .map(PathBuf::from)
+            .or_else(|| home.as_ref().map(|h| h.join("AppData").join("Roaming")));
+        let local = std::env::var_os("LOCALAPPDATA")
+            .filter(|d| !d.is_empty())
+            .map(PathBuf::from)
+            .or_else(|| home.as_ref().map(|h| h.join("AppData").join("Local")));
+        let dirs = [
+            roaming.map(|d| d.join("npm")),
+            local.map(|d| d.join("qwen-code").join("bin")),
+        ];
+        for dir in dirs.into_iter().flatten() {
+            paths.extend(
+                WINDOWS_PATH_EXTS
+                    .iter()
+                    .map(|ext| dir.join(format!("qwen.{ext}"))),
+            );
+        }
+        return paths;
+    }
+    if let Some(h) = &home {
+        paths.push(h.join(".local").join("bin").join("qwen"));
+        paths.push(h.join(".npm-global").join("bin").join("qwen"));
+        paths.extend(nvm_dirs(h).iter().filter_map(|d| nvm_qwen(d)));
+    }
+    if cfg!(target_os = "macos") {
+        paths.push(PathBuf::from("/opt/homebrew/bin/qwen"));
+    } else {
+        paths.push(PathBuf::from("/home/linuxbrew/.linuxbrew/bin/qwen"));
+    }
+    paths.push(PathBuf::from("/usr/local/bin/qwen"));
+    paths
+}
+
+/// `$NVM_DIR`, `$XDG_CONFIG_HOME/nvm`, `~/.config/nvm` and `~/.nvm`: which
+/// one an install took depends on the environment nvm was installed in,
+/// not on this process's, so all are probed.
+fn nvm_dirs(home: &Path) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(dir) = std::env::var_os("NVM_DIR").filter(|d| !d.is_empty()) {
+        dirs.push(PathBuf::from(dir));
+    }
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME").filter(|d| !d.is_empty()) {
+        dirs.push(PathBuf::from(xdg).join("nvm"));
+    }
+    dirs.push(home.join(".config").join("nvm"));
+    dirs.push(home.join(".nvm"));
+    dirs
+}
+
+/// The `qwen` under the newest node version nvm holds one for; nvm keeps
+/// one tree per version and picks between them by editing `PATH` in the
+/// shell.
+fn nvm_qwen(nvm_dir: &Path) -> Option<PathBuf> {
+    let node = nvm_dir.join("versions").join("node");
+    let mut versions: Vec<String> = std::fs::read_dir(&node)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    sort_node_versions_newest_first(&mut versions);
+    versions
+        .into_iter()
+        .map(|v| node.join(v).join("bin").join("qwen"))
+        .find(|p| p.is_file())
+}
+
+/// `v22.14.0` before `v22.9.1` before `v9.0.0`; a name that is not a
+/// version sorts last.
+fn sort_node_versions_newest_first(names: &mut [String]) {
+    fn key(name: &str) -> Option<Vec<u64>> {
+        name.strip_prefix('v')?
+            .split('.')
+            .map(|part| part.parse().ok())
+            .collect()
+    }
+    names.sort_by_key(|name| std::cmp::Reverse(key(name)));
 }
 
 /// `$QWEN_HOME` if set, else `~/.qwen`: `Storage.getGlobalQwenDir` in
@@ -1310,6 +1424,53 @@ mod tests {
             qwen_args("m:latest", &user_camel),
             ["--model", "m:latest", "--authType", "openai"]
         );
+    }
+
+    /// Newest node first; the directory order is not by version.
+    #[test]
+    fn node_versions_sort_newest_first_with_other_names_last() {
+        let mut names: Vec<String> = ["v9.0.0", "v20.19.0", ".DS_Store", "v22.14.0", "v22.9.1"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        sort_node_versions_newest_first(&mut names);
+        assert_eq!(
+            names,
+            ["v22.14.0", "v22.9.1", "v20.19.0", "v9.0.0", ".DS_Store"]
+        );
+    }
+
+    /// Over nvm's layout, the newest version that has qwen wins.
+    #[test]
+    fn nvm_qwen_picks_the_newest_version_that_has_it() {
+        let dir = std::env::temp_dir().join(format!(
+            "llmman-nvm-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let node = dir.join("versions").join("node");
+        for v in ["v20.19.0", "v22.14.0", "v22.9.1"] {
+            std::fs::create_dir_all(node.join(v).join("bin")).unwrap();
+        }
+        std::fs::write(node.join("v20.19.0/bin/qwen"), "").unwrap();
+        std::fs::write(node.join("v22.9.1/bin/qwen"), "").unwrap();
+        assert_eq!(nvm_qwen(&dir), Some(node.join("v22.9.1/bin/qwen")));
+        assert_eq!(nvm_qwen(&dir.join("nowhere")), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The documented targets are on the list (see `find_qwen`).
+    #[cfg(unix)]
+    #[test]
+    fn qwen_fallback_paths_name_the_documented_targets() {
+        let home = dirs::home_dir().unwrap();
+        let paths = qwen_fallback_paths();
+        assert!(paths.contains(&home.join(".local/bin/qwen")));
+        assert!(paths.contains(&home.join(".npm-global/bin/qwen")));
+        assert!(paths.contains(&PathBuf::from("/usr/local/bin/qwen")));
     }
 
     /// A file a Qwen Code user already has: llmman's entry goes first, an

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -1030,10 +1030,11 @@ fn sort_node_versions_newest_first(names: &mut [String]) {
 /// `$QWEN_HOME` if set, else `~/.qwen`: `Storage.getGlobalQwenDir` in
 /// Qwen Code's `packages/core/src/config/storage.ts`.
 fn qwen_home() -> anyhow::Result<PathBuf> {
-    let home = dirs::home_dir().context("no home directory")?;
+    let home = || dirs::home_dir().context("no home directory");
     match std::env::var("QWEN_HOME").ok().filter(|d| !d.is_empty()) {
-        Some(dir) => Ok(expand_tilde(&dir, &home)),
-        None => Ok(home.join(".qwen")),
+        Some(dir) if !dir.starts_with('~') => Ok(PathBuf::from(dir)),
+        Some(dir) => Ok(expand_tilde(&dir, &home()?)),
+        None => Ok(home()?.join(".qwen")),
     }
 }
 

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -11,7 +11,7 @@
 //! integration a provider's URL directly — one endpoint, one place
 //! integrations are configured, whether or not the weights are local.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::Context;
@@ -856,30 +856,32 @@ fn launch_openclaw(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
     exec_with_env(&bin, extra_args, &[])
 }
 
-/// qwen: Qwen Code's OpenAI-compatible mode, pointed at our /v1.
+/// qwen: Qwen Code's OpenAI-compatible mode, pointed at our /v1 by the
+/// command line, the environment and its settings file together, since
+/// it reads the three in a different order for each value.
 ///
-/// The auth type and model go on the command line, not only in the
-/// environment. Qwen Code resolves both as `argv`, then its own
-/// `~/.qwen/settings.json`, then the `OPENAI_*` variables, and it writes
-/// that file itself whenever a user picks a provider or model with
-/// `/auth` or `/model`. For anyone who has used it before, variables alone
-/// lose: the session went to the cloud provider recorded there, with that
-/// provider's real key, and reported success. Ollama's own
-/// `cmd/launch/qwen.go` prepends the same two flags.
-///
-/// The base URL and key stay in the environment even though Qwen Code
-/// has `--openai-base-url` and `--openai-api-key`: a key on the command
-/// line is visible in `ps` to anyone on the host, and for these two
-/// Qwen Code reads the variables ahead of its settings file, so the flags
-/// buy nothing. The one thing that still precedes them is a
-/// `modelProviders` entry whose id equals the launched model, which the
-/// `docker.io/…` and `hf.co/…` references llmman hands over do not
-/// collide with.
-///
-/// `--model` is required; `check_model_flag` refuses a launch without one
-/// before the daemon starts.
+/// `--auth-type` and `--model` go on the command line: for those it
+/// reads `argv`, then `~/.qwen/settings.json`, then the `OPENAI_*`
+/// variables, and it writes that file itself on `/auth` and `/model`, so
+/// for anyone who has used it before the variables alone lose. For the
+/// base URL a `modelProviders` entry in the settings file whose id is the
+/// model beats both flag and variable (`resolveModelConfig` in its
+/// `packages/core/src/models/modelConfigResolver.ts`), which is what
+/// `write_qwen_settings` is for. The key stays in the environment: on the
+/// command line it shows in `ps`, and the file only names the variable.
+/// Ollama's `cmd/launch/qwen.go` does the same three. `--model` is
+/// required; `check_model_flag` refuses a launch without one before the
+/// daemon starts.
 fn launch_qwen(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
     let bin = find_on_path("qwen").ok_or_else(|| anyhow::anyhow!("qwen is not installed"))?;
+    // After the lookup, so nothing is written for an integration that is
+    // not there; `check_model_flag` has made sure there is a model. A
+    // file that cannot be merged into is left alone and the launch goes
+    // on: Qwen Code resets a file it cannot parse to `{}` itself, and
+    // the flags and variables below carry the endpoint regardless.
+    if let Err(e) = write_qwen_settings(model) {
+        eprintln!("[llmman] qwen: settings.json left alone: {e:#}");
+    }
 
     let base_url = format!("{}/v1", daemon::server());
     exec_with_env(
@@ -909,6 +911,204 @@ fn qwen_args(model: &str, extra_args: &[String]) -> Vec<String> {
     }
     args.extend_from_slice(extra_args);
     args
+}
+
+/// `$QWEN_HOME` if set, else `~/.qwen`: `Storage.getGlobalQwenDir` in
+/// Qwen Code's `packages/core/src/config/storage.ts`.
+fn qwen_home() -> anyhow::Result<PathBuf> {
+    let home = dirs::home_dir().context("no home directory")?;
+    match std::env::var("QWEN_HOME").ok().filter(|d| !d.is_empty()) {
+        Some(dir) => Ok(expand_tilde(&dir, &home)),
+        None => Ok(home.join(".qwen")),
+    }
+}
+
+/// A leading `~` is `home`, as Qwen Code's `Storage.resolvePath` reads
+/// it; a quoted export leaves it for the program to expand.
+fn expand_tilde(dir: &str, home: &Path) -> PathBuf {
+    match dir.strip_prefix('~') {
+        Some(rest) if rest.is_empty() || rest.starts_with(['/', '\\']) => {
+            home.join(rest.trim_start_matches(['/', '\\']))
+        }
+        _ => PathBuf::from(dir),
+    }
+}
+
+/// Records llmman as the `openai` provider for `model` in Qwen Code's
+/// `settings.json`, as `write_codex_config` and `write_hermes_config` do
+/// for theirs. See `qwen_settings_merged` for what goes in.
+fn write_qwen_settings(model: &str) -> anyhow::Result<()> {
+    write_qwen_settings_at(&qwen_home()?, model, &format!("{}/v1", daemon::server()))
+}
+
+/// Read as Qwen Code reads it, comments stripped and an empty file as
+/// `{}`; what is still not a JSON object is refused rather than repaired,
+/// since Qwen Code moves a file it cannot parse to `settings.json.corrupted`
+/// and resets it to `{}`. The file as it was before llmman first wrote
+/// it stays as `settings.json.bak`, and a later one carrying comments,
+/// which the rewrite drops, replaces that copy; llmman's own renderings
+/// and Qwen Code's do not.
+fn write_qwen_settings_at(dir: &Path, model: &str, base_url: &str) -> anyhow::Result<()> {
+    let path = dir.join("settings.json");
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => Some(raw),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => return Err(e).with_context(|| format!("read {}", path.display())),
+    };
+    let existing = match raw.as_deref().map(str::trim) {
+        None | Some("") => serde_json::json!({}),
+        Some(text) => serde_json::from_str::<serde_json::Value>(&strip_json_comments(text))
+            .with_context(|| {
+                format!(
+                    "{} is not valid JSON; fix or move it, then retry",
+                    path.display()
+                )
+            })?,
+    };
+    if !existing.is_object() {
+        anyhow::bail!(
+            "{} is not a JSON object; fix or move it, then retry",
+            path.display()
+        );
+    }
+    let merged = qwen_settings_merged(&existing, model, base_url);
+    if merged == existing {
+        return Ok(());
+    }
+    std::fs::create_dir_all(dir).with_context(|| format!("create {}", dir.display()))?;
+    if let Some(raw) = &raw {
+        let bak = path.with_extension("json.bak");
+        if !bak.exists() || strip_json_comments(raw) != *raw {
+            std::fs::copy(&path, &bak)
+                .with_context(|| format!("back up {} to {}", path.display(), bak.display()))?;
+        }
+    }
+    let mut out = serde_json::to_string_pretty(&merged)?;
+    out.push('\n');
+    crate::fsutil::write_atomic(&path, out.as_bytes())
+        .with_context(|| format!("write {}", path.display()))
+}
+
+/// `//` and `/* */` comments outside strings replaced by spaces, so a
+/// parse error still points at the right place; what `strip-json-comments`
+/// does for Qwen Code before `JSON.parse`.
+fn strip_json_comments(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut chars = raw.chars().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+    while let Some(c) = chars.next() {
+        if in_string {
+            out.push(c);
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match c {
+            '"' => {
+                in_string = true;
+                out.push(c);
+            }
+            '/' if chars.peek() == Some(&'/') => {
+                out.push(' ');
+                while chars.peek().is_some_and(|&n| n != '\n') {
+                    chars.next();
+                    out.push(' ');
+                }
+            }
+            '/' if chars.peek() == Some(&'*') => {
+                chars.next();
+                out.push_str("  ");
+                let mut prev = ' ';
+                for n in chars.by_ref() {
+                    out.push(if n == '\n' { '\n' } else { ' ' });
+                    if prev == '*' && n == '/' {
+                        break;
+                    }
+                    prev = n;
+                }
+            }
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// On the name of every entry `qwen_settings_merged` writes, and what
+/// `qwen_entry_is_ours` recognises one by.
+const QWEN_ENTRY_MARK: &str = " (llmman)";
+
+/// `existing` with llmman's entry merged in; pure, so it is testable on a
+/// literal document. The keys are the ones Qwen Code's own `/auth` and
+/// `/model` write, and ollama's `applyQwenOllamaConfig` in
+/// `cmd/launch/qwen.go`: llmman's entry first in `modelProviders.openai`,
+/// with an earlier one of its own for this daemon replaced, the rest
+/// kept, and a `{ protocol, models }` wrapper an older Qwen Code wrote
+/// unwrapped as its `V5ToV4Migration` does; `security.auth.selectedType`
+/// and `baseUrl`; `model.name` with `model.baseUrl`, which Qwen Code sets
+/// together. No `$version`, which Qwen Code stamps itself, and no key: the
+/// entry names `OPENAI_API_KEY`, which `launch_qwen` exports. A value of
+/// the wrong type on the way down is replaced, as ollama's `qwenMap` does.
+fn qwen_settings_merged(
+    existing: &serde_json::Value,
+    model: &str,
+    base_url: &str,
+) -> serde_json::Value {
+    let mut doc = existing.as_object().cloned().unwrap_or_default();
+    let ours = serde_json::json!({
+        "id": model,
+        "name": format!("{model}{QWEN_ENTRY_MARK}"),
+        "baseUrl": base_url,
+        "envKey": "OPENAI_API_KEY",
+    });
+    let openai = object_under(&mut doc, "modelProviders")
+        .entry("openai")
+        .or_insert_with(|| serde_json::json!([]));
+    let entries = openai
+        .as_array()
+        .or_else(|| openai.get("models").and_then(serde_json::Value::as_array));
+    let kept = entries.map_or_else(Vec::new, |entries| {
+        entries
+            .iter()
+            .filter(|e| !qwen_entry_is_ours(e, base_url))
+            .cloned()
+            .collect()
+    });
+    *openai = serde_json::Value::Array(std::iter::once(ours).chain(kept).collect());
+    let auth = object_under(object_under(&mut doc, "security"), "auth");
+    auth.insert("selectedType".into(), "openai".into());
+    auth.insert("baseUrl".into(), base_url.into());
+    let model_cfg = object_under(&mut doc, "model");
+    model_cfg.insert("name".into(), model.into());
+    model_cfg.insert("baseUrl".into(), base_url.into());
+    serde_json::Value::Object(doc)
+}
+
+/// The object at `key` in `parent`, put there if absent or not an object.
+fn object_under<'a>(
+    parent: &'a mut serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> &'a mut serde_json::Map<String, serde_json::Value> {
+    let slot = parent.entry(key).or_insert_with(|| serde_json::json!({}));
+    if !slot.is_object() {
+        *slot = serde_json::json!({});
+    }
+    slot.as_object_mut().expect("set to an object just above")
+}
+
+/// An entry llmman wrote: `QWEN_ENTRY_MARK` on its name, at this daemon's
+/// address. The id is the model name and `envKey` is `OPENAI_API_KEY` on
+/// a hand-written entry too, so neither can mark an owner.
+fn qwen_entry_is_ours(entry: &serde_json::Value, base_url: &str) -> bool {
+    let field = |k: &str| entry.get(k).and_then(serde_json::Value::as_str);
+    field("name").is_some_and(|n| n.ends_with(QWEN_ENTRY_MARK))
+        && field("baseUrl")
+            .is_some_and(|u| u.trim_end_matches('/') == base_url.trim_end_matches('/'))
 }
 
 // ---------------------------------------------------------------------------
@@ -1110,6 +1310,220 @@ mod tests {
             qwen_args("m:latest", &user_camel),
             ["--model", "m:latest", "--authType", "openai"]
         );
+    }
+
+    /// A file a Qwen Code user already has: llmman's entry goes first, an
+    /// older one of its own for this daemon goes, and everything else
+    /// stays, a hand-written entry at this daemon's address included.
+    #[test]
+    fn qwen_settings_merge_keeps_what_is_not_llmmans() {
+        let existing = serde_json::json!({
+            "$version": 4,
+            "ui": { "theme": "keep-me" },
+            "modelProviders": {
+                "gemini": [ { "id": "gemini-2.5-pro" } ],
+                "openai": [
+                    { "id": "docker.io/ai/m:latest", "name": "cloud copy",
+                      "baseUrl": "https://cloud.example/v1",
+                      "envKey": "QWEN_CUSTOM_API_KEY_X", "customField": 1 },
+                    { "id": "old:latest", "name": "old:latest (llmman)",
+                      "baseUrl": "http://127.0.0.1:17434/v1/", "envKey": "OPENAI_API_KEY" },
+                    { "id": "other:latest", "name": "other:latest (llmman)",
+                      "baseUrl": "http://10.0.0.2:17434/v1", "envKey": "OPENAI_API_KEY" },
+                    { "id": "local-alias", "name": "my alias for the daemon",
+                      "baseUrl": "http://127.0.0.1:17434/v1", "envKey": "OPENAI_API_KEY",
+                      "generationConfig": { "temperature": 0.2 } }
+                ]
+            },
+            "security": { "auth": { "selectedType": "qwen-oauth", "apiKey": "keep-too" } },
+            "model": { "name": "gemini-2.5-pro", "generationConfig": { "temperature": 0.1 } }
+        });
+        let url = "http://127.0.0.1:17434/v1";
+        let merged = qwen_settings_merged(&existing, "docker.io/ai/m:latest", url);
+        assert_eq!(merged["$version"], 4);
+        assert_eq!(merged["ui"]["theme"], "keep-me");
+        assert_eq!(
+            merged["modelProviders"]["gemini"],
+            existing["modelProviders"]["gemini"]
+        );
+        let before = existing["modelProviders"]["openai"].as_array().unwrap();
+        let openai = merged["modelProviders"]["openai"].as_array().unwrap();
+        assert_eq!(
+            openai[0],
+            serde_json::json!({ "id": "docker.io/ai/m:latest",
+                "name": "docker.io/ai/m:latest (llmman)", "baseUrl": url,
+                "envKey": "OPENAI_API_KEY" })
+        );
+        assert_eq!(
+            openai[1..],
+            [before[0].clone(), before[2].clone(), before[3].clone()]
+        );
+        assert_eq!(merged["security"]["auth"]["selectedType"], "openai");
+        assert_eq!(merged["security"]["auth"]["baseUrl"], url);
+        assert_eq!(merged["security"]["auth"]["apiKey"], "keep-too");
+        assert_eq!(merged["model"]["name"], "docker.io/ai/m:latest");
+        assert_eq!(merged["model"]["baseUrl"], url);
+        assert_eq!(merged["model"]["generationConfig"]["temperature"], 0.1);
+    }
+
+    /// From nothing, and then again: the second merge changes nothing,
+    /// so `write_qwen_settings_at` leaves a correct file alone. No key
+    /// value and no `env` block anywhere in it.
+    #[test]
+    fn qwen_settings_merge_is_complete_from_nothing_and_idempotent() {
+        let url = "http://127.0.0.1:17434/v1";
+        let once = qwen_settings_merged(&serde_json::json!({}), "m:latest", url);
+        assert_eq!(
+            once,
+            serde_json::json!({
+                "modelProviders": { "openai": [ { "id": "m:latest",
+                    "name": "m:latest (llmman)", "baseUrl": url,
+                    "envKey": "OPENAI_API_KEY" } ] },
+                "security": { "auth": { "selectedType": "openai", "baseUrl": url } },
+                "model": { "name": "m:latest", "baseUrl": url }
+            })
+        );
+        assert_eq!(qwen_settings_merged(&once, "m:latest", url), once);
+        let text = once.to_string();
+        assert!(!text.contains("apiKey") && !text.contains("\"env\""));
+        assert!(!PROVIDER_NEEDS_DAEMON_KEY.contains(&"qwen"));
+    }
+
+    /// A wrong-typed value on the path is replaced, a non-object root
+    /// counts as empty, and a `{ protocol, models }` wrapper keeps its
+    /// entries.
+    #[test]
+    fn qwen_settings_merge_replaces_a_wrong_typed_value_on_its_path() {
+        let existing = serde_json::json!({
+            "security": 3, "modelProviders": { "openai": "x" }, "model": []
+        });
+        let merged = qwen_settings_merged(&existing, "m", "http://h/v1");
+        assert_eq!(merged["security"]["auth"]["selectedType"], "openai");
+        assert_eq!(merged["modelProviders"]["openai"][0]["id"], "m");
+        assert_eq!(merged["model"]["name"], "m");
+        let from_null = qwen_settings_merged(&serde_json::json!(null), "m", "http://h/v1");
+        assert_eq!(from_null["model"]["name"], "m");
+
+        let wrapped = serde_json::json!({
+            "$version": 5,
+            "modelProviders": { "openai": { "protocol": "openai", "models": [
+                { "id": "gpt-5", "baseUrl": "https://api.openai.com/v1", "envKey": "MY_KEY" }
+            ] } }
+        });
+        let merged = qwen_settings_merged(&wrapped, "m", "http://h/v1");
+        let openai = merged["modelProviders"]["openai"].as_array().unwrap();
+        assert_eq!(openai.len(), 2);
+        assert_eq!(openai[1]["id"], "gpt-5");
+    }
+
+    /// Ownership is the mark on the name at this daemon's address; a
+    /// trailing slash does not make a second daemon of the same one.
+    #[test]
+    fn qwen_entry_is_ours_needs_the_mark_and_the_address() {
+        let url = "http://127.0.0.1:17434/v1";
+        let ours = serde_json::json!({ "id": "anything", "name": "anything (llmman)",
+            "baseUrl": "http://127.0.0.1:17434/v1/", "envKey": "OPENAI_API_KEY" });
+        assert!(qwen_entry_is_ours(&ours, url));
+        let hand_written = serde_json::json!({ "id": "local-alias", "name": "my alias",
+            "baseUrl": url, "envKey": "OPENAI_API_KEY" });
+        assert!(!qwen_entry_is_ours(&hand_written, url));
+        let elsewhere = serde_json::json!({ "id": "m:latest", "name": "m:latest (llmman)",
+            "baseUrl": "http://10.0.0.2:17434/v1", "envKey": "OPENAI_API_KEY" });
+        assert!(!qwen_entry_is_ours(&elsewhere, url));
+        assert!(!qwen_entry_is_ours(
+            &serde_json::json!("not an object"),
+            url
+        ));
+    }
+
+    /// Comments go, as `strip-json-comments` takes them out for Qwen Code,
+    /// and nothing else moves: not a `//` inside a string, not a column.
+    #[test]
+    fn strip_json_comments_keeps_strings_and_columns() {
+        let raw =
+            "{\n  // note\n  \"url\": \"http://h//v1\", /* block\n  */ \"q\": \"a\\\"//b\"\n}\n";
+        let stripped = strip_json_comments(raw);
+        assert_eq!(stripped.chars().count(), raw.chars().count());
+        assert_eq!(stripped.lines().count(), raw.lines().count());
+        let v: serde_json::Value = serde_json::from_str(&stripped).unwrap();
+        assert_eq!(v["url"], "http://h//v1");
+        assert_eq!(v["q"], "a\"//b");
+        assert_eq!(strip_json_comments("{\"a\": 1}"), "{\"a\": 1}");
+    }
+
+    /// A leading `~` is the home directory; anything else is as given.
+    #[test]
+    fn expand_tilde_reads_the_forms_qwen_code_reads() {
+        let home = Path::new("/h");
+        assert_eq!(expand_tilde("~/alt", home), PathBuf::from("/h/alt"));
+        assert_eq!(expand_tilde("~", home), PathBuf::from("/h"));
+        assert_eq!(expand_tilde("/abs", home), PathBuf::from("/abs"));
+        assert_eq!(expand_tilde("~user/x", home), PathBuf::from("~user/x"));
+    }
+
+    /// The reading and writing half over a directory of its own: a fresh
+    /// one gets the file, a correct file is not touched, a commented one
+    /// merges with its text kept as `.bak`, a later rewrite of llmman's
+    /// own rendering leaves that `.bak` alone while a hand edit with
+    /// comments refreshes it, an empty file counts as
+    /// `{}`, and what is not JSON is refused with the file left alone.
+    #[test]
+    fn write_qwen_settings_at_writes_once_keeps_a_bak_and_refuses_non_json() {
+        let dir = std::env::temp_dir().join(format!(
+            "llmman-qwen-settings-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let url = "http://127.0.0.1:17434/v1";
+        let path = dir.join("settings.json");
+        let bak = dir.join("settings.json.bak");
+        let read = || -> serde_json::Value {
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap()
+        };
+
+        write_qwen_settings_at(&dir, "m:latest", url).unwrap();
+        assert_eq!(read()["model"]["name"], "m:latest");
+        assert!(!bak.exists(), "nothing to back up on a first write");
+        let written = std::fs::metadata(&path).unwrap().modified().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        write_qwen_settings_at(&dir, "m:latest", url).unwrap();
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().modified().unwrap(),
+            written
+        );
+
+        let commented = "{\n  // mine\n  \"ui\": { \"theme\": \"x\" }\n}\n";
+        std::fs::write(&path, commented).unwrap();
+        write_qwen_settings_at(&dir, "m:latest", url).unwrap();
+        assert_eq!(read()["ui"]["theme"], "x");
+        assert_eq!(read()["model"]["name"], "m:latest");
+        assert_eq!(std::fs::read_to_string(&bak).unwrap(), commented);
+        write_qwen_settings_at(&dir, "other:latest", url).unwrap();
+        assert_eq!(read()["model"]["name"], "other:latest");
+        assert_eq!(
+            std::fs::read_to_string(&bak).unwrap(),
+            commented,
+            "llmman's own rendering must not replace the user's backup"
+        );
+        let edited = "{\n  // edited by hand\n  \"ui\": { \"theme\": \"y\" }\n}\n";
+        std::fs::write(&path, edited).unwrap();
+        write_qwen_settings_at(&dir, "m:latest", url).unwrap();
+        assert_eq!(std::fs::read_to_string(&bak).unwrap(), edited);
+
+        std::fs::write(&path, "  \n").unwrap();
+        write_qwen_settings_at(&dir, "m:latest", url).unwrap();
+        assert_eq!(read()["model"]["name"], "m:latest");
+
+        std::fs::write(&path, "{ not json").unwrap();
+        let err = write_qwen_settings_at(&dir, "m:latest", url).unwrap_err();
+        assert!(format!("{err:#}").contains("not valid JSON"), "{err:#}");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "{ not json");
+        std::fs::write(&path, "[]").unwrap();
+        assert!(write_qwen_settings_at(&dir, "m:latest", url).is_err());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Regression test for the codex config bug described on

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -883,8 +883,11 @@ fn launch_openclaw(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
 /// model beats both flag and variable (`resolveModelConfig` in its
 /// `packages/core/src/models/modelConfigResolver.ts`), which is what
 /// `write_qwen_settings` is for. The key stays in the environment: on the
-/// command line it shows in `ps`, and the file only names the variable.
-/// Ollama's `cmd/launch/qwen.go` does the same three. `--model` is
+/// command line it shows in `ps`, and the file only names the variable,
+/// `LLMMAN_API_KEY`, exported with the same value as `OPENAI_API_KEY` so
+/// that llmman's entry is told from any other by its key name, the way
+/// ollama's is by `OLLAMA_API_KEY`. Ollama's `cmd/launch/qwen.go` does
+/// the same three. `--model` is
 /// required; `check_model_flag` refuses a launch without one before the
 /// daemon starts.
 fn launch_qwen(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
@@ -900,6 +903,7 @@ fn launch_qwen(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Res
         &[
             ("OPENAI_BASE_URL", base_url.as_str()),
             ("OPENAI_API_KEY", api_key),
+            (QWEN_ENV_KEY, api_key),
             ("OPENAI_MODEL", model),
         ],
     )
@@ -1150,9 +1154,9 @@ fn strip_json_comments(raw: &str) -> String {
     out
 }
 
-/// On the name of every entry `qwen_settings_merged` writes, and what
-/// `qwen_entry_is_ours` recognises one by.
-const QWEN_ENTRY_MARK: &str = " (llmman)";
+/// The variable llmman's entry names as its key, and what marks the entry
+/// as llmman's: a user can rename it in `/model`, but not re-key it.
+const QWEN_ENV_KEY: &str = "LLMMAN_API_KEY";
 
 /// `existing` with llmman's entry merged in; pure, so it is testable on a
 /// literal document. The keys are the ones Qwen Code's own `/auth` and
@@ -1163,7 +1167,7 @@ const QWEN_ENTRY_MARK: &str = " (llmman)";
 /// unwrapped as its `V5ToV4Migration` does; `security.auth.selectedType`
 /// and `baseUrl`; `model.name` with `model.baseUrl`, which Qwen Code sets
 /// together. No `$version`, which Qwen Code stamps itself, and no key: the
-/// entry names `OPENAI_API_KEY`, which `launch_qwen` exports. A value of
+/// entry names `QWEN_ENV_KEY`, which `launch_qwen` exports. A value of
 /// the wrong type on the way down is replaced, as ollama's `qwenMap` does.
 fn qwen_settings_merged(
     existing: &serde_json::Value,
@@ -1173,9 +1177,9 @@ fn qwen_settings_merged(
     let mut doc = existing.as_object().cloned().unwrap_or_default();
     let ours = serde_json::json!({
         "id": model,
-        "name": format!("{model}{QWEN_ENTRY_MARK}"),
+        "name": format!("{model} (llmman)"),
         "baseUrl": base_url,
-        "envKey": "OPENAI_API_KEY",
+        "envKey": QWEN_ENV_KEY,
     });
     let openai = object_under(&mut doc, "modelProviders")
         .entry("openai")
@@ -1212,12 +1216,13 @@ fn object_under<'a>(
     slot.as_object_mut().expect("set to an object just above")
 }
 
-/// An entry llmman wrote: `QWEN_ENTRY_MARK` on its name, at this daemon's
-/// address. The id is the model name and `envKey` is `OPENAI_API_KEY` on
-/// a hand-written entry too, so neither can mark an owner.
+/// An entry llmman wrote: `QWEN_ENV_KEY` as its key, at this daemon's
+/// address, the test `qwenIsOllamaProvider` makes in ollama's
+/// `cmd/launch/qwen.go`. The id is the model name and the display name
+/// is the user's to change, so neither marks an owner.
 fn qwen_entry_is_ours(entry: &serde_json::Value, base_url: &str) -> bool {
     let field = |k: &str| entry.get(k).and_then(serde_json::Value::as_str);
-    field("name").is_some_and(|n| n.ends_with(QWEN_ENTRY_MARK))
+    field("envKey") == Some(QWEN_ENV_KEY)
         && field("baseUrl")
             .is_some_and(|u| u.trim_end_matches('/') == base_url.trim_end_matches('/'))
 }
@@ -1484,10 +1489,10 @@ mod tests {
                     { "id": "docker.io/ai/m:latest", "name": "cloud copy",
                       "baseUrl": "https://cloud.example/v1",
                       "envKey": "QWEN_CUSTOM_API_KEY_X", "customField": 1 },
-                    { "id": "old:latest", "name": "old:latest (llmman)",
-                      "baseUrl": "http://127.0.0.1:17434/v1/", "envKey": "OPENAI_API_KEY" },
+                    { "id": "old:latest", "name": "renamed by the user",
+                      "baseUrl": "http://127.0.0.1:17434/v1/", "envKey": "LLMMAN_API_KEY" },
                     { "id": "other:latest", "name": "other:latest (llmman)",
-                      "baseUrl": "http://10.0.0.2:17434/v1", "envKey": "OPENAI_API_KEY" },
+                      "baseUrl": "http://10.0.0.2:17434/v1", "envKey": "LLMMAN_API_KEY" },
                     { "id": "local-alias", "name": "my alias for the daemon",
                       "baseUrl": "http://127.0.0.1:17434/v1", "envKey": "OPENAI_API_KEY",
                       "generationConfig": { "temperature": 0.2 } }
@@ -1510,7 +1515,7 @@ mod tests {
             openai[0],
             serde_json::json!({ "id": "docker.io/ai/m:latest",
                 "name": "docker.io/ai/m:latest (llmman)", "baseUrl": url,
-                "envKey": "OPENAI_API_KEY" })
+                "envKey": "LLMMAN_API_KEY" })
         );
         assert_eq!(
             openai[1..],
@@ -1536,7 +1541,7 @@ mod tests {
             serde_json::json!({
                 "modelProviders": { "openai": [ { "id": "m:latest",
                     "name": "m:latest (llmman)", "baseUrl": url,
-                    "envKey": "OPENAI_API_KEY" } ] },
+                    "envKey": "LLMMAN_API_KEY" } ] },
                 "security": { "auth": { "selectedType": "openai", "baseUrl": url } },
                 "model": { "name": "m:latest", "baseUrl": url }
             })
@@ -1574,19 +1579,20 @@ mod tests {
         assert_eq!(openai[1]["id"], "gpt-5");
     }
 
-    /// Ownership is the mark on the name at this daemon's address; a
-    /// trailing slash does not make a second daemon of the same one.
+    /// Ownership is the key name at this daemon's address, whatever the
+    /// entry was renamed to; a trailing slash does not make a second
+    /// daemon of the same one.
     #[test]
-    fn qwen_entry_is_ours_needs_the_mark_and_the_address() {
+    fn qwen_entry_is_ours_needs_the_key_name_and_the_address() {
         let url = "http://127.0.0.1:17434/v1";
-        let ours = serde_json::json!({ "id": "anything", "name": "anything (llmman)",
-            "baseUrl": "http://127.0.0.1:17434/v1/", "envKey": "OPENAI_API_KEY" });
+        let ours = serde_json::json!({ "id": "anything", "name": "renamed by the user",
+            "baseUrl": "http://127.0.0.1:17434/v1/", "envKey": "LLMMAN_API_KEY" });
         assert!(qwen_entry_is_ours(&ours, url));
-        let hand_written = serde_json::json!({ "id": "local-alias", "name": "my alias",
+        let hand_written = serde_json::json!({ "id": "local-alias", "name": "m (llmman)",
             "baseUrl": url, "envKey": "OPENAI_API_KEY" });
         assert!(!qwen_entry_is_ours(&hand_written, url));
         let elsewhere = serde_json::json!({ "id": "m:latest", "name": "m:latest (llmman)",
-            "baseUrl": "http://10.0.0.2:17434/v1", "envKey": "OPENAI_API_KEY" });
+            "baseUrl": "http://10.0.0.2:17434/v1", "envKey": "LLMMAN_API_KEY" });
         assert!(!qwen_entry_is_ours(&elsewhere, url));
         assert!(!qwen_entry_is_ours(
             &serde_json::json!("not an object"),

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -933,14 +933,19 @@ fn find_qwen() -> Option<PathBuf> {
 }
 
 /// Where a Qwen Code install lands that a process without the user's
-/// login shell does not see: the standalone installer's `~/.local/bin`,
-/// the `~/.npm-global` prefix its older npm installer set, nvm's newest
-/// node that has it, Homebrew's prefixes, `/usr/local/bin`, and on
-/// Windows npm's `%APPDATA%\npm` and the standalone installer's
-/// `%LOCALAPPDATA%\qwen-code\bin`. Ollama's `cmd/launch/qwen.go` checks
-/// a similar list. What nvm holds is a `#!/usr/bin/env node` shim whose
-/// `node` is on `PATH` only in an nvm-sourced shell, so a launch from
-/// another shell fails at exec rather than here.
+/// login shell does not see: the standalone installer's `~/.local/bin`
+/// and, on Windows, its `%LOCALAPPDATA%\qwen-code\bin`
+/// (`Get-QwenInstallBinDir` in Qwen Code's
+/// `scripts/installation/install-qwen-standalone.ps1`); the
+/// `~/.npm-global` prefix its older npm installer set; nvm's newest node
+/// that has it; Homebrew's prefixes and `/usr/local/bin`; and the rest of
+/// what ollama's `cmd/launch/qwen.go` probes, `~/.cargo/bin`, macOS's
+/// `~/Library/Application Support/qwen/bin`, and on Windows npm's global
+/// directory under both `%APPDATA%` and `%LOCALAPPDATA%`,
+/// `%LOCALAPPDATA%\Programs\qwen` and `%APPDATA%\qwen\bin`. What nvm
+/// holds is a `#!/usr/bin/env node` shim whose `node` is on `PATH` only
+/// in an nvm-sourced shell, so a launch from another shell fails at exec
+/// rather than here.
 fn qwen_fallback_paths() -> Vec<PathBuf> {
     let home = dirs::home_dir();
     let mut paths = Vec::new();
@@ -955,8 +960,11 @@ fn qwen_fallback_paths() -> Vec<PathBuf> {
             .map(PathBuf::from)
             .or_else(|| home.as_ref().map(|h| h.join("AppData").join("Local")));
         let dirs = [
-            roaming.map(|d| d.join("npm")),
-            local.map(|d| d.join("qwen-code").join("bin")),
+            roaming.as_ref().map(|d| d.join("npm")),
+            local.as_ref().map(|d| d.join("npm")),
+            local.as_ref().map(|d| d.join("qwen-code").join("bin")),
+            local.as_ref().map(|d| d.join("Programs").join("qwen")),
+            roaming.as_ref().map(|d| d.join("qwen").join("bin")),
         ];
         for dir in dirs.into_iter().flatten() {
             paths.extend(
@@ -970,6 +978,16 @@ fn qwen_fallback_paths() -> Vec<PathBuf> {
     if let Some(h) = &home {
         paths.push(h.join(".local").join("bin").join("qwen"));
         paths.push(h.join(".npm-global").join("bin").join("qwen"));
+        paths.push(h.join(".cargo").join("bin").join("qwen"));
+        if cfg!(target_os = "macos") {
+            paths.push(
+                h.join("Library")
+                    .join("Application Support")
+                    .join("qwen")
+                    .join("bin")
+                    .join("qwen"),
+            );
+        }
         paths.extend(nvm_dirs(h).iter().filter_map(|d| nvm_qwen(d)));
     }
     if cfg!(target_os = "macos") {
@@ -1477,6 +1495,7 @@ mod tests {
         let paths = qwen_fallback_paths();
         assert!(paths.contains(&home.join(".local/bin/qwen")));
         assert!(paths.contains(&home.join(".npm-global/bin/qwen")));
+        assert!(paths.contains(&home.join(".cargo/bin/qwen")));
         assert!(paths.contains(&PathBuf::from("/usr/local/bin/qwen")));
     }
 

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -1164,9 +1164,10 @@ const QWEN_ENV_KEY: &str = "LLMMAN_API_KEY";
 /// `cmd/launch/qwen.go`: llmman's entry first in `modelProviders.openai`,
 /// with an earlier one of its own for this daemon replaced, the rest
 /// kept, and a `{ protocol, models }` wrapper an older Qwen Code wrote
-/// unwrapped as its `V5ToV4Migration` does; `security.auth.selectedType`
-/// and `baseUrl`; `model.name` with `model.baseUrl`, which Qwen Code sets
-/// together. No `$version`, which Qwen Code stamps itself, and no key: the
+/// unwrapped as its `V5ToV4Migration` does, `$version` set to 4 with it;
+/// `security.auth.selectedType` and `baseUrl`; `model.name` with
+/// `model.baseUrl`, which Qwen Code sets together. Otherwise no
+/// `$version`, which Qwen Code stamps itself, and no key: the
 /// entry names `QWEN_ENV_KEY`, which `launch_qwen` exports. A value of
 /// the wrong type on the way down is replaced, as ollama's `qwenMap` does.
 fn qwen_settings_merged(
@@ -1184,6 +1185,7 @@ fn qwen_settings_merged(
     let openai = object_under(&mut doc, "modelProviders")
         .entry("openai")
         .or_insert_with(|| serde_json::json!([]));
+    let unwrapped = openai.get("models").is_some_and(|m| m.is_array());
     let entries = openai
         .as_array()
         .or_else(|| openai.get("models").and_then(serde_json::Value::as_array));
@@ -1195,6 +1197,9 @@ fn qwen_settings_merged(
             .collect()
     });
     *openai = serde_json::Value::Array(std::iter::once(ours).chain(kept).collect());
+    if unwrapped {
+        doc.insert("$version".into(), 4.into());
+    }
     let auth = object_under(object_under(&mut doc, "security"), "auth");
     auth.insert("selectedType".into(), "openai".into());
     auth.insert("baseUrl".into(), base_url.into());
@@ -1577,6 +1582,7 @@ mod tests {
         let openai = merged["modelProviders"]["openai"].as_array().unwrap();
         assert_eq!(openai.len(), 2);
         assert_eq!(openai[1]["id"], "gpt-5");
+        assert_eq!(merged["$version"], 4, "the version follows the shape");
     }
 
     /// Ownership is the key name at this daemon's address, whatever the

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -889,9 +889,12 @@ fn launch_openclaw(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
 /// ollama's is by `OLLAMA_API_KEY`. Ollama's `cmd/launch/qwen.go` does
 /// the same three. `--model` is
 /// required; `check_model_flag` refuses a launch without one before the
-/// daemon starts.
+/// daemon starts. A `--model` after `--` is the one Qwen Code will use
+/// (`qwen_args` yields to it), so the settings and `OPENAI_MODEL` follow
+/// it; `run` has resolved and preloaded the top-level one regardless.
 fn launch_qwen(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
     let bin = find_qwen().ok_or_else(|| anyhow::anyhow!("qwen is not installed"))?;
+    let model = forwarded_model(extra_args).unwrap_or(model);
     // After the lookup, so nothing is written for an integration that is
     // not there; `check_model_flag` has made sure there is a model.
     write_qwen_settings(model)?;
@@ -907,6 +910,24 @@ fn launch_qwen(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Res
             ("OPENAI_MODEL", model),
         ],
     )
+}
+
+/// The value of the last `--model`/`-m` after `--`, as a word or
+/// `=`-joined, the forms `has_flag` takes; yargs keeps the last too.
+fn forwarded_model(extra_args: &[String]) -> Option<&str> {
+    let mut found = None;
+    let mut args = extra_args.iter().map(String::as_str);
+    while let Some(a) = args.next() {
+        match a {
+            "--model" | "-m" => found = args.next().or(found),
+            _ => {
+                if let Some(v) = a.strip_prefix("--model=").or_else(|| a.strip_prefix("-m=")) {
+                    found = Some(v);
+                }
+            }
+        }
+    }
+    found.filter(|v| !v.is_empty())
 }
 
 /// `--auth-type openai --model <model>` ahead of the caller's own
@@ -1394,6 +1415,18 @@ mod tests {
             assert!(check_model_flag(id, Some("m"), None, &forwarded).is_ok());
         }
         assert!(check_model_flag("claude", None, None, &none).is_ok());
+    }
+
+    /// The last forwarded model wins, in either spelling; none is none.
+    #[test]
+    fn forwarded_model_takes_the_last_spelling() {
+        let args = |a: &[&str]| a.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        assert_eq!(forwarded_model(&args(&["--model", "b"])), Some("b"));
+        assert_eq!(forwarded_model(&args(&["-m=b", "--model", "c"])), Some("c"));
+        assert_eq!(forwarded_model(&args(&["--model=b", "-m", "c"])), Some("c"));
+        assert_eq!(forwarded_model(&args(&["-p", "x"])), None);
+        assert_eq!(forwarded_model(&args(&["--model"])), None);
+        assert_eq!(forwarded_model(&args(&["--model="])), None);
     }
 
     /// A word or `=`-joined, and nothing looser: `-sm` is not `-m`.

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -53,6 +53,9 @@ pub fn run(args: &LaunchArgs) -> anyhow::Result<()> {
         return Ok(());
     };
 
+    // Before either arm starts the daemon; see `check_model_flag`.
+    check_model_flag(name, args.model.as_deref(), provider, &args.extra_args)?;
+
     let (model, api_key) = match provider {
         Some(provider) => {
             check_provider_supported(name)?;
@@ -102,6 +105,51 @@ pub fn run(args: &LaunchArgs) -> anyhow::Result<()> {
     };
 
     launch(name, &model, &api_key, &args.extra_args)
+}
+
+// ---------------------------------------------------------------------------
+// Pre-flight
+// ---------------------------------------------------------------------------
+
+/// Integrations that cannot be launched without `--model`: Qwen Code has
+/// no notion of a missing model and sends its own built-in default
+/// (`qwen3.7-max` in 0.22.3), which the daemon would then try to pull.
+/// Checked before `ensure_server`, so the refusal costs no daemon start.
+const MODEL_REQUIRED: &[&str] = &["qwen"];
+
+/// Refuses a launch of one of `MODEL_REQUIRED` without a model, under
+/// `--provider` too. A second `--model` after `--` is the caller's to
+/// win (`qwen_args` yields to it), but `run` resolves the top-level one
+/// and, locally, preloads it, so that gets said.
+fn check_model_flag(
+    integration: &str,
+    model: Option<&str>,
+    provider: Option<&str>,
+    extra_args: &[String],
+) -> anyhow::Result<()> {
+    let name = integration.to_lowercase();
+    if !MODEL_REQUIRED.contains(&name.as_str()) {
+        return Ok(());
+    }
+    let Some(model) = model.map(str::trim).filter(|m| !m.is_empty()) else {
+        let with_provider = provider.map_or(String::new(), |p| format!(" --provider {p}"));
+        anyhow::bail!("{name} needs a model: llmman launch {name}{with_provider} --model <model>");
+    };
+    if has_flag(extra_args, "--model", Some("-m")) {
+        eprintln!(
+            "[llmman] {name}: the --model after -- wins over --model {model}, the one llmman resolved"
+        );
+    }
+    Ok(())
+}
+
+/// Whether `extra_args` spells `long` or `short`, as a word or `=`-joined.
+fn has_flag(extra_args: &[String], long: &str, short: Option<&str>) -> bool {
+    extra_args.iter().any(|a| {
+        a == long
+            || a.starts_with(&format!("{long}="))
+            || short.is_some_and(|s| a == s || a.starts_with(&format!("{s}=")))
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -828,16 +876,10 @@ fn launch_openclaw(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
 /// `docker.io/…` and `hf.co/…` references llmman hands over do not
 /// collide with.
 ///
-/// `--model` is required. Qwen Code has no notion of a missing model:
-/// given none it sends its own built-in default (`qwen3.7-max` in
-/// 0.22.3), which the daemon would then try to pull as
-/// `docker.io/ai/qwen3.7-max` and fail on, minutes later, naming a model
-/// the caller did not ask for. Refusing here names the flag instead.
+/// `--model` is required; `check_model_flag` refuses a launch without one
+/// before the daemon starts.
 fn launch_qwen(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
     let bin = find_on_path("qwen").ok_or_else(|| anyhow::anyhow!("qwen is not installed"))?;
-    if model.is_empty() {
-        anyhow::bail!("qwen needs a model: llmman launch qwen --model <model>");
-    }
 
     let base_url = format!("{}/v1", daemon::server());
     exec_with_env(
@@ -858,18 +900,11 @@ fn launch_qwen(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Res
 /// out an auth type meant it. `--authType` is checked too — yargs accepts
 /// a flag's camelCase spelling as well.
 fn qwen_args(model: &str, extra_args: &[String]) -> Vec<String> {
-    let has = |long: &str, short: Option<&str>| {
-        extra_args.iter().any(|a| {
-            a == long
-                || a.starts_with(&format!("{long}="))
-                || short.is_some_and(|s| a == s || a.starts_with(&format!("{s}=")))
-        })
-    };
     let mut args = Vec::with_capacity(extra_args.len() + 4);
-    if !has("--auth-type", Some("--authType")) {
+    if !has_flag(extra_args, "--auth-type", Some("--authType")) {
         args.extend(["--auth-type".to_string(), "openai".to_string()]);
     }
-    if !has("--model", Some("-m")) {
+    if !has_flag(extra_args, "--model", Some("-m")) {
         args.extend(["--model".to_string(), model.to_string()]);
     }
     args.extend_from_slice(extra_args);
@@ -994,6 +1029,48 @@ mod tests {
         );
         assert_eq!(openclaw_model_id(""), "default");
         assert_eq!(openclaw_model_id("docker.io/ai/"), "default");
+    }
+
+    /// Every integration `check_model_flag` holds to a model must be one
+    /// `launch` dispatches; it is refused without one, under `--provider`
+    /// too, and a `--model` after `--` is let through.
+    #[test]
+    fn model_required_integrations_are_refused_without_a_model() {
+        let none: Vec<String> = vec![];
+        for id in MODEL_REQUIRED {
+            assert!(
+                INTEGRATIONS.iter().any(|i| i.name == *id),
+                "{id} is not an integration"
+            );
+            assert!(check_model_flag(id, None, None, &none).is_err());
+            assert!(check_model_flag(id, Some(" "), None, &none).is_err());
+            assert!(check_model_flag(&id.to_uppercase(), None, None, &none).is_err());
+            let err = check_model_flag(id, None, Some("openrouter"), &none).unwrap_err();
+            assert!(
+                err.to_string().contains("--provider openrouter --model"),
+                "{err}"
+            );
+            assert!(check_model_flag(id, Some("m"), None, &none).is_ok());
+            let forwarded = vec!["--model".to_string(), "theirs".to_string()];
+            assert!(check_model_flag(id, Some("m"), None, &forwarded).is_ok());
+        }
+        assert!(check_model_flag("claude", None, None, &none).is_ok());
+    }
+
+    /// A word or `=`-joined, and nothing looser: `-sm` is not `-m`.
+    #[test]
+    fn has_flag_takes_the_exact_and_joined_forms_only() {
+        let args = |a: &[&str]| a.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        assert!(has_flag(&args(&["--model", "x"]), "--model", Some("-m")));
+        assert!(has_flag(&args(&["--model=x"]), "--model", Some("-m")));
+        assert!(has_flag(&args(&["-m", "x"]), "--model", Some("-m")));
+        assert!(has_flag(&args(&["-m=x"]), "--model", Some("-m")));
+        assert!(!has_flag(&args(&["-sm", "x"]), "--model", Some("-m")));
+        assert!(!has_flag(
+            &args(&["--model-context", "x"]),
+            "--model",
+            Some("-m")
+        ));
     }
 
     /// The two flags `launch_qwen` relies on to beat a persisted

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -890,13 +890,8 @@ fn launch_openclaw(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
 fn launch_qwen(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
     let bin = find_qwen().ok_or_else(|| anyhow::anyhow!("qwen is not installed"))?;
     // After the lookup, so nothing is written for an integration that is
-    // not there; `check_model_flag` has made sure there is a model. A
-    // file that cannot be merged into is left alone and the launch goes
-    // on: Qwen Code resets a file it cannot parse to `{}` itself, and
-    // the flags and variables below carry the endpoint regardless.
-    if let Err(e) = write_qwen_settings(model) {
-        eprintln!("[llmman] qwen: settings.json left alone: {e:#}");
-    }
+    // not there; `check_model_flag` has made sure there is a model.
+    write_qwen_settings(model)?;
 
     let base_url = format!("{}/v1", daemon::server());
     exec_with_env(
@@ -1057,9 +1052,13 @@ fn write_qwen_settings(model: &str) -> anyhow::Result<()> {
 }
 
 /// Read as Qwen Code reads it, comments stripped and an empty file as
-/// `{}`; what is still not a JSON object is refused rather than repaired,
-/// since Qwen Code moves a file it cannot parse to `settings.json.corrupted`
-/// and resets it to `{}`. The file as it was before llmman first wrote
+/// `{}`. What is still not a JSON object is left alone, with a line to
+/// say so, and the launch goes on: Qwen Code moves a file it cannot parse
+/// to `settings.json.corrupted` and resets it to `{}`, so no entry in it
+/// survives to outrank the flags and variables `launch_qwen` passes. A
+/// file that parses but cannot be written is an error, since an entry in
+/// it may be exactly what the write was to outrank.
+/// The file as it was before llmman first wrote
 /// it stays as `settings.json.bak`, and a later one carrying comments,
 /// which the rewrite drops, replaces that copy; llmman's own renderings
 /// and Qwen Code's do not.
@@ -1072,20 +1071,17 @@ fn write_qwen_settings_at(dir: &Path, model: &str, base_url: &str) -> anyhow::Re
     };
     let existing = match raw.as_deref().map(str::trim) {
         None | Some("") => serde_json::json!({}),
-        Some(text) => serde_json::from_str::<serde_json::Value>(&strip_json_comments(text))
-            .with_context(|| {
-                format!(
-                    "{} is not valid JSON; fix or move it, then retry",
+        Some(text) => match serde_json::from_str::<serde_json::Value>(&strip_json_comments(text)) {
+            Ok(value) if value.is_object() => value,
+            _ => {
+                eprintln!(
+                    "[llmman] qwen: {} is not a JSON object; leaving it alone",
                     path.display()
-                )
-            })?,
+                );
+                return Ok(());
+            }
+        },
     };
-    if !existing.is_object() {
-        anyhow::bail!(
-            "{} is not a JSON object; fix or move it, then retry",
-            path.display()
-        );
-    }
     let merged = qwen_settings_merged(&existing, model, base_url);
     if merged == existing {
         return Ok(());
@@ -1627,8 +1623,8 @@ mod tests {
     /// one gets the file, a correct file is not touched, a commented one
     /// merges with its text kept as `.bak`, a later rewrite of llmman's
     /// own rendering leaves that `.bak` alone while a hand edit with
-    /// comments refreshes it, an empty file counts as
-    /// `{}`, and what is not JSON is refused with the file left alone.
+    /// comments refreshes it, an empty file counts as `{}`, and what is
+    /// not JSON is left alone without an error.
     #[test]
     fn write_qwen_settings_at_writes_once_keeps_a_bak_and_refuses_non_json() {
         let dir = std::env::temp_dir().join(format!(
@@ -1680,11 +1676,11 @@ mod tests {
         assert_eq!(read()["model"]["name"], "m:latest");
 
         std::fs::write(&path, "{ not json").unwrap();
-        let err = write_qwen_settings_at(&dir, "m:latest", url).unwrap_err();
-        assert!(format!("{err:#}").contains("not valid JSON"), "{err:#}");
+        write_qwen_settings_at(&dir, "m:latest", url).unwrap();
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "{ not json");
         std::fs::write(&path, "[]").unwrap();
-        assert!(write_qwen_settings_at(&dir, "m:latest", url).is_err());
+        write_qwen_settings_at(&dir, "m:latest", url).unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "[]");
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src/fsutil.rs
+++ b/src/fsutil.rs
@@ -1,0 +1,88 @@
+//! Whole-file writes a reader never sees half done.
+
+use std::io::Write as _;
+use std::path::Path;
+
+/// Writes `bytes` to `path` through a temp file beside it and a rename,
+/// so a reader sees the old file or the new one and not a partial one.
+/// A symlink whose target exists is written through to the target, the
+/// old file's permissions go on the temp before it holds anything, and
+/// the temp is synced before the rename.
+pub fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let mut tmp = path.clone().into_os_string();
+    tmp.push(format!(".{}.tmp", std::process::id()));
+    let _ = std::fs::remove_file(&tmp);
+    let written = (|| {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp)?;
+        if let Ok(meta) = std::fs::metadata(&path) {
+            file.set_permissions(meta.permissions())?;
+        }
+        file.write_all(bytes)?;
+        file.sync_all()
+    })();
+    if let Err(e) = written {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    std::fs::rename(&tmp, &path).inspect_err(|_| {
+        let _ = std::fs::remove_file(&tmp);
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(label: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "llmman-fsutil-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn write_atomic_replaces_the_content_and_leaves_no_temp_behind() {
+        let dir = temp_dir("replace");
+        let path = dir.join("f.tar.gz");
+        write_atomic(&path, b"one").unwrap();
+        write_atomic(&path, b"two").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"two");
+        assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A dotfile kept as a symlink stays one: the target changes, the
+    /// link does not, and the old mode comes along.
+    #[cfg(unix)]
+    #[test]
+    fn write_atomic_writes_through_a_symlink_and_keeps_the_mode() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = temp_dir("symlink");
+        let target = dir.join("real.json");
+        let link = dir.join("link.json");
+        std::fs::write(&target, b"old").unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o600)).unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        write_atomic(&link, b"new").unwrap();
+        assert!(std::fs::symlink_metadata(&link)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(std::fs::read(&target).unwrap(), b"new");
+        assert_eq!(
+            std::fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/fsutil.rs
+++ b/src/fsutil.rs
@@ -2,17 +2,27 @@
 
 use std::io::Write as _;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Distinguishes the temp files of concurrent writers in one process; the
+/// pid does the same across processes.
+static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Writes `bytes` to `path` through a temp file beside it and a rename,
-/// so a reader sees the old file or the new one and not a partial one.
+/// so a reader sees the old file or the new one and not a partial one;
+/// the temp name carries the pid and a counter, so no two writers share
+/// one.
 /// A symlink whose target exists is written through to the target, the
 /// old file's permissions go on the temp before it holds anything, and
 /// the temp is synced before the rename.
 pub fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
     let mut tmp = path.clone().into_os_string();
-    tmp.push(format!(".{}.tmp", std::process::id()));
-    let _ = std::fs::remove_file(&tmp);
+    tmp.push(format!(
+        ".{}.{}.tmp",
+        std::process::id(),
+        TMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
     let written = (|| {
         let mut file = std::fs::OpenOptions::new()
             .write(true)
@@ -57,6 +67,27 @@ mod tests {
         write_atomic(&path, b"one").unwrap();
         write_atomic(&path, b"two").unwrap();
         assert_eq!(std::fs::read(&path).unwrap(), b"two");
+        assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Writers in one process racing on one file each land whole.
+    #[test]
+    fn write_atomic_concurrent_writers_each_land_a_whole_file() {
+        let dir = temp_dir("race");
+        let path = dir.join("f.json");
+        let threads: Vec<_> = (0..8u8)
+            .map(|i| {
+                let path = path.clone();
+                std::thread::spawn(move || write_atomic(&path, &[i; 4096]).unwrap())
+            })
+            .collect();
+        for t in threads {
+            t.join().unwrap();
+        }
+        let got = std::fs::read(&path).unwrap();
+        assert_eq!(got.len(), 4096);
+        assert!(got.iter().all(|b| *b == got[0]));
         assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 1);
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod container;
 pub mod daemon;
 pub mod ffi;
 pub mod fmt;
+pub mod fsutil;
 pub mod gguf;
 pub mod harmony;
 pub mod hf;

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -747,21 +747,15 @@ fn load() -> anyhow::Result<Loaded> {
     }
 }
 
-/// Writes the cache through a temp file and a rename, as opencode does
+/// Writes the cache atomically (`fsutil::write_atomic`), as opencode does
 /// for its own copy: `llmman launch` and `llmman serve` refresh it
 /// independently and do overlap, and a plain write leaves a window in
-/// which the other reads a half-written file. Rename is atomic, so a
-/// reader sees the old copy or the new one. The temp name carries the pid
-/// so two writers can't share one.
+/// which the other reads a half-written file.
 fn write_cache(path: &std::path::Path, raw: &[u8]) -> std::io::Result<()> {
     if let Some(dir) = path.parent() {
         std::fs::create_dir_all(dir)?;
     }
-    let tmp = path.with_extension(format!("{}.tmp", std::process::id()));
-    std::fs::write(&tmp, raw)?;
-    std::fs::rename(&tmp, path).inspect_err(|_| {
-        let _ = std::fs::remove_file(&tmp);
-    })
+    crate::fsutil::write_atomic(path, raw)
 }
 
 fn fetch(url: &str) -> anyhow::Result<Vec<u8>> {

--- a/tests/launch_e2e.rs
+++ b/tests/launch_e2e.rs
@@ -915,40 +915,7 @@ fn qwen_loop_detection(stderr: &str) -> bool {
 /// the real `PATH`.
 #[test]
 fn ensure_server_fails_fast_when_daemon_dies_at_startup() {
-    let dir = fresh_home("dead-daemon");
-    let bin_dir = dir.join("bin");
-    std::fs::create_dir_all(&bin_dir).expect("create fake bin dir");
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let fake = bin_dir.join("llama-server");
-        std::fs::write(&fake, "#!/bin/sh\nexit 0\n").expect("write fake llama-server");
-        std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755))
-            .expect("chmod fake llama-server");
-    }
-    // find_on_path probes only `{name}.exe` on Windows, so the fake must
-    // be an `.exe`; any content works because it is found, never executed.
-    #[cfg(windows)]
-    std::fs::write(bin_dir.join("llama-server.exe"), "not a real executable")
-        .expect("write fake llama-server");
-
-    std::fs::write(dir.join("cache"), "a file where serve expects a directory")
-        .expect("write cache blocker file");
-
-    // Bound once to reserve a definitely-free port number, then dropped:
-    // the port must NOT stay listening, or ensure_server would take a
-    // successful connect as "a daemon is already running" and never spawn
-    // the one under test.
-    let port = std::net::TcpListener::bind("127.0.0.1:0")
-        .expect("bind probe listener")
-        .local_addr()
-        .expect("probe listener addr")
-        .port();
-
-    let path = std::env::join_paths(std::iter::once(bin_dir).chain(std::env::split_paths(
-        &std::env::var_os("PATH").unwrap_or_default(),
-    )))
-    .expect("join PATH");
+    let (dir, port, path) = dead_daemon_setup("dead-daemon");
 
     let mut cmd = Command::new(llmman_bin());
     cmd.arg("pull").arg(MODEL);
@@ -985,6 +952,83 @@ fn ensure_server_fails_fast_when_daemon_dies_at_startup() {
         "fast-fail took {elapsed:?}; it should report within seconds, \
          not wait out ensure_server's 60s poll"
     );
+}
+
+/// `llmman launch qwen` with no `--model` is refused on the flag before
+/// any daemon work: under the dead-daemon setup a build that checked
+/// after `ensure_server` would report the daemon's startup exit instead.
+#[test]
+fn launch_qwen_without_a_model_is_refused_before_the_daemon() {
+    let (dir, port, path) = dead_daemon_setup("qwen-no-model");
+
+    let mut cmd = Command::new(llmman_bin());
+    cmd.arg("launch").arg("qwen");
+    cmd.env("HOME", &dir)
+        .env("USERPROFILE", &dir)
+        .env("QWEN_HOME", dir.join(".qwen"))
+        .env("LLMMAN_HOST", format!("127.0.0.1:{port}"))
+        .env("LLMMAN_MODELS", dir.join("store"))
+        .env("PATH", path);
+
+    let start = Instant::now();
+    let output = spawn_with_timeout(
+        cmd,
+        Duration::from_secs(45),
+        "`llmman launch qwen` with no --model",
+    );
+    let elapsed = start.elapsed();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "launch without a model succeeded\n{stderr}"
+    );
+    assert!(stderr.contains("qwen needs a model"), "{stderr}");
+    assert!(
+        !stderr.contains("exited during startup"),
+        "the daemon was started first\n{stderr}"
+    );
+    assert!(elapsed < Duration::from_secs(5), "refusal took {elapsed:?}");
+}
+
+/// A fresh `HOME` in which any daemon `llmman` spawns dies at startup, a
+/// port nothing answers on for `LLMMAN_HOST`, and the `PATH` that makes
+/// it so; see `ensure_server_fails_fast_when_daemon_dies_at_startup`.
+fn dead_daemon_setup(label: &str) -> (PathBuf, u16, std::ffi::OsString) {
+    let dir = fresh_home(label);
+    let bin_dir = dir.join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("create fake bin dir");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let fake = bin_dir.join("llama-server");
+        std::fs::write(&fake, "#!/bin/sh\nexit 0\n").expect("write fake llama-server");
+        std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake llama-server");
+    }
+    // find_on_path probes `.exe`, `.cmd` and `.bat` on Windows; `.exe` is
+    // the natural fake, and any content works: it is found, not executed.
+    #[cfg(windows)]
+    std::fs::write(bin_dir.join("llama-server.exe"), "not a real executable")
+        .expect("write fake llama-server");
+
+    std::fs::write(dir.join("cache"), "a file where serve expects a directory")
+        .expect("write cache blocker file");
+
+    // Bound once to reserve a definitely-free port number, then dropped:
+    // the port must NOT stay listening, or ensure_server would take a
+    // successful connect as "a daemon is already running" and never spawn
+    // the one under test.
+    let port = std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind probe listener")
+        .local_addr()
+        .expect("probe listener addr")
+        .port();
+
+    let path = std::env::join_paths(std::iter::once(bin_dir).chain(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    )))
+    .expect("join PATH");
+    (dir, port, path)
 }
 
 /// True for the one openclaw-specific failure shape confirmed live in

--- a/tests/launch_e2e.rs
+++ b/tests/launch_e2e.rs
@@ -601,7 +601,11 @@ fn run_launch(
     cmd.env("HOME", home)
         .env("USERPROFILE", home)
         .env("XDG_CONFIG_HOME", home.join(".config"))
-        .env("XDG_DATA_HOME", home.join(".local/share"));
+        .env("XDG_DATA_HOME", home.join(".local/share"))
+        // Set, not cleared: a `QWEN_HOME` in the developer's shell would
+        // send the settings `launch qwen` writes past this `HOME`, and on
+        // Windows `dirs::home_dir` reads neither `HOME` nor `USERPROFILE`.
+        .env("QWEN_HOME", home.join(".qwen"));
 
     try_spawn_with_timeout(
         cmd,


### PR DESCRIPTION
Follow-up to #355.

`llmman launch qwen` now writes `~/.qwen/settings.json` like the codex and hermes launchers do: llmman's provider entry goes first in `modelProviders.openai`, the auth type, base URL and model name are set, everything else in the file is left as it was, and the old file is kept as `settings.json.bak`. This fixes the case where a persisted entry with the same model id sent Qwen Code to another server. `find_qwen` also checks the usual install locations (`~/.local/bin`, the npm prefix, nvm, Homebrew, `%APPDATA%\npm`) when qwen is not on PATH; an nvm install found this way still needs `node` on PATH, so from a shell without nvm sourced the launch fails at exec. The model check now runs before the daemon starts, and a `--model` after `--` still wins, same as before.