### PR TITLE
docs: trim README to the pitch, fix stale claims, surface aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ GPU, loads the model, and execs an agent against it.
   moves a model from HuggingFace straight into your own registry, optionally
   signed, without landing on a laptop first.
   That is the shape air-gapped and compliance-bound environments need.
+- **Pool your machines.** Several `llmman serve` daemons form an
+  [aggregation](#aggregation): name the others, and a request to any of
+  them runs on whichever node has the model loaded or the most room for
+  it. A laptop, a workstation and a Spark look like one endpoint.
 
 | | llmman | Ollama |
 |---|---|---|
@@ -48,6 +52,7 @@ GPU, loads the model, and execs an agent against it.
 | Hosted models | Any provider via `--provider` | Ollama Cloud |
 | Registry-to-registry transfer | `llmman transfer hf.co/... docker.io/...` in one step, no local copy | Pull, write a `Modelfile`, `create`, push to ollama.com |
 | Signing and verification | cosign-format signatures; `verify` command and per-repo pull-time trust policy | None |
+| Multiple machines | Aggregation: daemons pool hardware, any node answers for all | One host per endpoint |
 
 ## Install
 
@@ -85,7 +90,7 @@ above takes `--provider`; see [Hosted providers](#hosted-providers).
 | `launch`  | Launch an integration (Claude Code, OpenCode, …) |
 | `run`     | Run a model interactively or with a one-shot prompt |
 | `pull`    | Pull a model from a registry or HuggingFace |
-| `list`    | List locally stored models, or a hosted provider's (`--provider`) models |
+| `list` (`ls`) | List locally stored models, or a hosted provider's (`--provider`) models |
 | `ps`      | List models currently loaded |
 | `providers` | List the hosted providers `--provider` can route to |
 | `stop`    | Stop (unload) a running model |
@@ -96,13 +101,9 @@ above takes `--provider`; see [Hosted providers](#hosted-providers).
 | `rm`      | Remove a local image |
 | `show`    | Show a local model's architecture, parameters, license, and template |
 | `verify`  | Check a registry model's signatures against trusted public keys |
-| `login`   | Log in to a container registry |
-| `logout`  | Log out from a container registry |
-| `config`  | Read and write `llmman.conf` settings |
-
-See [docs/configuration.md](docs/configuration.md) for `llmman config`,
-environment variables and the model store layout, and
-[docs/verification.md](docs/verification.md) for signature verification.
+| `login`   | Log in to a container registry or HuggingFace |
+| `logout`  | Log out from a container registry or HuggingFace |
+| `config`  | Read and write `llmman.conf` settings (aliases, API keys, trust policy, aggregation peers) |
 
 ## Models are OCI artifacts
 
@@ -148,76 +149,38 @@ See [docs/verification.md](docs/verification.md).
 
 ## Serve
 
-Start the inference server. GGUF models are served by `llama-server` from [llama.cpp](https://github.com/ggml-org/llama.cpp), used from `PATH` if it's already there; otherwise `llmman` downloads and caches a prebuilt release matching your OS/arch/GPU automatically (see `--llama-cpp-version` to pin a specific release). Safetensors models are served by [`vllm`](https://github.com/vllm-project/vllm) (plain `vllm` is CPU-only on macOS, unless you separately install [vllm-metal](https://github.com/vllm-project/vllm-metal) for Metal GPU support), or, on Apple Silicon macOS, by [`mlx-lm`](https://github.com/ml-explore/mlx-lm)'s `mlx_lm.server` instead when it's on `PATH`: Metal-accelerated, with no vLLM dependency at all, and it supports more model families than vllm-metal does.
-
 ```
 llmman serve
 ```
 
-The server listens on `127.0.0.1:17434` by default, overridable via `LLMMAN_HOST`, and exposes:
+One endpoint on `127.0.0.1:17434` that speaks Ollama, OpenAI and Anthropic:
 
 | API | Endpoints |
 |-----|-----------|
-| Ollama | `/api/generate`, `/api/chat`, `/api/embed`, `/api/embeddings`, `/api/tags`, `/api/show`, `/api/pull`, `/api/push`, `/api/copy`, `/api/create`, `/api/blobs/{digest}`, `/api/ps`, `/api/delete`, `/api/version` |
-| OpenAI | `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/models`, `/v1/responses`, `/v1/responses/input_tokens` |
+| Ollama | `/api/chat`, `/api/generate`, `/api/embed`, `/api/tags`, `/api/ps`, `/api/pull`, `/api/push`, `/api/create`, ... |
+| OpenAI | `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/models`, `/v1/responses`, `/v1/audio/transcriptions` |
 | Anthropic | `/v1/messages` |
-| llmman | `/llmman/providers`, `/llmman/providers/{id}`, `/llmman/node` |
-| Prometheus | `/metrics` (off unless `LLMMAN_METRICS` is `1`, `true`, `yes` or `on`) |
 
-`/llmman/...` is llmman's own API, not a compatibility surface: no
-upstream API has a notion of a [models.dev](https://models.dev) provider
-(see [Hosted providers](#hosted-providers)). `/llmman/providers` lists
-the ones this daemon can route to, each with its API-key variable,
-whether the daemon has that key, and how many models it serves;
-`/llmman/providers/{id}` adds those models and what each costs in US
-dollars per million tokens (absent, not zero, where models.dev publishes
-no price). `llmman providers`, `list --provider`, `run --provider` and
-`launch --provider` are all clients of it, so the catalog is fetched and
-cached in one process: the one that forwards the request upstream.
-
-`/metrics` is a Prometheus scrape target, off by default because the
-router has no authentication. `LLMMAN_METRICS=1 llmman serve` turns it
-on; the fifteen metric families and how to read them are in
-[docs/metrics.md](docs/metrics.md).
-
-`/v1/responses` implements the OpenAI Responses API (the dialect [OpenAI
-Codex](https://github.com/openai/codex) requires), including streaming SSE
-and function-tool-call re-mapping. This is a plain pass-through to
-`llama-server`'s own native `/v1/responses` support, so a recent enough
-`llama-server` build is required for it to work.
-
-Use it as an Ollama-compatible server:
+So any existing client works unchanged:
 
 ```
 OLLAMA_HOST=127.0.0.1:17434 ollama run unsloth/Qwen3.5-0.8B-GGUF
 ```
 
-Or with any Ollama, Anthropic or OpenAI-compatible client.
+Models load on demand, each in its own backend process, and unload after
+five idle minutes (`keep_alive`, as in Ollama). GGUF is served by upstream
+[`llama.cpp`](https://github.com/ggml-org/llama.cpp), downloaded to match
+your GPU if no `llama-server` is on `PATH`; safetensors by
+[`vllm`](https://github.com/vllm-project/vllm), or by
+[`mlx-lm`](https://github.com/ml-explore/mlx-lm) on Apple Silicon. Tool
+calling, vision, structured output, embeddings (GGUF) and the Responses
+API (what Codex speaks) all work; there is a web UI at `/` and an
+optional Prometheus `/metrics`.
 
-Models are loaded on demand. Each model gets its own `llama-server` subprocess on a random loopback port; subsequent requests reuse the running process.
-
-`/api/chat` also supports Ollama's `tools` (function calling, streamed back
-as `message.tool_calls`), `images` (vision, base64, same as Ollama's own
-wire format), and `format` (`"json"` or a JSON Schema object, for
-constrained structured output).
-
-`/api/embed` and `/api/embeddings` work with any embedding model (a GGUF
-with a pooling type, e.g. `embeddinggemma`, `nomic-embed-text`): `llama-server`
-is started with `--embeddings` for it, so `/v1/embeddings` works too.
-
-`/api/create` supports `from` (alias a model) and `files` (GGUFs uploaded via
-`/api/blobs/{digest}`, as `ollama create` does). Modelfile fields such as
-`system` or `quantize` are refused with a 400: the GGUF's own chat template
-applies.
-
-An idle, unused model is automatically unloaded after `keep_alive`
-(default 5 minutes, matching Ollama; set per-request, or daemon-wide via
-`LLMMAN_KEEP_ALIVE`), and `llmman ps`/`/api/ps` reports each model's
-`expires_at`.
-
-Daemon-wide settings (bind address, context length, keep-alive, GPU backend
-selection and the rest) are environment variables, set before `llmman serve`
-starts. They're documented in [docs/configuration.md](docs/configuration.md).
+The full endpoint list and per-API notes are in [docs/api.md](docs/api.md);
+backend selection in [docs/backends.md](docs/backends.md); bind address,
+context length, keep-alive and the other daemon settings in
+[docs/configuration.md](docs/configuration.md).
 
 ### Aggregation
 
@@ -233,19 +196,25 @@ LLMMAN_HOST=0.0.0.0 llmman serve
 
 `llmman ps`, `/api/tags` and `/v1/models` then show the whole
 aggregation, and `llmman stop` reaches a model wherever it was loaded.
-See [docs/aggregation.md](docs/aggregation.md).
+Nothing is elected and nothing is shared: every node is a whole llmman
+that knows the others' addresses. See [docs/aggregation.md](docs/aggregation.md).
 
 ## Launch an integration
 
-Point an integration at a model in one step. `llmman launch` starts `serve` in the background if it isn't already running (preloading the requested model), then sets the right environment variables and execs the integration:
+Point an integration at a model in one step. `llmman launch` starts `serve`
+in the background if it isn't already running (preloading a local
+model), then sets the right environment variables and execs the
+integration:
 
 ```
 llmman launch claude --model gemma4
 ```
 
-Run `llmman launch` with no arguments to list the supported integrations (Claude Code, OpenCode, Codex, etc.) and whether each is installed. Any extra arguments after `--` are forwarded to the integration's own CLI.
-
-Short names work wherever a model reference is accepted.
+Run `llmman launch` with no arguments to list the supported integrations
+(Claude Code, OpenCode, Codex, Aider, Qwen Code, Gemini CLI, ...) and
+whether each is installed. Any extra arguments after `--` are forwarded to
+the integration's own CLI. Short names work wherever a model reference is
+accepted.
 
 ### Hosted providers
 
@@ -260,89 +229,25 @@ llmman run --provider openrouter qwen/qwen3-coder   # chat with one directly
 llmman launch opencode --provider openrouter --model qwen/qwen3-coder
 ```
 
-The provider list is fetched at runtime from
-[models.dev](https://models.dev), the same catalog `opencode` resolves
-its own providers from, so a newly added provider works without an
-llmman release. It's cached for 24 hours, and a stale copy is used if the
-fetch fails, so being offline means an out-of-date list rather than a
-broken command.
+The provider list comes from [models.dev](https://models.dev), the same
+catalog `opencode` uses, so a new provider works without an llmman
+release. Requests still go through `llmman serve`; `--provider` changes
+where the daemon forwards them, not who the client talks to, so a local
+and a hosted model are one endpoint and one integration config. The key
+travels per request; it is never written into an integration's config.
 
-All four commands ask the daemon over [`/llmman/providers`](#serve)
-rather than fetching models.dev themselves, so the cache outlives any
-single command and the key status reported is that of the process whose
-key actually gets spent.
+Which integrations support `--provider`, where the key comes from, and
+why it is only ever sent to a loopback daemon are in
+[docs/providers.md](docs/providers.md).
 
-Requests still go through `llmman serve`; `--provider` changes where the
-daemon forwards them, not who the client talks to. So one endpoint and
-one place integrations are configured, whether a model is local or
-hosted, and both usable from the same session.
+## Documentation
 
-The API key comes from the variable models.dev names for that provider,
-or — when that is unset — from `~/.config/llmman/llmman.conf`, keyed by
-provider id:
-
-```toml
-[providers.openrouter]
-api_key = "sk-or-..."
-```
-
-Either way it travels per request; llmman itself never writes a key
-anywhere. A file carrying one must be `chmod 600` or the keys in it are
-ignored with a warning, and an `export` still overrides it. See
-[docs/configuration.md](docs/configuration.md#provider-api-keys).
-
-`hermes` is the exception: llmman configures it through a file on disk,
-so it can't carry a key and `llmman serve` needs one of its own instead.
-That fallback is only used for a daemon bound to loopback, and never for a
-browser request from another site. It bounds the blast radius rather
-than authenticating anyone, so on a shared machine prefer an integration
-that sends its own key. `cline`, `kimi`, `copilot` and `openclaw` can't be
-used with `--provider` at all: the first two pick their own model rather
-than taking llmman's, `copilot` has no way to send a key, and `openclaw`
-only takes a model during first-run onboarding.
-
-`--provider` needs a local `llmman serve`. The daemon talks plain HTTP
-and has no authentication, so neither `run` nor `launch` will send a real
-key to a remote `LLMMAN_HOST`, and a daemon bound to anything but
-loopback will not spend its own key on behalf of a caller
-that didn't present one. (`llmman providers` and `llmman list
---provider` read the catalog only, no key involved, and work against any
-daemon.)
-
-## Use with vLLM directly
-
-`llmman serve` already spawns `vllm` itself as a backend for safetensors
-models. The [`vllm-llmman`](https://pypi.org/project/vllm-llmman/) plugin
-is the inverse: install it alongside `vllm` and `vllm serve
-oci://<reference>` pulls a CNCF ModelPack image directly, instead of a
-HuggingFace repo.
-
-## MLX (Apple Silicon)
-
-On Apple Silicon macOS, `llmman serve` uses
-[`mlx_lm.server`](https://github.com/ml-explore/mlx-lm) instead of `vllm`
-for safetensors models whenever it's on `PATH`, Metal-accelerated, with
-no vLLM dependency at all (unlike getting the same acceleration out of
-`vllm serve` itself via [vllm-metal](https://github.com/vllm-project/vllm-metal)).
-Falls back to `vllm` otherwise. Doesn't support `/v1/embeddings`.
-
-## Transport backends
-
-The registry transport is a compiled-in Go shim. Two backends are available via Cargo feature flags.
-
-### Docker (default)
-
-Uses [`github.com/containerd/containerd`](https://github.com/containerd/containerd), the same OCI resolver used by Docker.
-
-```
-cargo build --release
-```
-
-### Podman
-
-Uses [`github.com/podman-container-tools/container-libs`](https://github.com/podman-container-tools/container-libs), the same library Podman uses internally.
-
-```
-cargo build --release --no-default-features --features podman
-```
-
+| | |
+|---|---|
+| [docs/api.md](docs/api.md) | Every HTTP endpoint, and per-API notes |
+| [docs/aggregation.md](docs/aggregation.md) | Pooling several machines into one endpoint |
+| [docs/backends.md](docs/backends.md) | llama.cpp, vLLM, MLX, containers, and building from source |
+| [docs/configuration.md](docs/configuration.md) | `llmman.conf`, `llmman config`, environment variables, store layout |
+| [docs/providers.md](docs/providers.md) | Hosted providers, API keys, and which integrations can use them |
+| [docs/verification.md](docs/verification.md) | Signing models and pull-time trust policy |
+| [docs/metrics.md](docs/metrics.md) | The Prometheus `/metrics` families |

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -32,11 +32,12 @@ $ LLMMAN_HOST=0.0.0.0 llmman serve
 ```toml
 # ~/.config/llmman/llmman.conf
 [aggregation]
-peers = "asahi, spark:17434, http://10.0.0.5"
+peers = "asahi, spark:17434, 10.0.0.5"
 ```
 
 Each entry is spelled like `LLMMAN_HOST` — `[scheme://]host[:port]`, the
-port defaulting to `17434`. `LLMMAN_PEERS=asahi,spark` overrides the
+port defaulting to `17434` (or 80/443 when an explicit `http://`/`https://`
+scheme is given). `LLMMAN_PEERS=asahi,spark` overrides the
 file for one daemon, and `LLMMAN_PEERS=` (empty) takes it out of the
 aggregation without editing anything.
 
@@ -73,13 +74,14 @@ an ordinary request: its own queue, keep-alive and eviction apply. A
 node that receives a hopped request never forwards it again, so two
 nodes that name each other never bounce one between them.
 
-Memory is what `llmman gpu-discover` reports as VRAM, or system RAM for
-a node with no accelerator (which is what a CPU-only `llama-server`
-fills). Apple Silicon is unified, so it is system RAM there too.
+Memory is the VRAM llmman's GPU probe finds, or system RAM for a node
+with no accelerator (which is what a CPU-only `llama-server` fills).
+Apple Silicon is unified, so it is system RAM there too. Unknown memory
+reports `0`: assumed to fit anything, ranked last on room.
 
-A peer that does not answer within a few seconds is simply not part of
-the aggregation for that decision. Nothing is remembered between
-requests: bring a node up or down and the next request sees it.
+A peer that does not answer within 3 seconds is simply not part of the
+aggregation for that decision. Nothing is remembered between requests:
+bring a node up or down and the next request sees it.
 
 `llmman serve <model>` pre-loads on the node it was run on, always.
 
@@ -91,9 +93,9 @@ is loaded elsewhere:
 
 ```console
 $ llmman ps
-NAME                        ID              SIZE        PROCESSOR    CONTEXT      STARTED          NODE           UNTIL
-docker.io/ai/gemma4:latest  sha256:3f2a…    8.1 GB      GPU          65536        2 minutes ago    spark:17434    4 minutes from now
-docker.io/ai/qwen3.5:0.8b   sha256:9c01…    0.7 GB      GPU          65536        1 minute ago     local          4 minutes from now
+NAME                        ID              SIZE        PROCESSOR               CONTEXT      STARTED          NODE           UNTIL
+docker.io/ai/gemma4:latest  sha256:3f2a…    8.1 GB      llama-server (local)    65536        2 minutes ago    spark:17434    4 minutes from now
+docker.io/ai/qwen3.5:0.8b   sha256:9c01…    0.7 GB      llama-server (local)    65536        1 minute ago     local          4 minutes from now
 ```
 
 `llmman stop <model>` unloads it wherever the aggregation put it.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,94 @@
+# HTTP API
+
+`llmman serve` listens on `127.0.0.1:17434` by default (`LLMMAN_HOST`
+changes it; see [configuration.md](configuration.md)) and speaks the
+Ollama, OpenAI and Anthropic wire formats, plus a small API of its own.
+
+| API | Endpoints |
+|-----|-----------|
+| Ollama | `/api/generate`, `/api/chat`, `/api/embed`, `/api/embeddings`, `/api/tags`, `/api/show`, `/api/pull`, `/api/push`, `/api/copy`, `/api/create`, `/api/blobs/{digest}`, `/api/ps`, `/api/delete`, `/api/version` |
+| OpenAI | `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/models`, `/v1/responses`, `/v1/responses/input_tokens`, `/v1/audio/transcriptions` (also `/audio/transcriptions`) |
+| Anthropic | `/v1/messages` |
+| llmman | `/llmman/providers`, `/llmman/providers/{id}`, `/llmman/node` |
+| llama.cpp | `/props`, and the llama.cpp web UI at `/` |
+| Prometheus | `/metrics` (off unless `LLMMAN_METRICS` is `1`, `true`, `yes` or `on`) |
+
+Use it as a drop-in Ollama server:
+
+```
+OLLAMA_HOST=127.0.0.1:17434 ollama run unsloth/Qwen3.5-0.8B-GGUF
+```
+
+Or with any Ollama, OpenAI or Anthropic client. `http://127.0.0.1:17434/`
+in a browser is llama.cpp's web UI.
+
+## Model lifecycle
+
+Models load on demand, each in its own backend subprocess
+(`llama-server`, `vllm` or `mlx_lm.server`; see [backends.md](backends.md))
+on a random loopback port, reused by later requests.
+
+An idle model unloads after `keep_alive` (default 5 minutes, as in
+Ollama; per-request, or daemon-wide via `LLMMAN_KEEP_ALIVE`);
+`llmman ps`/`/api/ps` report each model's `expires_at`.
+`LLMMAN_MAX_LOADED_MODELS` caps how many stay loaded, evicting the
+least-recently-used idle one. `llmman stop <model>` (or `keep_alive: 0`
+on `/api/generate`) unloads immediately.
+
+## Ollama API notes
+
+`/api/chat` supports Ollama's `tools` (function calling, streamed back as
+`message.tool_calls`), `images` (vision, base64, same as Ollama's own wire
+format), and `format` (`"json"` or a JSON Schema object, for constrained
+structured output).
+
+`/api/embed` and `/api/embeddings` work with any GGUF embedding model
+(one with a pooling type, e.g. `embeddinggemma`, `nomic-embed-text`):
+`llama-server` is started with `--embeddings` for it, so `/v1/embeddings`
+works too.
+
+`/api/create` supports `from` (alias a model) and `files` (GGUFs uploaded
+via `/api/blobs/{digest}`, as `ollama create` does). Modelfile fields such
+as `system` or `quantize` are refused with a 400: the GGUF's own chat
+template applies.
+
+## OpenAI API notes
+
+`/v1/responses` implements the OpenAI Responses API (the dialect
+[OpenAI Codex](https://github.com/openai/codex) requires), including
+streaming SSE and function-tool-call re-mapping. This is a plain
+pass-through to `llama-server`'s own native `/v1/responses` support, so a
+recent enough `llama-server` build is required for it to work.
+
+`/v1/audio/transcriptions` is likewise a pass-through. The model needs
+audio support (an `--mmproj` projector, supplied when the model image
+carries one). Bodies up to 200 MiB are accepted.
+
+## llmman's own API
+
+`/llmman/...` is llmman's own API, not a compatibility surface: no
+upstream API has a notion of a [models.dev](https://models.dev) provider
+(see [providers.md](providers.md)). `/llmman/providers` lists the ones
+this daemon can route to, each with its API-key variable, whether the
+daemon has that key, and how many models it serves;
+`/llmman/providers/{id}` adds those models and what each costs in US
+dollars per million tokens (absent, not zero, where models.dev publishes
+no price). `llmman providers`, `list --provider`, `run --provider` and
+`launch --provider` are all clients of it, so the catalog is fetched and
+cached in one process: the one that forwards the request upstream.
+
+`/llmman/node` reports this node's memory and loaded/stored models; it
+is what aggregation peers ask each other. See [aggregation.md](aggregation.md).
+
+## Metrics
+
+`/metrics` is a Prometheus scrape target, off by default because the
+router has no authentication. `LLMMAN_METRICS=1 llmman serve` turns it
+on; the fifteen metric families and how to read them are in
+[metrics.md](metrics.md).
+
+## CORS
+
+Browser clients on `localhost`, `127.0.0.1`, `0.0.0.0` and `[::1]` (any
+scheme, any port) are always allowed. `LLMMAN_ORIGINS` adds more; see
+[configuration.md](configuration.md#environment-variables).

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,0 +1,78 @@
+# Inference backends
+
+llmman does not ship an inference engine. `llmman serve` picks one that
+already exists for the model format it finds, and runs it unmodified.
+
+| Model format | Backend | Where it comes from |
+|--------------|---------|---------------------|
+| GGUF | [`llama-server`](https://github.com/ggml-org/llama.cpp) | Your `PATH` if it is there; otherwise a prebuilt upstream release matching your OS/arch/GPU, downloaded and cached on first use |
+| GGUF | `llama-server` in a container | `--ociman docker` / `--ociman podman` (Linux only): the `ghcr.io/ggml-org/llama.cpp:server-<backend>` image for your GPU |
+| safetensors | [`vllm`](https://github.com/vllm-project/vllm) | Your `PATH` |
+| safetensors | [`mlx_lm.server`](https://github.com/ml-explore/mlx-lm) | Your `PATH`, on Apple Silicon macOS; preferred over `vllm` when present |
+
+## llama.cpp
+
+A `llama-server` on `PATH` is used as-is. Otherwise llmman probes for
+CUDA, ROCm, Vulkan or Metal (in that order) and downloads the matching
+prebuilt release from llama.cpp's GitHub releases. `LLMMAN_LLM_LIBRARY`
+overrides the probe; `LLMMAN_DEBUG=1` shows what it found.
+
+`--llama-cpp-version <tag>` pins a release (and forces the managed
+download even with a `llama-server` on `PATH`). `--pull-bin` downloads
+it in the foreground and exits, so the first request is not stuck behind
+a silent download.
+
+Context length, parallel slots, flash attention, KV-cache type and GPU
+split are environment variables; see [configuration.md](configuration.md).
+
+### In a container
+
+On Linux, `--ociman docker` (or `podman`) runs `llama-server` from the
+`ghcr.io/ggml-org/llama.cpp` image instead, picking the
+`server-cuda`/`server-cuda13`/`server-rocm`/`server-vulkan`/`server` tag
+for the host.
+`--llama-cpp-version` pins the image tag; `--pull-oci` pulls it in the
+foreground and exits. `CUDA_VISIBLE_DEVICES` and friends are forwarded
+into the container.
+
+## vLLM
+
+Safetensors models are served by a separately installed `vllm`. Plain
+`vllm` is CPU-only on macOS unless
+[vllm-metal](https://github.com/vllm-project/vllm-metal) is installed.
+`LLMMAN_CONTEXT_LENGTH` is forwarded as `--max-model-len`;
+`LLMMAN_LOAD_TIMEOUT` (default 10 minutes) bounds a stalled load.
+
+### `vllm serve` from llmman's store
+
+The inverse: the [`vllm-llmman`](https://pypi.org/project/vllm-llmman/)
+plugin lets `vllm serve oci://<reference>` pull a CNCF ModelPack image
+from any OCI registry, via `llmman` (`LLMMAN_BIN` if it is not on
+`PATH`). See [vllm-plugin/README.md](../vllm-plugin/README.md).
+
+## MLX (Apple Silicon)
+
+On Apple Silicon, `mlx_lm.server` (`pip install mlx-lm`) is preferred
+over `vllm` for safetensors when on `PATH`: Metal-accelerated, no vLLM
+dependency, more model families than vllm-metal. `LLMMAN_CONTEXT_LENGTH`
+is not forwarded and `/v1/embeddings` is unsupported.
+
+## Registry transport
+
+Registry access goes through a Go shim compiled into the binary, with
+two implementations behind Cargo features. Building needs Rust and Go
+1.22+.
+
+**Docker (default)**, via
+[containerd](https://github.com/containerd/containerd)'s resolver:
+
+```
+cargo build --release
+```
+
+**Podman**, via
+[container-libs](https://github.com/podman-container-tools/container-libs):
+
+```
+cargo build --release --no-default-features --features podman
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,11 +10,11 @@ Default locations:
 | Windows | `%LOCALAPPDATA%\llmman\store` |
 
 Set `LLMMAN_MODELS` to change this (matching Ollama's `OLLAMA_MODELS`).
-Commands that read or write the local store directly (`list`, `rm`,
-`build`, `serve`) all honor it. Commands that go through the background
-daemon instead (`pull`, `push`, `run`, `launch`, `ps`) always use whichever
-store the daemon was started with; set `LLMMAN_MODELS` before
-`llmman serve` to change it for all of them. `transfer`, `login`, and
+Commands that read or write the local store directly (`list`, `rm`, `cp`,
+`show`, `build`, `serve`) all honor it. Commands that go through the
+background daemon instead (`pull`, `push`, `run`, `launch`, `ps`, `stop`)
+always use whichever store the daemon was started with; set `LLMMAN_MODELS`
+before `llmman serve` to change it for all of them. `transfer`, `login`, and
 `logout` never touch a local store at all.
 
 The store uses [OCI Image Layout](https://github.com/opencontainers/image-spec/blob/main/image-layout.md), readable by `docker` and `podman`.
@@ -100,6 +100,7 @@ so `verify.trust[0]` names one entry per file and `--show-origin` is what
 tells them apart. `set`, `unset` and `edit`
 write the per-user file; pass `--system` for `/etc/llmman/llmman.conf`
 (which generally needs root) or `--file <path>` for any other one.
+`--user` restricts `list` and `get` to the per-user file alone.
 
 Two things it does that an editor cannot. Every write is checked against
 the format before the file is replaced, so `api_kye` is an error on the
@@ -114,8 +115,8 @@ output ends up in a bug report. `get` prints it in full.
 
 ### Provider API keys
 
-`--provider` reaches a hosted model with a key llmman never generates and
-never writes. It takes one from the variable models.dev names for that
+`--provider` reaches a hosted model with a key llmman never generates
+and never writes into an integration's config. It takes one from the variable models.dev names for that
 provider, or — when that is unset — from `[providers.<id>]`. Entries are
 keyed by the provider id `llmman providers` prints, not by the variable,
 which is models.dev's naming rather than llmman's.
@@ -163,7 +164,8 @@ and the limitations.
 
 `[aggregation]` names the other `llmman serve` daemons this one pools
 hardware with, comma-separated and spelled like `LLMMAN_HOST`
-(`[scheme://]host[:port]`, port defaulting to `17434`). `LLMMAN_PEERS`
+(`[scheme://]host[:port]`, port defaulting to `17434`, or 80/443 with an
+explicit scheme). `LLMMAN_PEERS`
 overrides it for one daemon; a user file's value replaces `/etc`'s
 rather than merging with it, and `peers = ""` opts out. See
 [aggregation.md](aggregation.md).
@@ -188,19 +190,19 @@ setting may not behave identically.
 | `LLMMAN_MODELS` | Local store directory, overriding the default above. `pull`/`push`/`run`/etc. go through the daemon and always use whichever store it was started with. |
 | `LLMMAN_NUM_PARALLEL` | Number of parallel request slots (`--parallel`) for GGUF models (llama-server only; no vllm/mlx equivalent). `--ctx-size` is scaled up by this value first, so each slot still gets the full configured/default context rather than an even split of it; ignored (with a warning) for a load with no explicit context size to scale. Unset leaves llama-server's own default of 1 untouched. |
 | `LLMMAN_PEERS` | Comma-separated peer daemons (`[scheme://]host[:port]`) to pool hardware with, overriding `[aggregation]` in `llmman.conf`. Set but empty takes this daemon out of its aggregation. See [aggregation.md](aggregation.md). |
-| `LLMMAN_ORIGINS` | A comma-separated list of extra allowed CORS origins for the HTTP API. A trailing `:*` on an entry matches any port on that scheme+host. Always includes every scheme/port on `localhost`/`127.0.0.1`/`0.0.0.0`/`[::1]` regardless of this variable. |
+| `LLMMAN_ORIGINS` | A comma-separated list of extra allowed CORS origins for the HTTP API. A single `*` anywhere in an entry matches any substring (`http://host:*` for any port, `https://*.example.com` for any subdomain, a bare `*` for everything), same as Ollama. Always includes every scheme/port on `localhost`/`127.0.0.1`/`0.0.0.0`/`[::1]` regardless of this variable. |
 | `LLMMAN_SCHED_SPREAD` | Truthy forwards `--split-mode layer` (spread a model across every GPU, already llama-server's own default); falsey forwards `--split-mode none` (restrict to one GPU). |
 | `LLMMAN_FLASH_ATTENTION` | Flash Attention mode (`--flash-attn`): `on`, `off`, or `auto` (llama-server's own default). Also accepts `1`/`0`/`true`/`false`. |
 | `LLMMAN_KV_CACHE_TYPE` | KV-cache quantization (`--cache-type-k`/`--cache-type-v`), e.g. `f16` (default), `q8_0`, `q4_0`. Trades output quality for memory at long context lengths. |
-| `LLMMAN_LLM_LIBRARY` | Forces which GPU backend `llmman serve`/`run` picks (`cpu`, `cuda`/`cuda12`, `cuda13`, `rocm`, `vulkan`, or macOS-only `metal`), bypassing autodetection. Has no effect when a `llama-server` binary is already on `PATH` (its own backend is fixed), or on macOS's local-binary download (one asset per architecture, no separate choice to make). |
+| `LLMMAN_LLM_LIBRARY` | Forces which GPU backend `llmman serve`/`run` picks (`cpu`, `cuda`/`cuda12`/`cuda_v12`, `cuda13`/`cuda_v13`, `rocm`, `vulkan`, or macOS-only `metal`), bypassing autodetection. Has no effect when a `llama-server` binary is already on `PATH` (its own backend is fixed), or on macOS's local-binary download (one asset per architecture, no separate choice to make). |
 | `LLMMAN_GPU_OVERHEAD` | Bytes of VRAM to hold back from the VRAM-tiered `LLMMAN_CONTEXT_LENGTH` default, leaving headroom for whatever else shares the device. Applied as one combined-total subtraction rather than per-GPU (llmman only ever probes one combined VRAM total). |
 | `LLMMAN_IGPU_ENABLE` | Counts integrated GPUs (Vulkan only) when probing for an accelerator. Defaults to disabled, since an integrated GPU is usually a worse choice than the discrete/CPU fallback it would otherwise be skipped in favor of. |
 | `LLMMAN_LOAD_TIMEOUT` | How long to allow a model load to stall before giving up. Zero or negative means wait forever. Defaults to 10 minutes (`vllm` can take several minutes to load a large safetensors model). |
 | `LLMMAN_TMPDIR` | Staging directory for `llama-server` release downloads, overriding the default `tmp` subdirectory of the install root. |
 | `LLMMAN_VERIFY` | Overrides the signature-verification mode (`off`, `warn`, or `enforce`) for every reference, ignoring what `[verify]` selected. Does *not* supply trusted keys — those still come from `llmman.conf`, so `enforce` with no configured keys fails every check rather than passing them. Intended for CI, which can demand `enforce` without editing config files. See [verification.md](verification.md). |
-| `LLMMAN_SIGN_PASSWORD` | Passphrase for the `--sign-key` private key used by `push`/`transfer`, when it is an encrypted PEM. Falls back to `COSIGN_PASSWORD`. Read from the client's environment and forwarded to the daemon, since the daemon's own environment is generally not the shell you set it in. |
+| `LLMMAN_SIGN_PASSWORD` | Passphrase for the `--sign-key` private key used by `push`/`transfer`, when it is an encrypted PEM. Falls back to `COSIGN_PASSWORD`. Read by the CLI process, which does the signing itself; neither key nor passphrase reaches the daemon. |
 | `LLMMAN_NOPRUNE` | When set (to anything other than `0`/`false`/`no`/`off`), skips the garbage-collection sweep that `llmman rm` and `llmman serve` startup otherwise run to delete blobs and extracted-cache entries no longer referenced by any local model. Note this is broader than skipping the daemon-startup catch-all: it also stops `llmman rm` itself from ever freeing disk space, so a removed model's (possibly multi-GB) weights stay on disk until a later sweep runs without this set. Useful for a shared/read-mostly store, or scripts that `rm` in a loop and prune once at the end. |
-| `LLAMA_ARG_FIT` / `LLAMA_ARG_FIT_TARGET` | llama.cpp's own env-configurable `--fit`/`--fit-target` options. Not something llmman parses itself, just forwarded through to every `llama-server` (local or `--ociman` container) it spawns, same as `CUDA_VISIBLE_DEVICES`/etc. below. |
+| `LLAMA_ARG_FIT` / `LLAMA_ARG_FIT_TARGET` / `LLAMA_ARG_THREADS` | llama.cpp's own env-configurable `--fit`/`--fit-target`/`--threads` options. Not something llmman parses itself, just forwarded through to every `llama-server` (local or `--ociman` container) it spawns, same as `CUDA_VISIBLE_DEVICES`/etc. below. |
 
 ### Context length by backend
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,77 @@
+# Hosted providers
+
+`--provider` points llmman at a model it doesn't serve itself, from
+`launch`, from `run`, and from `list`:
+
+```sh
+export OPENROUTER_API_KEY=...
+llmman providers                                    # which providers, and is the key set
+llmman list --provider openrouter                   # its models, and $/Mtok in and out
+llmman run --provider openrouter qwen/qwen3-coder   # chat with one directly
+llmman launch opencode --provider openrouter --model qwen/qwen3-coder
+```
+
+Requests still go through `llmman serve`; `--provider` changes where the
+daemon forwards them, not who the client talks to, so local and hosted
+models share one endpoint and one integration config.
+
+## The catalog
+
+The provider list comes from [models.dev](https://models.dev), the
+catalog `opencode` uses, so a new provider needs no llmman release. It
+is cached for 24 hours and a stale copy is used when the fetch fails.
+
+All four commands read it from the daemon over
+[`/llmman/providers`](api.md#llmmans-own-api), so the cache outlives any
+one command and the key status reported is the daemon's.
+
+## API keys
+
+The API key comes from the variable models.dev names for that provider,
+or — when that is unset — from `~/.config/llmman/llmman.conf`, keyed by
+provider id:
+
+```toml
+[providers.openrouter]
+api_key = "sk-or-..."
+```
+
+or, equivalently, `llmman config set providers.openrouter.api_key sk-or-...`.
+
+Either way it travels per request; it is never written into an
+integration's config.
+A file carrying one must be `chmod 600` or its keys are ignored with a
+warning; an `export` overrides it. See
+[configuration.md](configuration.md#provider-api-keys).
+
+`--provider` needs a local `llmman serve`. The daemon is plain HTTP with
+no authentication, so `run` and `launch` never send a key to a remote
+`LLMMAN_HOST`, and a daemon bound off loopback never spends its own key
+for a caller that presented none. (`providers` and `list --provider`
+read the catalog only and work against any daemon.)
+
+## Integrations
+
+`llmman launch` with no arguments lists these and whether each is
+installed:
+
+| Name | Integration | `--provider` |
+|------|-------------|--------------|
+| `claude` | Claude Code | yes |
+| `opencode` | OpenCode | yes |
+| `codex` | OpenAI Codex CLI | yes |
+| `aider` | Aider | yes |
+| `qwen` | Qwen Code | yes |
+| `hermes` | Hermes Agent | yes, but the daemon holds the key (below) |
+| `gemini` | Gemini CLI | no: llmman cannot confirm the key would come here rather than go to Google |
+| `cline` | Cline | no: it picks its own model rather than taking llmman's |
+| `kimi` | Kimi Code CLI | no: it picks its own model rather than taking llmman's |
+| `copilot` | GitHub Copilot CLI (`gh`) | no: it has no way to send a key |
+| `openclaw` | OpenClaw | no: it only takes a model during first-run onboarding |
+
+Any extra arguments after `--` are forwarded to the integration's own CLI.
+
+`hermes` is configured through a file on disk, so it can't carry a key
+per request; `llmman serve` needs one of its own, spent only for a
+loopback daemon and never for a cross-site browser request. On a shared
+machine prefer an integration that sends its own key.

--- a/install.sh
+++ b/install.sh
@@ -63,7 +63,7 @@ main() {
 	(Darwin)
 		[ "$ARCH" = "aarch64" ] || die \
 			"Intel (x86_64) macOS is not supported by llmman's published builds — only" \
-			"Apple Silicon (arm64) is. Build from source instead: see README.md."
+			"Apple Silicon (arm64) is. Build from source instead: see docs/backends.md."
 		TARGET="aarch64-apple-darwin"
 		;;
 	(*) die "OS not supported: $(uname -s). On Windows, use install.ps1 instead." ;;

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -51,11 +51,12 @@ Environment Variables:
       LLMMAN_MAX_LOADED_MODELS       Maximum number of loaded models (default: unbounded)
       LLMMAN_MAX_TRANSFER_STREAMS    Maximum parallel transfer streams for safetensors model pulls (default 4)
       LLMMAN_MAX_QUEUE               Maximum number of queued requests (default 512)
+      LLMMAN_METRICS                 Serve a Prometheus scrape endpoint at /metrics (default: off)
       LLMMAN_MODELS                  The path to the models directory
       LLMMAN_NUM_PARALLEL            Maximum number of parallel requests per model (GGUF only)
       LLMMAN_NOPRUNE                 Do not prune model blobs on startup
       LLMMAN_ORIGINS                 A comma separated list of allowed CORS origins
-      LLMMAN_PEERS                   A comma separated list of peer daemons ([host][:port]) to pool hardware with (overrides [aggregation] in llmman.conf)
+      LLMMAN_PEERS                   A comma separated list of peer daemons ([scheme://]host[:port]) to pool hardware with (overrides [aggregation] in llmman.conf)
       LLMMAN_SCHED_SPREAD            Always schedule model across all GPUs
       LLMMAN_FLASH_ATTENTION         Enable flash attention
       LLMMAN_KV_CACHE_TYPE           Quantization type for the K/V cache (default: f16)


### PR DESCRIPTION
Every doc was audited against the source, and the README cut from 348 to 253 lines by moving reference material into `docs/`.

**README**: keeps pitch, install, quick start, commands, OCI story, short Serve section, docs index. Aggregation gets a "Why llmman?" bullet and comparison-table row. Moved out: endpoint table and per-API notes -> `docs/api.md`; MLX, vLLM plugin, transport features, backend selection -> `docs/backends.md`; provider key rules and integration restrictions -> `docs/providers.md`.

**Accuracy fixes**
- `LLMMAN_SIGN_PASSWORD` is not forwarded to the daemon (`src/cmd/push.rs:53`); contradicted verification.md
- `http://10.0.0.5` peer example parses to port 80 (`src/daemon.rs:43-50`)
- Peer timeout is 3s; `ps` sample showed a `PROCESSOR` value never printed; referenced hidden `gpu-discover`
- `gemini` also refuses `--provider` (`src/cmd/launch.rs:135`)
- Undocumented: web UI at `/`, `/props`, `/v1/audio/transcriptions`, `config --user`, `LLAMA_ARG_THREADS`, `LLMMAN_ORIGINS` wildcard, `cp`/`show`/`stop` store access, `login`/`logout` HuggingFace
- `serve --help`: adds `LLMMAN_METRICS`; `[scheme://]host[:port]` matches the parser

There is no `llmman aggregate` subcommand; the feature is `[aggregation] peers` / `LLMMAN_PEERS`, documented as such throughout.

Verified: `cargo build`, `cargo fmt --check`, rendered `--help`, all relative links resolve.
