### PR TITLE
fix(ci): call wingetcreate version, not --version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1813,7 +1813,9 @@ jobs:
           Invoke-WebRequest -Uri $url -OutFile wingetcreate.exe
           $got = (Get-FileHash wingetcreate.exe -Algorithm SHA256).Hash
           if ($got -ne $env:WINGETCREATE_SHA256) { throw "wingetcreate.exe sha256 $got != $env:WINGETCREATE_SHA256" }
-          .\wingetcreate.exe --version
+          # `version` is a subcommand; `--version` prints help and exits 1.
+          .\wingetcreate.exe version
+          if ($LASTEXITCODE -ne 0) { throw "wingetcreate version failed with exit code $LASTEXITCODE" }
 
       # WINGET_CREATE_GITHUB_TOKEN is wingetcreate's env var for CI
       # (https://aka.ms/winget-create-token); --token may be logged.


### PR DESCRIPTION
## Summary

The `Publish winget manifest` job has failed on every main push since #411 landed. The post-download sanity check runs `wingetcreate.exe --version`, but wingetcreate 1.12.13 has no `--version` flag: it prints its help text and exits 1, so the job dies before `submit` is ever reached.

This swaps it for the `version` subcommand the CLI actually exposes, and checks `$LASTEXITCODE` explicitly so the step fails with a clear message rather than relying on pwsh's implicit exit-code propagation.

## Not fixed here (needs an account action, not a code change)

The `Publish to crates.io` job is also failing on main, but for an unrelated reason:

```
the remote server responded with an error (status 400 Bad Request):
A verified email address is required to publish crates to crates.io.
```

That's a setting on the crates.io account that owns `CARGO_REGISTRY_TOKEN`. Someone with access to that account needs to verify an email at https://crates.io/settings/profile; nothing in the repo can change it.

## Verification

- `actionlint` and YAML parse clean (only pre-existing SC2016 info note at an unrelated line).
- Publish jobs only run on `push` to `main`, so this PR's CI won't exercise the path; it'll be confirmed by the first main run after merge.