### PR TITLE
docs: add "Why llmman?" section and move metrics reference to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,35 @@ GPU, loads the model, and execs an agent against it.
 
 <!-- TODO: 20s asciinema/GIF here: launch claude -> boots -> wifi off -> still coding -->
 
+## Why llmman?
+
+- **Provider agnostic.** The same `launch`, `run` and `list` commands work
+  against a local model or any hosted provider (`--provider baseten`,
+  `--provider groq`, ...). One endpoint, one agent config, local or hosted.
+- **Registry agnostic.** `llmman run qwen3.8` pulls straight from Docker
+  Hub; `llmman run hf.co/org/model` pulls straight from Hugging Face. Or
+  package a model as a plain OCI artifact and push it to GHCR, quay, Harbor
+  or a self-hosted mirror, then `llmman run` it from there. No curated
+  library, no account with llmman, no gatekeeper.
+- **Vanilla everything.** Upstream `llama.cpp` releases (or the
+  `llama-server` already on your `PATH`), `vllm` and `mlx-lm` as-is, serving
+  unmodified GGUF and safetensors files. No fork to wait on, no import step,
+  no private blob format: the store is a standard OCI Image Layout that all
+  can read.
+- **One-step transfer.** `llmman transfer hf.co/org/model docker.io/you/model`
+  moves a model from HuggingFace straight into your own registry, optionally
+  signed, without landing on a laptop first.
+  That is the shape air-gapped and compliance-bound environments need.
+
+| | llmman | Ollama |
+|---|---|---|
+| Model registry | Hugging Face directly, or any OCI registry (Docker Hub, GHCR, quay, Harbor, self-hosted) | ollama.com library, own registry protocol |
+| Model format on disk | Unmodified GGUF / safetensors in a standard OCI Image Layout | GGUF and safetensors imported via `Modelfile` into Ollama's blob layout |
+| Inference engine | Upstream `llama.cpp` release, or your own `llama-server`; `vllm`; `mlx-lm` | Bundled `llama.cpp`/ggml fork plus Ollama's own engine |
+| Hosted models | Any provider via `--provider` | Ollama Cloud |
+| Registry-to-registry transfer | `llmman transfer hf.co/... docker.io/...` in one step, no local copy | Pull, write a `Modelfile`, `create`, push to ollama.com |
+| Signing and verification | cosign-format signatures; `verify` command and per-repo pull-time trust policy | None |
+
 ## Install
 
 **Linux, macOS:**
@@ -145,55 +174,10 @@ no price). `llmman providers`, `list --provider`, `run --provider` and
 `launch --provider` are all clients of it, so the catalog is fetched and
 cached in one process: the one that forwards the request upstream.
 
-`/metrics` is a Prometheus scrape target, off by default: the router has
-no authentication, and `LLMMAN_HOST` can bind it beyond loopback.
-`LLMMAN_METRICS=1` (or `true`, `yes`, `on`) serves it; unset, the route
-is absent, answers 404 and records nothing.
-
-```bash
-LLMMAN_METRICS=1 llmman serve
-```
-
-It is on Prometheus' default path, so a scrape config needs no
-`metrics_path`:
-
-```yaml
-scrape_configs:
-  - job_name: llmman
-    static_configs:
-      - targets: ["127.0.0.1:17434"]
-```
-
-Fifteen metric families:
-
-| Metric | Type | Labels | What it tells you |
-|--------|------|--------|-------------------|
-| `llmman_build_info` | gauge | `version` | Which build is running; join against it to break a graph out by version. |
-| `llmman_start_time_seconds` | gauge | — | `time() - llmman_start_time_seconds` is uptime; a step down is a restart. |
-| `llmman_scheduling_requests_in_flight` | gauge | — | Requests doing model-scheduling work right now. |
-| `llmman_scheduling_capacity` | gauge | — | The limit those are counted against, i.e. `LLMMAN_MAX_QUEUE.max(1)`. |
-| `llmman_scheduling_rejections_total` | counter | — | Requests refused with a 503 because that limit was full. |
-| `llmman_models_loaded` | gauge | — | Backends currently running, the set `/api/ps` reports. |
-| `llmman_models_loading` | gauge | — | Loads under way; `loaded + loading` is what `LLMMAN_MAX_LOADED_MODELS` caps. |
-| `llmman_model_up` | gauge | `model`, `engine` | 1 while the backend process is alive, 0 once it has died but llmman has not noticed. |
-| `llmman_model_loads_total` | counter | `model` | Cold starts per model — the churn a too-small `LLMMAN_MAX_LOADED_MODELS` produces. |
-| `llmman_model_load_duration_seconds` | histogram | `model` | How long a cold start takes, from admission to ready. |
-| `llmman_model_load_oom_retries_total` | counter | `model`, `strategy` | Loads that hit an out-of-memory failure and retried: `evict_others`, `split_mode`, `ctx_shrink`. |
-| `llmman_model_unloads_total` | counter | `model`, `reason` | `idle`, `requested`, `crashed`, `oom`, `evicted`. |
-| `llmman_http_requests_total` | counter | `route`, `status` | Request rate and error rate by matched route. |
-| `llmman_http_request_ttfb_seconds` | histogram | `route` | Time to response headers. This is the latency number. |
-| `llmman_http_request_duration_seconds` | histogram | `route` | Time to the last byte of the body. |
-
-On a streaming route, time to the last byte mostly tracks how many tokens
-were asked for. Graph `_ttfb_` as latency; `_duration_` is for a stream
-that dies after its first byte.
-
-llmman only notices a dead backend when a request arrives for it, so
-`sum by (instance) (llmman_models_loaded) - sum by (instance) (llmman_model_up)`
-is how many dead backends it has not noticed yet.
-
-Per-token counters are deliberately absent: `llama-server` already
-publishes them on its own `/metrics` when started with `--metrics`.
+`/metrics` is a Prometheus scrape target, off by default because the
+router has no authentication. `LLMMAN_METRICS=1 llmman serve` turns it
+on; the fifteen metric families and how to read them are in
+[docs/metrics.md](docs/metrics.md).
 
 `/v1/responses` implements the OpenAI Responses API (the dialect [OpenAI
 Codex](https://github.com/openai/codex) requires), including streaming SSE
@@ -233,7 +217,7 @@ Point an integration at a model in one step. `llmman launch` starts `serve` in t
 llmman launch claude --model gemma4
 ```
 
-Run `llmman launch` with no arguments to list the supported integrations (Claude Code, OpenCode) and whether each is installed. Any extra arguments after `--` are forwarded to the integration's own CLI.
+Run `llmman launch` with no arguments to list the supported integrations (Claude Code, OpenCode, Codex, etc.) and whether each is installed. Any extra arguments after `--` are forwarded to the integration's own CLI.
 
 Short names work wherever a model reference is accepted.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,60 @@
+# Prometheus metrics
+
+`llmman serve` can expose a Prometheus scrape target at `/metrics`. It is
+off by default: the router has no authentication, and `LLMMAN_HOST` can
+bind it beyond loopback, so an upgrade should not start publishing this
+daemon's version, route mix, model names and model churn to whoever can
+reach the port. `LLMMAN_METRICS=1` (or `true`, `yes`, `on`) serves it;
+unset, the route is absent, answers 404 and records nothing.
+
+```bash
+LLMMAN_METRICS=1 llmman serve
+```
+
+It is on Prometheus' default path, so a scrape config needs no
+`metrics_path`:
+
+```yaml
+scrape_configs:
+  - job_name: llmman
+    static_configs:
+      - targets: ["127.0.0.1:17434"]
+```
+
+## Metric families
+
+Fifteen metric families:
+
+| Metric | Type | Labels | What it tells you |
+|--------|------|--------|-------------------|
+| `llmman_build_info` | gauge | `version` | Which build is running; join against it to break a graph out by version. |
+| `llmman_start_time_seconds` | gauge | — | `time() - llmman_start_time_seconds` is uptime; a step down is a restart. |
+| `llmman_scheduling_requests_in_flight` | gauge | — | Requests doing model-scheduling work right now. |
+| `llmman_scheduling_capacity` | gauge | — | The limit those are counted against, i.e. `LLMMAN_MAX_QUEUE.max(1)`. |
+| `llmman_scheduling_rejections_total` | counter | — | Requests refused with a 503 because that limit was full. |
+| `llmman_models_loaded` | gauge | — | Backends currently running, the set `/api/ps` reports. |
+| `llmman_models_loading` | gauge | — | Loads under way; `loaded + loading` is what `LLMMAN_MAX_LOADED_MODELS` caps. |
+| `llmman_model_up` | gauge | `model`, `engine` | 1 while the backend process is alive, 0 once it has died but llmman has not noticed. |
+| `llmman_model_loads_total` | counter | `model` | Cold starts per model — the churn a too-small `LLMMAN_MAX_LOADED_MODELS` produces. |
+| `llmman_model_load_duration_seconds` | histogram | `model` | How long a cold start takes, from admission to ready. |
+| `llmman_model_load_oom_retries_total` | counter | `model`, `strategy` | Loads that hit an out-of-memory failure and retried: `evict_others`, `split_mode`, `ctx_shrink`. |
+| `llmman_model_unloads_total` | counter | `model`, `reason` | `idle`, `requested`, `crashed`, `oom`, `evicted`. |
+| `llmman_http_requests_total` | counter | `route`, `status` | Request rate and error rate by matched route. |
+| `llmman_http_request_ttfb_seconds` | histogram | `route` | Time to response headers. This is the latency number. |
+| `llmman_http_request_duration_seconds` | histogram | `route` | Time to the last byte of the body. |
+
+## Reading them
+
+On a streaming route, time to the last byte mostly tracks how many tokens
+were asked for. Graph `_ttfb_` as latency; `_duration_` is for a stream
+that dies after its first byte.
+
+llmman only notices a dead backend when a request arrives for it, so
+`sum by (instance) (llmman_models_loaded) - sum by (instance) (llmman_model_up)`
+is how many dead backends it has not noticed yet.
+
+Per-token counters are deliberately absent: `llama-server` already
+publishes them on its own `/metrics` when started with `--metrics`.
+
+See [configuration.md](configuration.md) for `LLMMAN_METRICS` alongside
+the other daemon settings.


### PR DESCRIPTION
## Summary

- Add a **Why llmman?** section right after the intro: four bullets (provider agnostic, registry agnostic, vanilla llama.cpp / GGUF / safetensors with no private blob format, one-step `transfer` into your own registry for air-gapped or compliance-bound setups) followed by a side-by-side comparison table with Ollama.
- Fix the launch section's integration list, which still named only Claude Code and OpenCode while `src/cmd/launch.rs` registers eleven.
- Move the Prometheus metrics reference (scrape config, fifteen-family table, PromQL hints) out of the README into `docs/metrics.md`, alongside `configuration.md` and `verification.md`, leaving a short pointer under **Serve**. Content is unchanged apart from headings.

## Notes for review

- The Ollama column is deliberately limited to claims that hold today (registry, on-disk format, engine, hosted models, transfer, signing, launcher, API compat). I left out API-surface rows since Ollama has since added Anthropic compatibility and llmman serves Ollama's own API anyway.
- Docs-only change; no code touched.