### PR TITLE
docs: drop the playback caption under the launch demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,6 @@ GPU, loads the model, and execs an agent against it.
   <img src="https://github.com/llmmanorg/llmman/releases/download/docs-assets/launch.gif" alt="llmman launch claude --model qwen3.8, answering from a local model" width="900">
 </p>
 
-<p align="center">
-<sub>A real session, played back at 1.95×. <a href="docs/launch.cast">docs/launch.cast</a> is
-the unedited recording, and <a href="docs/record-launch.py">docs/record-launch.py</a> reproduces it.</sub>
-</p>
-
 Models are OCI images, so moving one takes no tooling you don't already have:
 
 ```


### PR DESCRIPTION
Removes the caption under the launch GIF in the README.

The recording itself stays in the repo (`docs/launch.cast`, `docs/record-launch.py`); only the README caption pointing at it is gone.