### PR TITLE
feat(serve): pool hardware across daemons as an aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The server listens on `127.0.0.1:17434` by default, overridable via `LLMMAN_HOST
 | Ollama | `/api/generate`, `/api/chat`, `/api/tags`, `/api/show`, `/api/pull`, `/api/ps`, `/api/delete` |
 | OpenAI | `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/models`, `/v1/responses`, `/v1/responses/input_tokens` |
 | Anthropic | `/v1/messages` |
-| llmman | `/llmman/providers`, `/llmman/providers/{id}` |
+| llmman | `/llmman/providers`, `/llmman/providers/{id}`, `/llmman/node` |
 | Prometheus | `/metrics` (off unless `LLMMAN_METRICS` is `1`, `true`, `yes` or `on`) |
 
 `/llmman/...` is llmman's own API, not a compatibility surface: no
@@ -209,6 +209,22 @@ An idle, unused model is automatically unloaded after `keep_alive`
 Daemon-wide settings (bind address, context length, keep-alive, GPU backend
 selection and the rest) are environment variables, set before `llmman serve`
 starts. They're documented in [docs/configuration.md](docs/configuration.md).
+
+### Aggregation
+
+Several machines each running `llmman serve` can pool their hardware — a
+group of manatees is an aggregation. Name the others on each node and a
+request to any of them is served by whichever has the model loaded, or
+the most room to load it:
+
+```
+llmman config set aggregation.peers asahi,spark
+LLMMAN_HOST=0.0.0.0 llmman serve
+```
+
+`llmman ps`, `/api/tags` and `/v1/models` then show the whole
+aggregation, and `llmman stop` reaches a model wherever it was loaded.
+See [docs/aggregation.md](docs/aggregation.md).
 
 ## Launch an integration
 

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -1,0 +1,124 @@
+# Aggregation
+
+A group of manatees is an aggregation. An llmman aggregation is a group
+of `llmman serve` daemons on different machines pooling their hardware:
+send a request to any one of them and it is served by whichever node has
+the model loaded, or has the most room to load it.
+
+```
+                 ┌──────────────┐
+  agent ───────▶ │ mac (64 GB)  │──── /v1/chat/completions ────┐
+                 │ llmman serve │                              ▼
+                 └──────────────┘                     ┌──────────────┐
+                        │                             │ spark (128GB)│
+                        └──── /v1/chat/completions ──▶│ llmman serve │
+                                                      └──────────────┘
+```
+
+Every node is a whole llmman: its own store, its own `llama-server`
+children, the same API. Nothing is elected and nothing is shared. Each
+node just knows the others' addresses.
+
+## Setup
+
+On every node, bind the daemon somewhere the others can reach and name
+the others:
+
+```console
+$ llmman config set aggregation.peers asahi,spark
+$ LLMMAN_HOST=0.0.0.0 llmman serve
+```
+
+```toml
+# ~/.config/llmman/llmman.conf
+[aggregation]
+peers = "asahi, spark:17434, http://10.0.0.5"
+```
+
+Each entry is spelled like `LLMMAN_HOST` — `[scheme://]host[:port]`, the
+port defaulting to `17434`. `LLMMAN_PEERS=asahi,spark` overrides the
+file for one daemon, and `LLMMAN_PEERS=` (empty) takes it out of the
+aggregation without editing anything.
+
+The port has to be reachable: a distribution that ships a host firewall
+(Fedora's `firewalld`, say) needs `17434/tcp` opened, or the node is
+silently just not part of anyone's aggregation.
+
+A node does not have to be named by the nodes it names. A laptop can
+list a workstation as a peer without the workstation listing the laptop;
+the laptop then offloads to it, and the workstation serves as it always
+did.
+
+`llmman serve` has no authentication and no TLS. An aggregation is for a
+network you already trust — the same caveat as any non-loopback
+`LLMMAN_HOST`. A daemon bound off loopback does not spend its own
+provider API keys; see [configuration.md](configuration.md).
+
+## What each node does
+
+For a request naming a model this node does not have loaded, it asks
+every peer `GET /llmman/node` — what it has loaded, what it has stored,
+how much memory it has — and picks:
+
+1. A node that already has the model **loaded**. Never a second copy.
+2. Otherwise, of the nodes the model **fits** on (free memory, estimated
+   as capacity less the weights already loaded), one that has it
+   **stored**: loading from disk beats pulling over the network.
+3. Otherwise the node with the **most room**. Ties go to this node.
+
+If that is this node, it loads the model as it always did. If it is a
+peer, the request is forwarded there — the same bytes, the same
+streaming, with an `x-llmman-hop: 1` header — and the peer treats it as
+an ordinary request: its own queue, keep-alive and eviction apply. A
+node that receives a hopped request never forwards it again, so two
+nodes that name each other never bounce one between them.
+
+Memory is what `llmman gpu-discover` reports as VRAM, or system RAM for
+a node with no accelerator (which is what a CPU-only `llama-server`
+fills). Apple Silicon is unified, so it is system RAM there too.
+
+A peer that does not answer within a few seconds is simply not part of
+the aggregation for that decision. Nothing is remembered between
+requests: bring a node up or down and the next request sees it.
+
+`llmman serve <model>` pre-loads on the node it was run on, always.
+
+## Seeing the aggregation
+
+`/api/ps`, `/api/tags` and `/v1/models` answer for every node, so any
+node is a complete view. `llmman ps` gains a NODE column when something
+is loaded elsewhere:
+
+```console
+$ llmman ps
+NAME                        ID              SIZE        PROCESSOR    CONTEXT      STARTED          NODE           UNTIL
+docker.io/ai/gemma4:latest  sha256:3f2a…    8.1 GB      GPU          65536        2 minutes ago    spark:17434    4 minutes from now
+docker.io/ai/qwen3.5:0.8b   sha256:9c01…    0.7 GB      GPU          65536        1 minute ago     local          4 minutes from now
+```
+
+`llmman stop <model>` unloads it wherever the aggregation put it.
+
+`GET /llmman/node` is what peers ask each other, and is there for you
+too:
+
+```json
+{
+  "memory": 137438953472,
+  "loaded": { "docker.io/ai/gemma4:latest": 8100000000 },
+  "stored": { "docker.io/ai/gemma4:latest": 8100000000, "docker.io/ai/qwen3.5:0.8b": 700000000 }
+}
+```
+
+## What it is not
+
+This routes whole requests to whole models. It does not split one model
+across machines — for a model too large for any single node, run
+llama.cpp's `rpc-server` on the others and point one `llama-server` at
+them with `--rpc`; that is a different tool for a different problem.
+Nor is it prefill/decode disaggregation or KV-cache-aware routing in
+the way [llm-d](https://llm-d.ai) or
+[Dynamo](https://github.com/ai-dynamo/dynamo) do it: there is no
+tokenizer in the router, no engine events, no shared state. A static
+peer list and a poll per cold request is what those systems fall back
+to when there is no cluster to ask, and it is all a handful of machines
+on one network needs.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,8 +22,8 @@ The store uses [OCI Image Layout](https://github.com/opencontainers/image-spec/b
 ## llmman.conf
 
 Everything that needs a file rather than an environment variable lives in
-one place: short-name aliases, provider API keys, and the signature trust
-policy.
+one place: short-name aliases, provider API keys, the signature trust
+policy, and the peers of an aggregation.
 
 ```toml
 # ~/.config/llmman/llmman.conf
@@ -41,6 +41,9 @@ default = "off"
 pattern = "docker.io/myorg/**"
 keys    = ["keys/myorg.pub"]   # relative to this file's directory
 mode    = "enforce"
+
+[aggregation]
+peers = "asahi, spark:17434"
 ```
 
 Read from two locations, later overriding earlier:
@@ -156,6 +159,15 @@ be mistaken for one that does not exist.
 See [verification.md](verification.md) for the format, what is checked,
 and the limitations.
 
+### Aggregation peers
+
+`[aggregation]` names the other `llmman serve` daemons this one pools
+hardware with, comma-separated and spelled like `LLMMAN_HOST`
+(`[scheme://]host[:port]`, port defaulting to `17434`). `LLMMAN_PEERS`
+overrides it for one daemon; a user file's value replaces `/etc`'s
+rather than merging with it, and `peers = ""` opts out. See
+[aggregation.md](aggregation.md).
+
 ## Environment variables
 
 Daemon-wide settings, set before `llmman serve` starts. llmman is a very
@@ -175,6 +187,7 @@ setting may not behave identically.
 | `LLMMAN_METRICS` | Serves the Prometheus scrape endpoint at `/metrics`. Accepts `1`/`true`/`yes`/`on`. Off by default: the router has no authentication, so an upgrade should not start publishing this daemon's version, route mix, model names and model churn to whoever can reach the port. Unset, the route is absent and answers `404`. |
 | `LLMMAN_MODELS` | Local store directory, overriding the default above. `pull`/`push`/`run`/etc. go through the daemon and always use whichever store it was started with. |
 | `LLMMAN_NUM_PARALLEL` | Number of parallel request slots (`--parallel`) for GGUF models (llama-server only; no vllm/mlx equivalent). `--ctx-size` is scaled up by this value first, so each slot still gets the full configured/default context rather than an even split of it; ignored (with a warning) for a load with no explicit context size to scale. Unset leaves llama-server's own default of 1 untouched. |
+| `LLMMAN_PEERS` | Comma-separated peer daemons (`[scheme://]host[:port]`) to pool hardware with, overriding `[aggregation]` in `llmman.conf`. Set but empty takes this daemon out of its aggregation. See [aggregation.md](aggregation.md). |
 | `LLMMAN_ORIGINS` | A comma-separated list of extra allowed CORS origins for the HTTP API. A trailing `:*` on an entry matches any port on that scheme+host. Always includes every scheme/port on `localhost`/`127.0.0.1`/`0.0.0.0`/`[::1]` regardless of this variable. |
 | `LLMMAN_SCHED_SPREAD` | Truthy forwards `--split-mode layer` (spread a model across every GPU, already llama-server's own default); falsey forwards `--split-mode none` (restrict to one GPU). |
 | `LLMMAN_FLASH_ATTENTION` | Flash Attention mode (`--flash-attn`): `on`, `off`, or `auto` (llama-server's own default). Also accepts `1`/`0`/`true`/`false`. |

--- a/src/cmd/ps.rs
+++ b/src/cmd/ps.rs
@@ -34,6 +34,9 @@ struct PsModel {
     /// "Forever" in the UNTIL column, same as `ollama ps` does for its own
     /// zero-value sentinel.
     expires_at: Option<String>,
+    /// The peer this model is loaded on; absent for the daemon's own.
+    #[serde(default)]
+    node: Option<String>,
 }
 
 /// `llmman ps` — list models currently loaded by a running `llmman serve`,
@@ -43,7 +46,8 @@ struct PsModel {
 /// cmd::serve::RunningModel::processor's doc comment) — PROCESSOR instead
 /// shows which engine loaded the model. STARTED (how long ago a model
 /// loaded) is also kept alongside UNTIL (when it'll be auto-unloaded),
-/// since `ollama ps` has no equivalent of the former.
+/// since `ollama ps` has no equivalent of the former. A NODE column
+/// appears only when a model is loaded on an aggregation peer.
 ///
 /// Unlike `pull`/`push`/`run`, this does not start `llmman serve` if it
 /// isn't already running — matching `ollama ps`'s own `checkServerHeartbeat`
@@ -105,29 +109,46 @@ pub fn run(args: &PsArgs) -> anyhow::Result<()> {
         .max()
         .unwrap_or(7)
         .max(7);
+    let nodes: Vec<&str> = models
+        .iter()
+        .map(|m| node_label(m.node.as_deref()))
+        .collect();
+    let node_w = models
+        .iter()
+        .any(|m| m.node.is_some())
+        .then(|| nodes.iter().map(|n| n.len()).max().unwrap_or(4).max(4));
+
+    // Its own segment (or nothing), so UNTIL stays last and unpadded.
+    let node_col = |node: &str| {
+        node_w
+            .map(|w| format!("{node:<w$}    "))
+            .unwrap_or_default()
+    };
 
     println!(
-        "{:<name_w$}    {:<12}    {:<10}    {:<proc_w$}    {:<9}    {:<started_w$}    UNTIL",
+        "{:<name_w$}    {:<12}    {:<10}    {:<proc_w$}    {:<9}    {:<started_w$}    {}UNTIL",
         "NAME",
         "ID",
         "SIZE",
         "PROCESSOR",
         "CONTEXT",
         "STARTED",
+        node_col("NODE"),
         name_w = name_w,
         proc_w = proc_w,
         started_w = started_w,
     );
 
-    for (m, (started, until)) in models.iter().zip(rendered.iter()) {
+    for ((m, (started, until)), node) in models.iter().zip(rendered.iter()).zip(nodes) {
         println!(
-            "{:<name_w$}    {:<12}    {:<10}    {:<proc_w$}    {:<9}    {:<started_w$}    {}",
+            "{:<name_w$}    {:<12}    {:<10}    {:<proc_w$}    {:<9}    {:<started_w$}    {}{}",
             m.name,
             short_id(&m.digest),
             human_size(m.size),
             m.processor,
             m.context_length.map(|c| c.to_string()).unwrap_or_default(),
             started,
+            node_col(node),
             until,
             name_w = name_w,
             proc_w = proc_w,
@@ -135,4 +156,24 @@ pub fn run(args: &PsArgs) -> anyhow::Result<()> {
         );
     }
     Ok(())
+}
+
+/// `http://spark:17434` -> `spark:17434`; this daemon's own -> `local`.
+fn node_label(node: Option<&str>) -> &str {
+    let Some(node) = node else {
+        return "local";
+    };
+    node.split_once("://").map_or(node, |(_, rest)| rest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_label_drops_the_scheme_and_names_this_daemon_local() {
+        assert_eq!(node_label(None), "local");
+        assert_eq!(node_label(Some("http://spark:17434")), "spark:17434");
+        assert_eq!(node_label(Some("asahi:17434")), "asahi:17434");
+    }
 }

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -32,6 +32,8 @@ use crate::providers::PLACEHOLDER_API_KEY;
 use crate::storage::OciStore;
 use crate::webui;
 
+mod aggregation;
+
 // ---------------------------------------------------------------------------
 // CLI args
 // ---------------------------------------------------------------------------
@@ -53,6 +55,7 @@ Environment Variables:
       LLMMAN_NUM_PARALLEL            Maximum number of parallel requests per model (GGUF only)
       LLMMAN_NOPRUNE                 Do not prune model blobs on startup
       LLMMAN_ORIGINS                 A comma separated list of allowed CORS origins
+      LLMMAN_PEERS                   A comma separated list of peer daemons ([host][:port]) to pool hardware with (overrides [aggregation] in llmman.conf)
       LLMMAN_SCHED_SPREAD            Always schedule model across all GPUs
       LLMMAN_FLASH_ATTENTION         Enable flash attention
       LLMMAN_KV_CACHE_TYPE           Quantization type for the K/V cache (default: f16)
@@ -540,6 +543,10 @@ struct Inner {
     max_queue: usize,
     // See max_loaded_models_from_env's doc comment.
     max_loaded_models: usize,
+    // Peer origins (`http://host:port`) — see the `aggregation` module.
+    peers: Vec<String>,
+    // See hostgpu::memory_bytes; what `aggregation` weighs this node by.
+    memory: u64,
     store_path: PathBuf,
     cache_path: PathBuf,
     client: Client,
@@ -564,9 +571,8 @@ struct RunningModel {
     /// Full manifest digest (e.g. "sha256:abcd...") from the OCI store,
     /// captured at load time (see resolve_model's caller in ensure_model).
     digest: String,
-    /// GGUF file size in bytes; 0 for a safetensors dir (vllm) — walking a
-    /// multi-file safetensors directory isn't worth the cost just for
-    /// `ps` output today.
+    /// Sum of the model's layer sizes from its store manifest (every
+    /// engine); 0 if that lookup failed.
     size: u64,
     started_at: String,
     /// Monotonic clock reading of this model's last activity (a request
@@ -823,55 +829,58 @@ struct OllamaToolCallFunction {
     arguments: serde_json::Value,
 }
 
-#[derive(Debug, Deserialize)]
+// `Serialize` too: forwarded as-is to an aggregation peer.
+#[derive(Debug, Serialize, Deserialize)]
 struct OllamaChatRequest {
     model: String,
     #[serde(default)]
     messages: Vec<OllamaMessage>,
     #[serde(default = "bool_true")]
     stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     options: Option<serde_json::Value>,
     /// Ollama's own top-level `think` field ("for thinking models, should
     /// the model think before responding? Can be a boolean or a thinking
     /// level"). See `think_to_chat_template_kwargs`.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     think: Option<serde_json::Value>,
     /// Tool/function definitions, in the same shape OpenAI's `tools`
     /// field uses (Ollama's own tool schema is already
     /// OpenAI-function-tool compatible) — passed straight through to
     /// llama-server. See `handle_ollama_chat`.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     tools: Option<serde_json::Value>,
     /// `"json"` for unconstrained-schema JSON mode, or a JSON Schema
     /// object for constrained structured output. See
     /// `format_to_response_format`.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     format: Option<serde_json::Value>,
     /// See `OllamaGenerateRequest::keep_alive`.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     keep_alive: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct OllamaGenerateRequest {
     model: String,
     #[serde(default)]
     prompt: String,
     #[serde(default = "bool_true")]
     stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     options: Option<serde_json::Value>,
     /// keep_alive: 0 with an empty prompt is the Ollama unload signal;
     /// otherwise resolved (see `resolve_keep_alive`) into how long this
     /// model should stay loaded once idle.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     keep_alive: Option<serde_json::Value>,
     /// See `OllamaChatRequest::think`.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     think: Option<serde_json::Value>,
     /// See `OllamaChatRequest::format`. `/api/generate` has no `tools`
     /// field in real Ollama either — only `/api/chat` supports tool
     /// calling.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     format: Option<serde_json::Value>,
 }
 
@@ -944,12 +953,13 @@ struct OllamaGenerateChunk {
     done_reason: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+// Also `Deserialize`: a node reads its peers' tags/ps answers back in.
+#[derive(Debug, Serialize, Deserialize)]
 struct OllamaTagsResponse {
     models: Vec<OllamaModelInfo>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct OllamaModelInfo {
     name: String,
     model: String,
@@ -959,7 +969,7 @@ struct OllamaModelInfo {
     details: OllamaModelDetails,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct OllamaModelDetails {
     format: String,
     family: String,
@@ -967,12 +977,12 @@ struct OllamaModelDetails {
     quantization_level: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct OllamaPsResponse {
     models: Vec<OllamaRunningModelInfo>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct OllamaRunningModelInfo {
     name: String,
     model: String,
@@ -997,6 +1007,9 @@ struct OllamaRunningModelInfo {
     processor: String,
     context_length: Option<u64>,
     started_at: String,
+    /// The peer this model is loaded on; absent for this node's own.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    node: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2573,6 +2586,35 @@ async fn unload_model(state: &AppState, model: &str) -> Result<(), AppError> {
     Ok(())
 }
 
+/// Forwards an Ollama request to a peer as-is, so `keep_alive` and a
+/// load-only request apply where the model runs.
+async fn forward_ollama<T: Serialize>(
+    state: &AppState,
+    target: &Target,
+    route: &str,
+    headers: &HeaderMap,
+    req: &T,
+    guard: ActivityGuard,
+) -> Result<Response, AppError> {
+    let body = Bytes::from(serde_json::to_vec(req).context("re-serialize Ollama request")?);
+    let activity = begin_activity(guard, None).await;
+    proxy(&state.0.client, target, route, headers, body, activity).await
+}
+
+/// [`unload_model`] here and on every peer. A peer that had it makes
+/// the local answer moot, including a 404 for a model never pulled here.
+async fn unload_everywhere(
+    state: &AppState,
+    model: &str,
+    headers: &HeaderMap,
+) -> Result<(), AppError> {
+    let local = unload_model(state, model).await;
+    if aggregation::unload(state, model, headers).await {
+        return Ok(());
+    }
+    local
+}
+
 /// Is `model_ref` already running and alive? See `ModelProcess::is_alive`.
 /// If so, claims it (`in_flight += 1`, under the same lock as the
 /// liveness check) and returns the same [`ActivityGuard`] `ensure_model`
@@ -2928,7 +2970,7 @@ async fn would_use_mlx(state: &AppState, model_ref: &str) -> Option<String> {
 }
 
 // ---------------------------------------------------------------------------
-// Request target: a local backend, or a remote provider
+// Request target: a local backend, a peer daemon, or a remote provider
 // ---------------------------------------------------------------------------
 
 /// Where a resolved request is actually sent.
@@ -2937,7 +2979,7 @@ async fn would_use_mlx(state: &AppState, model_ref: &str) -> Option<String> {
 /// was a `llama-server`/vllm/mlx child on loopback, so a port was the
 /// whole of "where does this go". [`Target::Remote`] is the same idea for
 /// a request that leaves the machine — see [`crate::providers`] for which
-/// providers qualify.
+/// providers qualify — and [`Target::Peer`] for another `llmman serve`.
 ///
 /// Requests are *routed* through, never redirected away from, this
 /// daemon: a provider-backed integration still talks to `llmman serve`
@@ -2947,6 +2989,9 @@ async fn would_use_mlx(state: &AppState, model_ref: &str) -> Option<String> {
 enum Target {
     /// A locally spawned backend listening on loopback.
     Local(u16),
+    /// Another `llmman serve`, by origin; speaks our dialect, so not
+    /// `is_remote`.
+    Peer(String),
     /// A remote provider's OpenAI-compatible API.
     Remote(Arc<RemoteTarget>),
 }
@@ -2992,11 +3037,13 @@ impl Target {
     fn url(&self, route: &str) -> String {
         match self {
             Self::Local(port) => format!("http://127.0.0.1:{port}{route}"),
+            Self::Peer(origin) => format!("{origin}{route}"),
             Self::Remote(remote) => crate::providers::rebase_url(&remote.base_url, route),
         }
     }
 
-    /// Attaches this target's credentials to an outgoing request.
+    /// Attaches this target's credentials to an outgoing request, or for
+    /// a peer the hop marker.
     ///
     /// A no-op for [`Target::Local`]: a loopback `llama-server` has no
     /// auth, which is why nothing below ever forwarded the client's own
@@ -3005,6 +3052,7 @@ impl Target {
     fn authorize(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
         match self {
             Self::Local(_) => req,
+            Self::Peer(_) => req.header(aggregation::HOP, "1"),
             Self::Remote(remote) => req.bearer_auth(&remote.api_key),
         }
     }
@@ -3021,6 +3069,7 @@ impl Target {
     fn describe(&self) -> String {
         match self {
             Self::Local(_) => "inference backend".to_string(),
+            Self::Peer(origin) => format!("peer {origin}"),
             Self::Remote(remote) => format!("provider {}", remote.provider),
         }
     }
@@ -3252,6 +3301,16 @@ async fn ensure_model(
         // Already loaded, so no pull and no re-check: a policy tightened
         // since the load takes effect on the next load, not mid-flight.
         return Ok((model_ref.to_string(), Target::Local(port), guard));
+    }
+
+    // Not loaded here: a peer may have it, or more room for it. The
+    // guard is a no-op one, as for a provider.
+    if let Some(peer) = aggregation::route(state, model_ref, headers).await {
+        return Ok((
+            model_ref.to_string(),
+            Target::Peer(peer),
+            ActivityGuard::new(state, model_ref),
+        ));
     }
 
     // The cold-start clock. It starts here rather than at the spawn
@@ -3962,10 +4021,12 @@ async fn post_chat(
 /// A [`Target::Local`] backend failing is llmman's own problem, so it
 /// stays a 500 as it always has. A provider's 4xx is about the caller's
 /// request or credentials, so it is passed through rather than buried;
-/// anything else from a provider is a bad gateway.
+/// anything else from a provider is a bad gateway. A peer already
+/// applied this mapping, so its status stands.
 fn remote_status(target: &Target, upstream: StatusCode) -> StatusCode {
     match target {
         Target::Local(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        Target::Peer(_) => upstream,
         Target::Remote(_) if upstream.is_client_error() => upstream,
         Target::Remote(_) => StatusCode::BAD_GATEWAY,
     }
@@ -4650,10 +4711,13 @@ async fn handle_version(State(state): State<AppState>) -> impl IntoResponse {
     }))
 }
 
-async fn handle_tags(State(state): State<AppState>) -> Result<impl IntoResponse, AppError> {
+async fn handle_tags(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, AppError> {
     let store = OciStore::open(&state.0.store_path)?;
     let list = store.list()?;
-    let models = list
+    let mut models: Vec<OllamaModelInfo> = list
         .into_iter()
         .map(|img| OllamaModelInfo {
             name: img.reference.clone(),
@@ -4674,6 +4738,16 @@ async fn handle_tags(State(state): State<AppState>) -> Result<impl IntoResponse,
             },
         })
         .collect();
+    // A peer's models are servable from here too, by forwarding.
+    if aggregation::aggregates(&state, &headers) {
+        for (_, peer) in aggregation::poll::<OllamaTagsResponse>(&state, "/api/tags").await {
+            for m in peer.models {
+                if !models.iter().any(|have| have.name == m.name) {
+                    models.push(m);
+                }
+            }
+        }
+    }
     Ok(Json(OllamaTagsResponse { models }))
 }
 
@@ -4691,7 +4765,7 @@ struct PsEntry {
     expires_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
-async fn handle_ps(State(state): State<AppState>) -> impl IntoResponse {
+async fn handle_ps(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
     let entries: Vec<PsEntry> = {
         let mgr = state.0.manager.lock().await;
         mgr.running
@@ -4729,7 +4803,17 @@ async fn handle_ps(State(state): State<AppState>) -> impl IntoResponse {
             expires_at: entry
                 .expires_at
                 .map(|t| t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
+            node: None,
         });
+    }
+    // Loaded on a peer is loaded for this node's callers too.
+    if aggregation::aggregates(&state, &headers) {
+        for (origin, peer) in aggregation::poll::<OllamaPsResponse>(&state, "/api/ps").await {
+            models.extend(peer.models.into_iter().map(|m| OllamaRunningModelInfo {
+                node: Some(origin.clone()),
+                ..m
+            }));
+        }
     }
     Json(OllamaPsResponse { models })
 }
@@ -5155,18 +5239,20 @@ async fn handle_ollama_chat(
     // backend to continue from nothing: the caller gets a real, arbitrary
     // generation and `done_reason: "stop"` where ollama answers with an
     // empty message, and a `keep_alive: 0` never unloads anything.
-    if req.messages.is_empty() {
-        if is_explicit_unload(&req.keep_alive) {
-            unload_model(&state, &req.model).await?;
-            return Ok(Json(empty_chat_chunk(req.model, "unload")).into_response());
-        }
+    if req.messages.is_empty() && is_explicit_unload(&req.keep_alive) {
+        unload_everywhere(&state, &req.model, &headers).await?;
+        return Ok(Json(empty_chat_chunk(req.model, "unload")).into_response());
+    }
 
-        let (_model, _target, guard) = ensure_model(&state, &req.model, Some(&headers)).await?;
+    let (model, target, guard) = ensure_model(&state, &req.model, Some(&headers)).await?;
+    if matches!(target, Target::Peer(_)) {
+        return forward_ollama(&state, &target, "/api/chat", &headers, &req, guard).await;
+    }
+    if req.messages.is_empty() {
         refresh_activity(guard, resolve_keep_alive(&req.keep_alive)).await;
         return Ok(Json(empty_chat_chunk(req.model, "load")).into_response());
     }
 
-    let (model, target, guard) = ensure_model(&state, &req.model, Some(&headers)).await?;
     let keep_alive = resolve_keep_alive(&req.keep_alive);
     let activity = begin_activity(guard, Some(keep_alive)).await;
     // See backend_wire_model's own doc comment — usually just `model`
@@ -5243,7 +5329,7 @@ async fn handle_ollama_generate(
     // `LLMMAN_KEEP_ALIVE=0` turned a plain preload into an eviction.
     let is_unload = req.prompt.is_empty() && is_explicit_unload(&req.keep_alive);
     if is_unload {
-        unload_model(&state, &req.model).await?;
+        unload_everywhere(&state, &req.model, &headers).await?;
         return Ok(Json(OllamaGenerateChunk {
             model: req.model,
             created_at: now_rfc3339(),
@@ -5256,6 +5342,9 @@ async fn handle_ollama_generate(
     }
 
     let (model, target, guard) = ensure_model(&state, &req.model, Some(&headers)).await?;
+    if matches!(target, Target::Peer(_)) {
+        return forward_ollama(&state, &target, "/api/generate", &headers, &req, guard).await;
+    }
     // Empty prompt = load-only request (mirrors ollama server/routes.go:429)
     // — including "preload with a custom keep_alive", so refresh it here
     // even though no generation is happening.
@@ -5313,24 +5402,40 @@ async fn handle_ollama_generate(
 
 async fn handle_openai_models(
     State(state): State<AppState>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, AppError> {
     let store = OciStore::open(&state.0.store_path)?;
     let list = store.list()?;
-    let mgr = state.0.manager.lock().await;
-    let data: Vec<serde_json::Value> = list
-        .into_iter()
-        .map(|img| {
-            let loaded = mgr.running.contains_key(&img.reference);
-            serde_json::json!({
-                "id": img.reference,
-                "object": "model",
-                "created": 0,
-                "owned_by": "llmman",
-                // status field consumed by the web UI to track loaded/unloaded state
-                "status": { "value": if loaded { "loaded" } else { "unloaded" } },
+    let mut data: Vec<serde_json::Value> = {
+        let mgr = state.0.manager.lock().await;
+        list.into_iter()
+            .map(|img| {
+                let loaded = mgr.running.contains_key(&img.reference);
+                serde_json::json!({
+                    "id": img.reference,
+                    "object": "model",
+                    "created": 0,
+                    "owned_by": "llmman",
+                    // status field consumed by the web UI to track loaded/unloaded state
+                    "status": { "value": if loaded { "loaded" } else { "unloaded" } },
+                })
             })
-        })
-        .collect();
+            .collect()
+    };
+    // As `handle_tags`; loaded anywhere counts as loaded.
+    if aggregation::aggregates(&state, &headers) {
+        for (_, peer) in aggregation::poll::<serde_json::Value>(&state, "/v1/models").await {
+            for m in peer["data"].as_array().into_iter().flatten() {
+                match data.iter_mut().find(|have| have["id"] == m["id"]) {
+                    Some(have) if m["status"]["value"] == "loaded" => {
+                        have["status"] = m["status"].clone();
+                    }
+                    Some(_) => {}
+                    None => data.push(m.clone()),
+                }
+            }
+        }
+    }
     Ok(Json(serde_json::json!({ "object": "list", "data": data })))
 }
 
@@ -6262,6 +6367,7 @@ fn build_router(app_state: AppState, metrics_enabled: bool) -> Router {
         // llmman's own API — see handle_llmman_providers
         .route("/llmman/providers", get(handle_llmman_providers))
         .route("/llmman/providers/:id", get(handle_llmman_provider))
+        .route("/llmman/node", get(aggregation::handle_node))
         // Ollama API
         .route("/api/version", get(handle_version))
         .route("/api/tags", get(handle_tags))
@@ -6420,16 +6526,33 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         }
     }
 
-    // See context_length_from_env's doc comment. spawn_blocking: like
-    // resolve_llama_server above, the VRAM probe fallback spawns a
-    // subprocess and must not block this async fn's executor thread.
+    // See the `aggregation` module.
+    let peers: Vec<String> = crate::config::peers()
+        .iter()
+        .map(|p| crate::daemon::peer_url(p))
+        .collect();
+
+    // One accelerator probe serves both the VRAM-tiered context default
+    // and this node's weight in its aggregation; skipped when neither
+    // needs it. spawn_blocking: it spawns a subprocess.
     let ctx_size_explicit = context_length_from_env();
-    let ctx_size = match ctx_size_explicit {
-        Some(n) => Some(n),
-        None => tokio::task::spawn_blocking(crate::hostgpu::default_ctx_size)
+    let vram = if ctx_size_explicit.is_none() || !peers.is_empty() {
+        tokio::task::spawn_blocking(crate::hostgpu::detect_with_vram)
             .await
-            .context("hostgpu probe task panicked")?,
+            .context("hostgpu probe task panicked")?
+            .1
+    } else {
+        0
     };
+    let ctx_size = ctx_size_explicit.or_else(|| crate::hostgpu::default_ctx_size(vram));
+    let memory = crate::hostgpu::memory_bytes(vram);
+    if !peers.is_empty() {
+        eprintln!(
+            "[llmman] aggregation peers: {} (this node: {} of model memory)",
+            peers.join(", "),
+            crate::fmt::human_size(memory)
+        );
+    }
 
     // See threads_from_env_or_host's doc comment. Resolved once here
     // rather than per load, and logged so a surprising thread count is
@@ -6468,6 +6591,8 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         threads,
         max_queue: max_queue_from_env(),
         max_loaded_models: max_loaded_models_from_env(),
+        peers,
+        memory,
         store_path,
         cache_path,
         client: Client::new(),
@@ -6905,6 +7030,328 @@ mod tests {
             body.get("repeat_penalty").is_none(),
             "llama.cpp-only field sent to a provider: {body}"
         );
+    }
+
+    // -- aggregation (peer daemons) ------------------------------------------
+
+    #[test]
+    fn a_peer_target_is_a_local_backend_in_all_but_address() {
+        let peer = Target::Peer("http://spark:17434".into());
+        assert_eq!(
+            peer.url("/v1/chat/completions"),
+            "http://spark:17434/v1/chat/completions"
+        );
+        assert!(!peer.is_remote(), "a peer accepts llama.cpp extensions");
+        assert!(repeat_penalty_applies(&peer));
+        assert_eq!(peer.describe(), "peer http://spark:17434");
+        for upstream in [
+            StatusCode::NOT_FOUND,
+            StatusCode::SERVICE_UNAVAILABLE,
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ] {
+            assert_eq!(remote_status(&peer, upstream), upstream);
+        }
+    }
+
+    /// `/llmman/node` answers `node`; every other route records its call.
+    async fn mock_peer(
+        node: aggregation::Node,
+    ) -> (
+        String,
+        Arc<tokio::sync::Mutex<Vec<(String, HeaderMap, Bytes)>>>,
+    ) {
+        let seen = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let captured = seen.clone();
+        let app = Router::new()
+            .route("/llmman/node", get(move || async move { Json(node) }))
+            .fallback(move |req: Request| async move {
+                let (parts, body) = req.into_parts();
+                let body = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+                captured
+                    .lock()
+                    .await
+                    .push((parts.uri.path().to_string(), parts.headers, body));
+                ([("content-type", "application/json")], "{}")
+            });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let origin = format!("http://127.0.0.1:{}", listener.local_addr().unwrap().port());
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        (origin, seen)
+    }
+
+    /// Store tags `docker.io/ai/m:latest` with no blobs, so a local load
+    /// fails offline instead of pulling.
+    fn state_with_peers(peers: Vec<String>, memory: u64) -> AppState {
+        let dir = std::env::temp_dir().join(format!(
+            "llmman-aggregation-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let desc = crate::storage::oci::Descriptor {
+            media_type: "application/vnd.oci.image.manifest.v1+json".into(),
+            digest: "sha256:a1b2".into(),
+            size: 0,
+            annotations: None,
+        };
+        OciStore::open(&dir)
+            .unwrap()
+            .tag(desc, "docker.io/ai/m:latest")
+            .unwrap();
+        let mut inner = test_inner(dir);
+        inner.peers = peers;
+        inner.memory = memory;
+        AppState(Arc::new(inner))
+    }
+
+    fn node(memory: u64, loaded: &[&str], stored: &[&str]) -> aggregation::Node {
+        let map = |names: &[&str]| names.iter().map(|n| (n.to_string(), 1 << 30)).collect();
+        aggregation::Node {
+            memory,
+            loaded: map(loaded),
+            stored: map(stored),
+        }
+    }
+
+    /// A peer gets llmman's own dialect, the hop marker, no credential.
+    #[tokio::test]
+    async fn a_peer_request_carries_the_hop_marker_and_nothing_else() {
+        let (origin, seen) = mock_peer(node(0, &[], &[])).await;
+        let mut req = OAIChatRequest {
+            model: "docker.io/ai/m:latest".into(),
+            ..Default::default()
+        };
+        post_chat(&Client::new(), &Target::Peer(origin), &mut req)
+            .await
+            .unwrap();
+
+        let calls = seen.lock().await;
+        let (path, headers, body) = &calls[0];
+        assert_eq!(path, "/v1/chat/completions");
+        assert_eq!(headers[aggregation::HOP], "1");
+        assert!(headers.get("authorization").is_none());
+        let body: serde_json::Value = serde_json::from_slice(body).unwrap();
+        assert_eq!(body["repeat_penalty"], DEFAULT_REPEAT_PENALTY);
+    }
+
+    /// A model a peer has loaded is served there; a hopped request or a
+    /// pre-load stays put.
+    #[tokio::test]
+    async fn ensure_model_forwards_to_the_peer_that_has_the_model_loaded() {
+        let (origin, _) = mock_peer(node(8 << 30, &["docker.io/ai/m:latest"], &[])).await;
+        let state = state_with_peers(vec![origin.clone()], 0);
+
+        let (name, target, _) = ensure_model(&state, "docker.io/ai/m", Some(&HeaderMap::new()))
+            .await
+            .unwrap();
+        assert_eq!(name, "docker.io/ai/m:latest");
+        assert!(
+            matches!(&target, Target::Peer(o) if *o == origin),
+            "{target:?}"
+        );
+
+        // Hopped once: load here (failing on the fixture), never bounce.
+        let mut hopped = HeaderMap::new();
+        hopped.insert(aggregation::HOP, "1".parse().unwrap());
+        let err = ensure_model(&state, "docker.io/ai/m", Some(&hopped))
+            .await
+            .err()
+            .expect("the fixture has no blobs to load");
+        assert!(
+            format!("{:#}", err.0).contains("resolve model"),
+            "{:#}",
+            err.0
+        );
+
+        // A pre-load names a model for *this* node.
+        let err = ensure_model(&state, "docker.io/ai/m", None)
+            .await
+            .err()
+            .unwrap();
+        assert!(
+            format!("{:#}", err.0).contains("resolve model"),
+            "{:#}",
+            err.0
+        );
+    }
+
+    /// A cold model goes to the roomiest node that has it stored; a dead
+    /// peer is ignored and one that would have to pull loses to this node.
+    #[tokio::test]
+    async fn ensure_model_places_a_cold_model_on_the_roomiest_reachable_node() {
+        let (roomy, _) = mock_peer(node(128 << 30, &[], &["docker.io/ai/m:latest"])).await;
+        let state = state_with_peers(vec![roomy.clone()], 8 << 30);
+        let (_, target, _) = ensure_model(&state, "docker.io/ai/m", Some(&HeaderMap::new()))
+            .await
+            .unwrap();
+        assert!(
+            matches!(&target, Target::Peer(o) if *o == roomy),
+            "{target:?}"
+        );
+
+        // A dead peer, and a listening one that would have to pull.
+        let (bare, _) = mock_peer(node(128 << 30, &[], &[])).await;
+        let dead = "http://127.0.0.1:9".to_string();
+        let state = state_with_peers(vec![dead, bare], 8 << 30);
+        let err = ensure_model(&state, "docker.io/ai/m", Some(&HeaderMap::new()))
+            .await
+            .err()
+            .expect("loads (and fails on the fixture) locally");
+        assert!(
+            format!("{:#}", err.0).contains("resolve model"),
+            "{:#}",
+            err.0
+        );
+    }
+
+    /// Listings cover the peers' models too, unless a peer is asking.
+    #[tokio::test]
+    async fn listings_cover_the_aggregation_except_for_a_peer_asking() {
+        let ps = serde_json::json!({ "models": [{
+            "name": "docker.io/ai/m:latest", "model": "docker.io/ai/m:latest",
+            "expires_at": null, "digest": "sha256:aa", "size": 1, "size_vram": 0,
+            "pid": null, "port": 1, "processor": "GPU", "context_length": null,
+            "started_at": "2026-01-01T00:00:00Z"
+        }]});
+        let tags = serde_json::json!({ "models": [{
+            "name": "docker.io/ai/m:latest", "model": "docker.io/ai/m:latest",
+            "size": 1, "digest": "sha256:aa", "modified_at": "2026-01-01T00:00:00Z",
+            "details": { "format": "gguf", "family": "", "parameter_size": "", "quantization_level": "" }
+        }]});
+        let models = serde_json::json!({ "object": "list", "data": [
+            { "id": "docker.io/ai/m:latest", "object": "model", "created": 0,
+              "owned_by": "llmman", "status": { "value": "loaded" } }
+        ]});
+        let app = Router::new()
+            .route("/api/ps", get(move || async move { Json(ps) }))
+            .route("/api/tags", get(move || async move { Json(tags) }))
+            .route("/v1/models", get(move || async move { Json(models) }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let origin = format!("http://127.0.0.1:{}", listener.local_addr().unwrap().port());
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let dir = std::env::temp_dir().join(format!(
+            "llmman-aggregation-listings-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        OciStore::open(&dir).unwrap();
+        let mut inner = test_inner(dir);
+        inner.peers = vec![origin.clone()];
+        let state = AppState(Arc::new(inner));
+
+        async fn body(resp: Response) -> serde_json::Value {
+            let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            serde_json::from_slice(&bytes).unwrap()
+        }
+        let mut hopped = HeaderMap::new();
+        hopped.insert(aggregation::HOP, "1".parse().unwrap());
+
+        let ps = body(
+            handle_ps(State(state.clone()), HeaderMap::new())
+                .await
+                .into_response(),
+        )
+        .await;
+        assert_eq!(ps["models"][0]["name"], "docker.io/ai/m:latest");
+        assert_eq!(ps["models"][0]["node"], origin);
+        let own = body(
+            handle_ps(State(state.clone()), hopped.clone())
+                .await
+                .into_response(),
+        )
+        .await;
+        assert_eq!(own["models"].as_array().unwrap().len(), 0);
+
+        let tags = body(
+            handle_tags(State(state.clone()), HeaderMap::new())
+                .await
+                .unwrap()
+                .into_response(),
+        )
+        .await;
+        assert_eq!(tags["models"][0]["name"], "docker.io/ai/m:latest");
+        assert!(!tags.to_string().contains("\"node\""));
+        let own = body(
+            handle_tags(State(state.clone()), hopped.clone())
+                .await
+                .unwrap()
+                .into_response(),
+        )
+        .await;
+        assert_eq!(own["models"].as_array().unwrap().len(), 0);
+
+        let models = body(
+            handle_openai_models(State(state.clone()), HeaderMap::new())
+                .await
+                .unwrap()
+                .into_response(),
+        )
+        .await;
+        assert_eq!(models["data"][0]["id"], "docker.io/ai/m:latest");
+        assert_eq!(models["data"][0]["status"]["value"], "loaded");
+        let own = body(
+            handle_openai_models(State(state), hopped)
+                .await
+                .unwrap()
+                .into_response(),
+        )
+        .await;
+        assert_eq!(own["data"].as_array().unwrap().len(), 0);
+    }
+
+    /// An Ollama request bound for a peer goes there as-is.
+    #[tokio::test]
+    async fn an_ollama_request_reaches_a_peer_natively() {
+        let (origin, seen) = mock_peer(node(8 << 30, &["docker.io/ai/m:latest"], &[])).await;
+        let state = state_with_peers(vec![origin], 0);
+        let req: OllamaGenerateRequest = serde_json::from_value(
+            serde_json::json!({ "model": "docker.io/ai/m", "keep_alive": "1h" }),
+        )
+        .unwrap();
+        let resp = handle_ollama_generate(State(state), HeaderMap::new(), Json(req))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let calls = seen.lock().await;
+        let (path, headers, body) = &calls[0];
+        assert_eq!(path, "/api/generate");
+        assert_eq!(headers[aggregation::HOP], "1");
+        let body: serde_json::Value = serde_json::from_slice(body).unwrap();
+        assert_eq!(body["model"], "docker.io/ai/m");
+        assert_eq!(body["keep_alive"], "1h");
+        assert_eq!(body["prompt"], "");
+        assert!(body.get("think").is_none(), "{body}");
+    }
+
+    /// `llmman stop` reaches a model wherever the aggregation loaded it.
+    #[tokio::test]
+    async fn an_unload_is_forwarded_to_every_peer() {
+        let (origin, seen) = mock_peer(node(0, &[], &[])).await;
+        let state = state_with_peers(vec![origin], 0);
+        unload_everywhere(&state, "docker.io/ai/m", &HeaderMap::new())
+            .await
+            .unwrap();
+        let calls = seen.lock().await;
+        let (path, headers, body) = &calls[0];
+        assert_eq!(path, "/api/generate");
+        assert_eq!(headers[aggregation::HOP], "1");
+        let body: serde_json::Value = serde_json::from_slice(body).unwrap();
+        assert_eq!(body["model"], "docker.io/ai/m");
+        assert_eq!(body["keep_alive"], 0);
+        drop(calls);
+
+        // A peer asking does not fan out again.
+        let mut hopped = HeaderMap::new();
+        hopped.insert(aggregation::HOP, "1".parse().unwrap());
+        unload_everywhere(&state, "docker.io/ai/m", &hopped)
+            .await
+            .unwrap();
+        assert_eq!(seen.lock().await.len(), 1, "forwarded a forwarded unload");
     }
 
     // -- keep_alive parsing / resolution (idle-timeout auto-unload) ---------
@@ -7467,7 +7914,12 @@ mod tests {
     /// `test_state` with a real store directory, for the few tests that
     /// need `canonical_ref` to actually resolve something.
     fn test_state_at(store_path: PathBuf) -> AppState {
-        AppState(Arc::new(Inner {
+        AppState(Arc::new(test_inner(store_path)))
+    }
+
+    /// `test_state_at`'s `Inner`, for tests that set one field differently.
+    fn test_inner(store_path: PathBuf) -> Inner {
+        Inner {
             manager: Mutex::new(ModelManager {
                 running: HashMap::new(),
                 pending_loads: 0,
@@ -7489,10 +7941,12 @@ mod tests {
             // anyway.
             max_queue: usize::MAX,
             max_loaded_models: 0,
+            peers: Vec::new(),
+            memory: 0,
             store_path,
             cache_path: std::env::temp_dir(),
             client: Client::new(),
-        }))
+        }
     }
 
     /// A long-lived, harmless real child process to back a test

--- a/src/cmd/serve/aggregation.rs
+++ b/src/cmd/serve/aggregation.rs
@@ -1,0 +1,253 @@
+//! Aggregation — `llmman serve` daemons pooling hardware. (A group of
+//! manatees is an aggregation.)
+//!
+//! Every node is a whole llmman; peers are listed, not discovered, and
+//! there is no leader. [`route`] sends a cold request to the peer that
+//! has the model loaded, or to the node with the most room; the listing
+//! routes answer for every node. A forwarded request carries [`HOP`] and
+//! is never forwarded again.
+
+use std::collections::HashMap;
+
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::Json;
+use futures::future::join_all;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use tokio::time::Duration;
+
+use super::AppState;
+use crate::storage::OciStore;
+
+/// Marks a request forwarded by a peer: answer for this node alone.
+pub(super) const HOP: &str = "x-llmman-hop";
+
+/// Short, so a peer that is down costs a cold request a moment.
+const PEER_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// What one node tells another about itself: `GET /llmman/node`.
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+pub(super) struct Node {
+    /// Bytes of model memory — see `hostgpu::memory_bytes`. 0 if unknown.
+    pub(super) memory: u64,
+    /// Loaded models by canonical reference, with their weight sizes.
+    pub(super) loaded: HashMap<String, u64>,
+    /// Models in the store, likewise.
+    pub(super) stored: HashMap<String, u64>,
+}
+
+impl Node {
+    /// Capacity less loaded weights; an estimate, but the same for all.
+    fn free(&self) -> u64 {
+        self.memory.saturating_sub(self.loaded.values().sum())
+    }
+}
+
+/// This node, as a peer would see it.
+pub(super) async fn local_node(state: &AppState) -> Node {
+    let loaded = state
+        .0
+        .manager
+        .lock()
+        .await
+        .running
+        .iter()
+        .map(|(name, m)| (name.clone(), m.size))
+        .collect();
+    let stored = OciStore::open(&state.0.store_path)
+        .and_then(|s| s.list())
+        .map(|list| list.into_iter().map(|i| (i.reference, i.size)).collect())
+        .unwrap_or_default();
+    Node {
+        memory: state.0.memory,
+        loaded,
+        stored,
+    }
+}
+
+pub(super) async fn handle_node(State(state): State<AppState>) -> Json<Node> {
+    Json(local_node(&state).await)
+}
+
+/// Whether this node answers for the aggregation: it has peers, and the
+/// request did not come from one.
+pub(super) fn aggregates(state: &AppState, headers: &HeaderMap) -> bool {
+    !state.0.peers.is_empty() && !headers.contains_key(HOP)
+}
+
+/// `GET path` from every peer at once, as `(origin, body)`, skipping any
+/// that is down, slow or unparseable.
+pub(super) async fn poll<T: DeserializeOwned>(state: &AppState, path: &str) -> Vec<(String, T)> {
+    join_all(state.0.peers.iter().map(|peer| async move {
+        let sent = state
+            .0
+            .client
+            .get(format!("{peer}{path}"))
+            .header(HOP, "1")
+            .timeout(PEER_TIMEOUT)
+            .send()
+            .await
+            .and_then(|r| r.error_for_status());
+        let body = match sent {
+            Ok(resp) => resp.json::<T>().await,
+            Err(e) => Err(e),
+        };
+        match body {
+            Ok(body) => Some((peer.clone(), body)),
+            Err(e) => {
+                crate::debug_log!("peer {peer}{path}: {e}");
+                None
+            }
+        }
+    }))
+    .await
+    .into_iter()
+    .flatten()
+    .collect()
+}
+
+/// Where a request for `model`, not loaded here, should go: `None` for
+/// this node, else a peer's origin. `headers == None` is a pre-load,
+/// which is never forwarded.
+pub(super) async fn route(
+    state: &AppState,
+    model: &str,
+    headers: Option<&HeaderMap>,
+) -> Option<String> {
+    let headers = headers?;
+    if !aggregates(state, headers) {
+        return None;
+    }
+    let mut origins = vec![None];
+    let mut nodes = vec![local_node(state).await];
+    for (origin, node) in poll::<Node>(state, "/llmman/node").await {
+        origins.push(Some(origin));
+        nodes.push(node);
+    }
+    let peer = origins.swap_remove(place(&nodes, model))?;
+    eprintln!("[llmman] aggregation: {model} -> {peer}");
+    Some(peer)
+}
+
+/// A node that has `model` loaded; else, among those it fits on, one
+/// that has it stored, then the most room; else the most room. Ties go
+/// to the first (this node).
+fn place(nodes: &[Node], model: &str) -> usize {
+    if let Some(i) = nodes.iter().position(|n| n.loaded.contains_key(model)) {
+        return i;
+    }
+    let size = nodes.iter().find_map(|n| n.stored.get(model).copied());
+    let rank = |n: &Node| {
+        let fits = size.is_none_or(|size| n.memory == 0 || n.free() >= size);
+        (fits, fits && n.stored.contains_key(model), n.free())
+    };
+    // `max_by_key` keeps the *last* maximum; reversed, that is the first.
+    (0..nodes.len())
+        .rev()
+        .max_by_key(|&i| rank(&nodes[i]))
+        .unwrap_or(0)
+}
+
+/// Asks every peer to unload `model`; `true` if one answered 2xx.
+pub(super) async fn unload(state: &AppState, model: &str, headers: &HeaderMap) -> bool {
+    if !aggregates(state, headers) {
+        return false;
+    }
+    let body = serde_json::json!({ "model": model, "keep_alive": 0 });
+    join_all(state.0.peers.iter().map(|peer| {
+        state
+            .0
+            .client
+            .post(format!("{peer}/api/generate"))
+            .header(HOP, "1")
+            .json(&body)
+            .timeout(PEER_TIMEOUT)
+            .send()
+    }))
+    .await
+    .into_iter()
+    .any(|r| r.is_ok_and(|r| r.status().is_success()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(memory: u64, loaded: &[(&str, u64)], stored: &[(&str, u64)]) -> Node {
+        let map = |kv: &[(&str, u64)]| {
+            kv.iter()
+                .map(|(k, v)| (k.to_string(), *v))
+                .collect::<HashMap<_, _>>()
+        };
+        Node {
+            memory,
+            loaded: map(loaded),
+            stored: map(stored),
+        }
+    }
+
+    const GIB: u64 = 1 << 30;
+
+    #[test]
+    fn a_node_that_has_the_model_loaded_wins_outright() {
+        let nodes = [
+            node(128 * GIB, &[], &[("m", GIB)]),
+            node(8 * GIB, &[("m", GIB)], &[("m", GIB)]),
+        ];
+        assert_eq!(place(&nodes, "m"), 1);
+    }
+
+    #[test]
+    fn a_node_that_has_the_model_stored_beats_a_roomier_one_it_fits_on() {
+        let nodes = [
+            node(128 * GIB, &[], &[]),
+            node(16 * GIB, &[], &[("m", 4 * GIB)]),
+        ];
+        assert_eq!(place(&nodes, "m"), 1);
+    }
+
+    #[test]
+    fn a_node_the_model_does_not_fit_on_loses_even_with_it_stored() {
+        let nodes = [
+            node(128 * GIB, &[], &[]),
+            node(8 * GIB, &[("other", 6 * GIB)], &[("m", 4 * GIB)]),
+        ];
+        assert_eq!(place(&nodes, "m"), 0);
+        // Fits nowhere: most room, stored or not.
+        let nowhere = [
+            node(2 * GIB, &[], &[("m", 4 * GIB)]),
+            node(3 * GIB, &[], &[]),
+        ];
+        assert_eq!(place(&nowhere, "m"), 1);
+    }
+
+    #[test]
+    fn otherwise_the_most_room_wins_and_ties_go_to_the_first() {
+        let nodes = [
+            node(64 * GIB, &[("big", 60 * GIB)], &[]),
+            node(128 * GIB, &[], &[]),
+            node(128 * GIB, &[], &[]),
+        ];
+        assert_eq!(place(&nodes, "m"), 1);
+        let same = [node(8 * GIB, &[], &[]), node(8 * GIB, &[], &[])];
+        assert_eq!(place(&same, "m"), 0);
+    }
+
+    #[test]
+    fn unknown_memory_fits_anything_but_ranks_last() {
+        let nodes = [node(0, &[], &[("m", GIB)]), node(GIB, &[], &[("m", GIB)])];
+        assert_eq!(place(&nodes, "m"), 1);
+        let only = [node(0, &[], &[])];
+        assert_eq!(place(&only, "m"), 0);
+    }
+
+    #[test]
+    fn free_never_underflows() {
+        assert_eq!(node(GIB, &[("m", 2 * GIB)], &[]).free(), 0);
+        assert_eq!(
+            node(4 * GIB, &[("m", GIB), ("n", GIB)], &[]).free(),
+            2 * GIB
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,9 @@
 //! pattern = "docker.io/myorg/**"
 //! keys    = ["keys/myorg.pub"]         # relative to this file's directory
 //! mode    = "enforce"
+//!
+//! [aggregation]                        # cmd::serve::aggregation
+//! peers = "asahi,spark:17434"
 //! ```
 //!
 //! Parsing happens once, in [`files`]; what a *failed* parse means is
@@ -58,6 +61,19 @@ pub struct Conf {
     /// Signature trust policy — see [`crate::verify`].
     #[serde(default)]
     pub verify: VerifyConf,
+    /// Peer daemons — see `cmd::serve::aggregation`.
+    #[serde(default)]
+    pub aggregation: AggregationConf,
+}
+
+/// The `[aggregation]` section.
+#[derive(Deserialize, Default, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct AggregationConf {
+    /// Comma-separated `[scheme://]host[:port]`, as `LLMMAN_PEERS` — a
+    /// string so `llmman config set aggregation.peers a,b` can write it.
+    #[serde(default)]
+    pub peers: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -298,6 +314,35 @@ fn merge_keys(per_file: Vec<HashMap<String, String>>) -> HashMap<String, String>
     merged
 }
 
+// ---------------------------------------------------------------------------
+// Aggregation peers
+// ---------------------------------------------------------------------------
+
+/// Peer daemons, as written: `LLMMAN_PEERS` when set (even empty), else
+/// the last file that sets `aggregation.peers`. Replaced, not merged —
+/// half of two aggregations is no one's intent — so `peers = ""` opts out.
+pub fn peers() -> Vec<String> {
+    peers_from(
+        std::env::var("LLMMAN_PEERS").ok().as_deref(),
+        files().unwrap_or_default(),
+    )
+}
+
+fn peers_from(env: Option<&str>, files: &[File]) -> Vec<String> {
+    env.or_else(|| {
+        files
+            .iter()
+            .rev()
+            .find_map(|f| f.conf.aggregation.peers.as_deref())
+    })
+    .unwrap_or_default()
+    .split(',')
+    .map(str::trim)
+    .filter(|s| !s.is_empty())
+    .map(str::to_string)
+    .collect()
+}
+
 /// Refuses a file that group or other can read, the way `ssh` refuses a
 /// loose private key.
 ///
@@ -455,6 +500,38 @@ mod tests {
     #[test]
     fn malformed_toml_is_an_error() {
         assert!(parse("[providers.openai").is_err());
+    }
+
+    // -- aggregation peers ---------------------------------------------------
+
+    fn file(text: &str) -> File {
+        File {
+            path: PathBuf::from("llmman.conf"),
+            dir: PathBuf::from("."),
+            conf: conf(text),
+        }
+    }
+
+    #[test]
+    fn peers_come_from_the_environment_then_the_last_file_that_sets_them() {
+        let system = || file("[aggregation]\npeers = \"a, b\"");
+        let user = file("[aggregation]\npeers = \"c\"");
+        let silent = file("");
+        let opted_out = file("[aggregation]\npeers = \"\"");
+
+        assert_eq!(
+            peers_from(Some(" x , ,y:1 "), &[]),
+            vec!["x".to_string(), "y:1".to_string()]
+        );
+        assert!(peers_from(Some(""), &[system()]).is_empty());
+        assert_eq!(
+            peers_from(None, &[system(), silent]),
+            vec!["a".to_string(), "b".to_string()]
+        );
+        assert_eq!(peers_from(None, &[system(), user]), vec!["c".to_string()]);
+        assert!(peers_from(None, &[system(), opted_out]).is_empty());
+        assert!(peers_from(None, &[]).is_empty());
+        assert!(parse("[aggregation]\npeer = \"a\"").is_err());
     }
 
     // -- search paths --------------------------------------------------------

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -106,6 +106,13 @@ pub fn server() -> String {
     format!("http://{}", connect_addr())
 }
 
+/// A peer's `scheme://host:port` origin from a `LLMMAN_HOST`-style spec
+/// (`asahi`, `spark:17434`, `http://10.0.0.5`), port defaulting to ours.
+pub fn peer_url(spec: &str) -> String {
+    let (scheme, host, port) = parse_host(Some(spec));
+    format!("{scheme}://{}", format_host_port(&host, port))
+}
+
 /// The bare `host:port` `llmman serve`'s own listener binds — the raw
 /// configured host, since a wildcard bind (`0.0.0.0`/`::`) is meaningful
 /// here, unlike for `connect_addr`.
@@ -1421,6 +1428,14 @@ mod tests {
             parse_host(Some("example.com:8080/some/path")),
             ("http".to_string(), "example.com".to_string(), 8080)
         );
+    }
+
+    #[test]
+    fn peer_url_spells_a_peer_the_way_llmman_host_is_spelled() {
+        assert_eq!(peer_url("asahi"), "http://asahi:17434");
+        assert_eq!(peer_url("spark:8080"), "http://spark:8080");
+        assert_eq!(peer_url("https://x.example/"), "https://x.example:443");
+        assert_eq!(peer_url("[fe80::1]"), "http://[fe80::1]:17434");
     }
 
     #[test]

--- a/src/hostgpu.rs
+++ b/src/hostgpu.rs
@@ -146,10 +146,84 @@ pub fn default_ctx_size_for(vram_bytes: u64) -> Option<u32> {
     }
 }
 
-/// [`default_ctx_size_for`] applied to [`detect_with_vram`]'s live probe,
+/// [`default_ctx_size_for`] applied to a [`detect_with_vram`] result,
 /// less [`gpu_overhead_bytes`] (floors at 0, never underflows).
-pub fn default_ctx_size() -> Option<u32> {
-    default_ctx_size_for(detect_with_vram().1.saturating_sub(gpu_overhead_bytes()))
+pub fn default_ctx_size(vram_bytes: u64) -> Option<u32> {
+    default_ctx_size_for(vram_bytes.saturating_sub(gpu_overhead_bytes()))
+}
+
+/// The accelerator's memory, else system RAM, else 0. What
+/// `cmd::serve::aggregation` weighs nodes by.
+pub fn memory_bytes(vram_bytes: u64) -> u64 {
+    if vram_bytes > 0 {
+        return vram_bytes;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::fs::read_to_string("/proc/meminfo")
+            .ok()
+            .and_then(|s| parse_meminfo_total(&s))
+            .unwrap_or(0)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        apple_unified_memory_bytes().unwrap_or(0)
+    }
+    #[cfg(windows)]
+    {
+        windows_memory_bytes().unwrap_or(0)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+    {
+        0
+    }
+}
+
+/// `GlobalMemoryStatusEx().ullTotalPhys`; no `windows` crate here.
+#[cfg(windows)]
+fn windows_memory_bytes() -> Option<u64> {
+    #[repr(C)]
+    struct MemoryStatusEx {
+        length: u32,
+        memory_load: u32,
+        total_phys: u64,
+        avail_phys: u64,
+        total_page_file: u64,
+        avail_page_file: u64,
+        total_virtual: u64,
+        avail_virtual: u64,
+        avail_extended_virtual: u64,
+    }
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn GlobalMemoryStatusEx(buffer: *mut MemoryStatusEx) -> i32;
+    }
+    let mut status = MemoryStatusEx {
+        length: std::mem::size_of::<MemoryStatusEx>() as u32,
+        memory_load: 0,
+        total_phys: 0,
+        avail_phys: 0,
+        total_page_file: 0,
+        avail_page_file: 0,
+        total_virtual: 0,
+        avail_virtual: 0,
+        avail_extended_virtual: 0,
+    };
+    (unsafe { GlobalMemoryStatusEx(&mut status) } != 0).then_some(status.total_phys)
+}
+
+/// `MemTotal:       16384000 kB` -> bytes.
+#[cfg(any(target_os = "linux", test))]
+fn parse_meminfo_total(meminfo: &str) -> Option<u64> {
+    let kib = meminfo
+        .lines()
+        .find_map(|l| l.strip_prefix("MemTotal:"))?
+        .trim()
+        .strip_suffix("kB")?
+        .trim()
+        .parse::<u64>()
+        .ok()?;
+    Some(kib * 1024)
 }
 
 /// The hidden re-exec argument `main()` checks for, before anything else,
@@ -365,6 +439,19 @@ mod tests {
         assert_eq!(default_ctx_size_for(46 * GIB), Some(65536));
         assert_eq!(default_ctx_size_for(47 * GIB), None);
         assert_eq!(default_ctx_size_for(80 * GIB), None);
+    }
+
+    #[test]
+    fn parse_meminfo_total_reads_the_kib_line() {
+        let meminfo = "MemTotal:        7864320 kB\nMemFree:         1234 kB\n";
+        assert_eq!(parse_meminfo_total(meminfo), Some(7864320 * 1024));
+        assert_eq!(parse_meminfo_total("MemFree: 1 kB\n"), None);
+        assert_eq!(parse_meminfo_total("MemTotal: lots\n"), None);
+    }
+
+    #[test]
+    fn memory_bytes_prefers_vram() {
+        assert_eq!(memory_bytes(8 * GIB), 8 * GIB);
     }
 
     #[test]

--- a/src/hostgpu/vendor.rs
+++ b/src/hostgpu/vendor.rs
@@ -460,8 +460,8 @@ mod tests {
         println!("detect_rocm() -> {:?}", detect_rocm());
         println!("detect_vulkan() -> {:?}", detect_vulkan());
         println!(
-            "default_ctx_size() -> {:?}",
-            super::super::default_ctx_size()
+            "detect_with_vram() -> {:?}",
+            super::super::detect_with_vram()
         );
     }
 }


### PR DESCRIPTION
Fixes #404.

`llmman serve` daemons on several machines pool their hardware. Name the others on each node (`llmman config set aggregation.peers asahi,spark`, bind with `LLMMAN_HOST=0.0.0.0`) and a request to any node is served by whichever already has the model loaded, or has the most room to load it. Forwarded requests carry `x-llmman-hop` so they are never forwarded again; `ps`, `tags`, `models` and `stop` cover every node. No leader, nothing shared. Tested across a Mac, a DGX Spark and an Asahi box. See `docs/aggregation.md`.
