### PR TITLE
docs: remove em dashes from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ llmman verify docker.io/myorg/mymodel:v1 --key signing.pub
 ```
 
 A `[verify]` trust policy turns that into an automatic check on every
-`pull`, warning or refusing outright per repository. Off by default —
+`pull`, warning or refusing outright per repository. Off by default:
 there is nothing to check against until you have said whom you trust.
 See [docs/verification.md](docs/verification.md).
 
@@ -213,7 +213,7 @@ context length, keep-alive and the other daemon settings in
 
 ### Aggregation
 
-Several machines each running `llmman serve` can pool their hardware — a
+Several machines each running `llmman serve` can pool their hardware; a
 group of manatees is an aggregation. Name the others on each node and a
 request to any of them is served by whichever has the model loaded, or
 the most room to load it:

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -35,7 +35,7 @@ $ LLMMAN_HOST=0.0.0.0 llmman serve
 peers = "asahi, spark:17434, 10.0.0.5"
 ```
 
-Each entry is spelled like `LLMMAN_HOST` — `[scheme://]host[:port]`, the
+Each entry is spelled like `LLMMAN_HOST`: `[scheme://]host[:port]`, the
 port defaulting to `17434` (or 80/443 when an explicit `http://`/`https://`
 scheme is given). `LLMMAN_PEERS=asahi,spark` overrides the
 file for one daemon, and `LLMMAN_PEERS=` (empty) takes it out of the
@@ -51,15 +51,15 @@ the laptop then offloads to it, and the workstation serves as it always
 did.
 
 `llmman serve` has no authentication and no TLS. An aggregation is for a
-network you already trust — the same caveat as any non-loopback
+network you already trust, the same caveat as any non-loopback
 `LLMMAN_HOST`. A daemon bound off loopback does not spend its own
 provider API keys; see [configuration.md](configuration.md).
 
 ## What each node does
 
 For a request naming a model this node does not have loaded, it asks
-every peer `GET /llmman/node` — what it has loaded, what it has stored,
-how much memory it has — and picks:
+every peer `GET /llmman/node` (what it has loaded, what it has stored,
+how much memory it has) and picks:
 
 1. A node that already has the model **loaded**. Never a second copy.
 2. Otherwise, of the nodes the model **fits** on (free memory, estimated
@@ -68,8 +68,8 @@ how much memory it has — and picks:
 3. Otherwise the node with the **most room**. Ties go to this node.
 
 If that is this node, it loads the model as it always did. If it is a
-peer, the request is forwarded there — the same bytes, the same
-streaming, with an `x-llmman-hop: 1` header — and the peer treats it as
+peer, the request is forwarded there (the same bytes, the same
+streaming, with an `x-llmman-hop: 1` header) and the peer treats it as
 an ordinary request: its own queue, keep-alive and eviction apply. A
 node that receives a hopped request never forwards it again, so two
 nodes that name each other never bounce one between them.
@@ -114,7 +114,7 @@ too:
 ## What it is not
 
 This routes whole requests to whole models. It does not split one model
-across machines — for a model too large for any single node, run
+across machines; for a model too large for any single node, run
 llama.cpp's `rpc-server` on the others and point one `llama-server` at
 them with `--rpc`; that is a different tool for a different problem.
 Nor is it prefill/decode disaggregation or KV-cache-aware routing in

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,7 +89,7 @@ $ llmman config unset providers.openrouter.api_key
 A key is a TOML dotted key, so an id that is not a bare key is quoted
 exactly as it is in the file: `llmman config get
 'providers."wafer.ai".api_key'`. Array entries are addressed by index for
-reading — `verify.trust[0].pattern` — but not for writing; use
+reading (`verify.trust[0].pattern`) but not for writing; use
 `llmman config edit` for a trust policy. Values are always written as
 strings, which is every field the format has.
 
@@ -117,18 +117,18 @@ output ends up in a bug report. `get` prints it in full.
 
 `--provider` reaches a hosted model with a key llmman never generates
 and never writes into an integration's config. It takes one from the variable models.dev names for that
-provider, or — when that is unset — from `[providers.<id>]`. Entries are
+provider, or, when that is unset, from `[providers.<id>]`. Entries are
 keyed by the provider id `llmman providers` prints, not by the variable,
 which is models.dev's naming rather than llmman's.
 
 The environment wins where both have a key, as it does for `aws` and
 `gh`: the file is the standing answer and an `export` is the deliberate,
 this-session-only override. An id that is not a bare TOML key must be
-quoted — `[providers."wafer.ai"]` — since `[providers.wafer.ai]` is two
+quoted, as `[providers."wafer.ai"]`, since `[providers.wafer.ai]` is two
 nested tables. Setting `api_key = ""` blanks out a key `/etc` supplied.
 
-On Unix a file carrying a key must not be readable by group or other —
-`chmod 600` it — or llmman ignores the keys in it with a warning, the way
+On Unix a file carrying a key must not be readable by group or other
+(`chmod 600` it), or llmman ignores the keys in it with a warning, the way
 `ssh` refuses a loose private key. Only the keys: a world-readable
 `/etc/llmman/llmman.conf` still supplies its aliases and trust policy,
 which are not secrets. This is unchecked on Windows, which has no mode
@@ -152,7 +152,7 @@ resolves to whatever you point it at. Nothing is compiled into the binary.
 nothing is verified.
 
 A file that is present but unreadable or malformed is a fatal error for
-verification, rather than a silent downgrade to `off` — even though the
+verification, rather than a silent downgrade to `off`, even though the
 same failure only costs the other two sections their aliases and keys.
 That asymmetry is deliberate: a trust policy llmman cannot read must not
 be mistaken for one that does not exist.
@@ -199,7 +199,7 @@ setting may not behave identically.
 | `LLMMAN_IGPU_ENABLE` | Counts integrated GPUs (Vulkan only) when probing for an accelerator. Defaults to disabled, since an integrated GPU is usually a worse choice than the discrete/CPU fallback it would otherwise be skipped in favor of. |
 | `LLMMAN_LOAD_TIMEOUT` | How long to allow a model load to stall before giving up. Zero or negative means wait forever. Defaults to 10 minutes (`vllm` can take several minutes to load a large safetensors model). |
 | `LLMMAN_TMPDIR` | Staging directory for `llama-server` release downloads, overriding the default `tmp` subdirectory of the install root. |
-| `LLMMAN_VERIFY` | Overrides the signature-verification mode (`off`, `warn`, or `enforce`) for every reference, ignoring what `[verify]` selected. Does *not* supply trusted keys — those still come from `llmman.conf`, so `enforce` with no configured keys fails every check rather than passing them. Intended for CI, which can demand `enforce` without editing config files. See [verification.md](verification.md). |
+| `LLMMAN_VERIFY` | Overrides the signature-verification mode (`off`, `warn`, or `enforce`) for every reference, ignoring what `[verify]` selected. Does *not* supply trusted keys; those still come from `llmman.conf`, so `enforce` with no configured keys fails every check rather than passing them. Intended for CI, which can demand `enforce` without editing config files. See [verification.md](verification.md). |
 | `LLMMAN_SIGN_PASSWORD` | Passphrase for the `--sign-key` private key used by `push`/`transfer`, when it is an encrypted PEM. Falls back to `COSIGN_PASSWORD`. Read by the CLI process, which does the signing itself; neither key nor passphrase reaches the daemon. |
 | `LLMMAN_NOPRUNE` | When set (to anything other than `0`/`false`/`no`/`off`), skips the garbage-collection sweep that `llmman rm` and `llmman serve` startup otherwise run to delete blobs and extracted-cache entries no longer referenced by any local model. Note this is broader than skipping the daemon-startup catch-all: it also stops `llmman rm` itself from ever freeing disk space, so a removed model's (possibly multi-GB) weights stay on disk until a later sweep runs without this set. Useful for a shared/read-mostly store, or scripts that `rm` in a loop and prune once at the end. |
 | `LLAMA_ARG_FIT` / `LLAMA_ARG_FIT_TARGET` / `LLAMA_ARG_THREADS` | llama.cpp's own env-configurable `--fit`/`--fit-target`/`--threads` options. Not something llmman parses itself, just forwarded through to every `llama-server` (local or `--ociman` container) it spawns, same as `CUDA_VISIBLE_DEVICES`/etc. below. |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -28,14 +28,14 @@ Fifteen metric families:
 | Metric | Type | Labels | What it tells you |
 |--------|------|--------|-------------------|
 | `llmman_build_info` | gauge | `version` | Which build is running; join against it to break a graph out by version. |
-| `llmman_start_time_seconds` | gauge | — | `time() - llmman_start_time_seconds` is uptime; a step down is a restart. |
-| `llmman_scheduling_requests_in_flight` | gauge | — | Requests doing model-scheduling work right now. |
-| `llmman_scheduling_capacity` | gauge | — | The limit those are counted against, i.e. `LLMMAN_MAX_QUEUE.max(1)`. |
-| `llmman_scheduling_rejections_total` | counter | — | Requests refused with a 503 because that limit was full. |
-| `llmman_models_loaded` | gauge | — | Backends currently running, the set `/api/ps` reports. |
-| `llmman_models_loading` | gauge | — | Loads under way; `loaded + loading` is what `LLMMAN_MAX_LOADED_MODELS` caps. |
+| `llmman_start_time_seconds` | gauge | (none) | `time() - llmman_start_time_seconds` is uptime; a step down is a restart. |
+| `llmman_scheduling_requests_in_flight` | gauge | (none) | Requests doing model-scheduling work right now. |
+| `llmman_scheduling_capacity` | gauge | (none) | The limit those are counted against, i.e. `LLMMAN_MAX_QUEUE.max(1)`. |
+| `llmman_scheduling_rejections_total` | counter | (none) | Requests refused with a 503 because that limit was full. |
+| `llmman_models_loaded` | gauge | (none) | Backends currently running, the set `/api/ps` reports. |
+| `llmman_models_loading` | gauge | (none) | Loads under way; `loaded + loading` is what `LLMMAN_MAX_LOADED_MODELS` caps. |
 | `llmman_model_up` | gauge | `model`, `engine` | 1 while the backend process is alive, 0 once it has died but llmman has not noticed. |
-| `llmman_model_loads_total` | counter | `model` | Cold starts per model — the churn a too-small `LLMMAN_MAX_LOADED_MODELS` produces. |
+| `llmman_model_loads_total` | counter | `model` | Cold starts per model, i.e. the churn a too-small `LLMMAN_MAX_LOADED_MODELS` produces. |
 | `llmman_model_load_duration_seconds` | histogram | `model` | How long a cold start takes, from admission to ready. |
 | `llmman_model_load_oom_retries_total` | counter | `model`, `strategy` | Loads that hit an out-of-memory failure and retried: `evict_others`, `split_mode`, `ctx_shrink`. |
 | `llmman_model_unloads_total` | counter | `model`, `reason` | `idle`, `requested`, `crashed`, `oom`, `evicted`. |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -28,7 +28,7 @@ one command and the key status reported is the daemon's.
 ## API keys
 
 The API key comes from the variable models.dev names for that provider,
-or — when that is unset — from `~/.config/llmman/llmman.conf`, keyed by
+or, when that is unset, from `~/.config/llmman/llmman.conf`, keyed by
 provider id:
 
 ```toml

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -8,7 +8,7 @@ put them there**.
 That gap matters more for llmman than for a registry with a curated
 library, because llmman deliberately has no gatekeeper. A bare
 `llmman pull gemma4` resolves through the `[aliases]` table of
-`llmman.conf` — which either config tier can repoint — to some registry
+`llmman.conf` (which either config tier can repoint) to some registry
 you never typed, and the GGUF it lands on goes straight into
 `llama-server`'s parser.
 
@@ -27,7 +27,7 @@ manifest, with one layer per signature:
 |---|---|
 | layer media type | `application/vnd.dev.cosign.simplesigning.v1+json` |
 | layer blob | the signed payload naming the manifest digest and repository |
-| layer annotation | `dev.cosignproject.cosign/signature` — base64 of the raw signature |
+| layer annotation | `dev.cosignproject.cosign/signature`, base64 of the raw signature |
 
 Nothing about this is llmman-specific: `cosign verify --key` reads what
 `llmman push --sign-key` writes. There is a test for exactly that claim
@@ -36,7 +36,7 @@ rather than against our own reading of its documentation.
 
 ## Quick start
 
-Generate a key pair. Any standard PEM works — this is plain PKCS#8, which
+Generate a key pair. Any standard PEM works: this is plain PKCS#8, which
 is what `openssl` produces:
 
 ```console
@@ -51,7 +51,7 @@ $ llmman push docker.io/myorg/mymodel:v1 --sign-key signing.key
 $ llmman transfer hf.co/owner/model docker.io/myorg/mymodel:v1 --sign-key signing.key
 ```
 
-Check by hand at any time — no daemon, no local copy required:
+Check by hand at any time, with no daemon and no local copy required:
 
 ```console
 $ llmman verify docker.io/myorg/mymodel:v1 --key signing.pub
@@ -70,7 +70,7 @@ full report.
 
 Verification during `pull` is driven by the `[verify]` section of
 `llmman.conf`, read from `/etc/llmman/` then `~/.config/llmman/` (later
-files win — see [configuration.md](configuration.md#llmmanconf)):
+files win; see [configuration.md](configuration.md#llmmanconf)):
 
 ```toml
 [verify]
@@ -84,7 +84,7 @@ mode    = "enforce"
 
 [[verify.trust]]
 # Narrower rules written later override broader earlier ones, and
-# *replace* their key set rather than adding to it — so "trust the org
+# *replace* their key set rather than adding to it, so "trust the org
 # key everywhere except here" is expressible.
 pattern = "docker.io/myorg/experimental"
 keys    = ["keys/lab.pub"]
@@ -110,7 +110,7 @@ path segment; `**` crosses them. So `docker.io/myorg/*` covers
 `docker.io/myorg/model` but not `docker.io/myorg/team/model`, and
 `docker.io/myorg/**` covers both.
 
-`LLMMAN_VERIFY=off|warn|enforce` overrides the mode — but not the keys —
+`LLMMAN_VERIFY=off|warn|enforce` overrides the mode (but not the keys)
 for every reference, which is the useful knob in CI: a pipeline can demand
 `enforce` without editing the image's config files.
 
@@ -118,7 +118,7 @@ for every reference, which is the useful knob in CI: a pipeline can demand
 
 A default of `warn` sounds safer and is worse. With no configured trust
 roots there is nothing any model could be checked against, so every pull
-would print an unsigned-model warning you can do nothing about — a
+would print an unsigned-model warning you can do nothing about, a
 reliable way to teach people to ignore the one warning that eventually
 matters. A trust policy only means anything once you have said whom you
 trust, so that is what turns it on.
@@ -134,7 +134,7 @@ For each published signature, all four of these must hold:
 
 Check 3 is not decoration. A signature is bound to a digest, not to a
 location, so an attacker who wants their repository to look endorsed can
-copy a legitimately signed model *and* its signature into it — the
+copy a legitimately signed model *and* its signature into it; the
 cryptography still checks out. Comparing the claimed identity is what
 pins a signature to where it was meant to live.
 
@@ -146,12 +146,12 @@ makes that safe.
 
 | Operation | Behaviour |
 |---|---|
-| `pull` from an OCI registry | Policy applied. Checked *before* any layer is fetched, so a rejected model costs one manifest lookup instead of a multi-gigabyte download, then re-confirmed against the digest actually stored — a tag repointed mid-pull cannot slip past the check that just passed. Under `enforce`, a failure removes the reference again. |
+| `pull` from an OCI registry | Policy applied. Checked *before* any layer is fetched, so a rejected model costs one manifest lookup instead of a multi-gigabyte download, then re-confirmed against the digest actually stored; a tag repointed mid-pull cannot slip past the check that just passed. Under `enforce`, a failure removes the reference again. |
 | A model already in the store | Re-checked against the digest held locally, on every `pull` and on the auto-pull an inference request triggers. Being on disk is not the same as being trusted: it may have arrived before the policy existed, or under `warn`. Costs nothing when no policy applies. |
 | `pull` from HuggingFace, `ms://`, `ngc://`, `s3://`, `gs://`, a local path | Not checked. There is no signature to find, and failing every such pull under `enforce` would only get the policy switched off. Use `llmman transfer --sign-key` to bring one of these into a registry as something you vouch for. |
 | `transfer` from an OCI registry | Source checked under the same policy as `pull`: re-publishing an unverified model under your own name is how a supply-chain problem propagates, and a transfer that skipped the check would launder one past a policy `pull` enforces. |
 | `push --sign-key` / `transfer --sign-key` | Signs the digest that was actually pushed, never one re-resolved from the destination tag afterwards. |
-| `verify` | Always checks and always reports, whatever the policy says — it is the diagnostic, so its exit status reflects the signature, not the policy. |
+| `verify` | Always checks and always reports, whatever the policy says: it is the diagnostic, so its exit status reflects the signature, not the policy. |
 
 Signing twice with different keys **appends**, so key rotation works:
 publish under the new key while the old one is still trusted, then
@@ -164,8 +164,8 @@ These are real and worth stating plainly.
 
 - **Keyless signing (Fulcio / Rekor) is not supported.** llmman does
   key-based verification only. Keyless brings a much larger dependency
-  and trust-root surface, and an air-gapped deployment — llmman's stated
-  audience — cannot use it anyway. The on-registry format leaves room for
+  and trust-root surface, and an air-gapped deployment (llmman's stated
+  audience) cannot use it anyway. The on-registry format leaves room for
   it: a keyless signature is the same layer shape with two extra
   annotations.
 
@@ -190,8 +190,8 @@ These are real and worth stating plainly.
 - **A mirrored or relocated repository cannot verify.** The claimed-identity
   check compares repositories, so a model re-hosted at
   `mirror.corp/original/name` will not match a signature naming
-  `original/name`. That is the check working as intended — it is what stops
-  a signature being copied into someone else's repository — but it means a
+  `original/name`. That is the check working as intended (it is what stops
+  a signature being copied into someone else's repository), but it means a
   pull-through mirror needs its own signatures today. A per-rule identity
   override would close this and is not implemented.
 
@@ -199,5 +199,5 @@ These are real and worth stating plainly.
   --sign-key` has the daemon report which digest it pushed and then signs
   that itself, so no key path or passphrase ever crosses the socket. The
   daemon binds unauthenticated TCP loopback, which is not user-scoped and
-  carries no peer credentials — accepting a key path there would let any
+  carries no peer credentials; accepting a key path there would let any
   local user have it read a file only its own user can read.

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,6 +1,6 @@
 # llmmanorg/homebrew-tap
 
-Homebrew tap for [llmman](https://github.com/llmmanorg/llmman) — run any
+Homebrew tap for [llmman](https://github.com/llmmanorg/llmman): run any
 agent on any model, models stored as OCI images.
 
 ## Install
@@ -20,7 +20,7 @@ Supported platforms (the platforms llmman publishes builds for):
 | Linux | `x86_64` |
 | Linux | `aarch64` |
 
-Intel macOS is not supported — llmman publishes no `x86_64-apple-darwin`
+Intel macOS is not supported; llmman publishes no `x86_64-apple-darwin`
 build. `cargo install llmman` builds from source there (needs Rust and Go).
 
 ## Versions
@@ -35,5 +35,5 @@ is no separate stable channel.
 `Formula/llmman.rb` is rendered by
 [`packaging/render.sh`](https://github.com/llmmanorg/llmman/blob/main/packaging/render.sh)
 in the main repo and pushed here by its CI on every release. **Edits made
-directly in this repo are overwritten by the next release** — change
+directly in this repo are overwritten by the next release**; change
 `packaging/homebrew/llmman.rb.in` upstream instead.

--- a/vllm-plugin/README.md
+++ b/vllm-plugin/README.md
@@ -12,7 +12,7 @@ vllm serve oci://ghcr.io/org/model:tag
 
 ## Requirements
 
-- vLLM (any recent version — no vLLM core changes required, see
+- vLLM (any recent version; no vLLM core changes required, see
   [How it works](#how-it-works)).
 - The `llmman` binary on `PATH` (or point `LLMMAN_BIN` at it):
 
@@ -29,19 +29,19 @@ for `s3://`/`gs://`/`az://`, pulling the reference into a local
 directory and rewriting `self.model`/`self.tokenizer` to point at it).
 
 This plugin registers itself via vLLM's `vllm.general_plugins` entry
-point (loaded once per process, before any `ModelConfig` is built — see
+point (loaded once per process, before any `ModelConfig` is built; see
 `docs/design/plugin_system.md` in the vLLM repo) and wraps that same
 hook: when `model=`/`tokenizer=` starts with `oci://`, it shells out to
 `llmman resolve <reference>` (see llmman's
 `src/cmd/resolve.rs`), which pulls the image into llmman's local OCI
 store if it isn't already there, extracts it, and returns the local
 path as JSON. That path is what vLLM's default HuggingFace-format
-loading then sees — same as if you had passed a local directory all
+loading then sees, the same as if you had passed a local directory all
 along. Every other `model=` value (a HF repo id, a local path, an
 existing `s3://`/`gs://`/`az://` reference) is left completely
 untouched, delegated straight to vLLM's original behavior.
 
-No vLLM core file is modified — this only uses vLLM's own plugin entry
+No vLLM core file is modified; this only uses vLLM's own plugin entry
 point plus a narrowly scoped runtime monkeypatch (see
 `src/vllm_llmman/_patch.py`'s module docstring for exactly what and why
 a monkeypatch was necessary here, unlike e.g. a custom `--load-format`,
@@ -49,7 +49,7 @@ which vLLM *does* let plugins register without any monkeypatching).
 
 An explicit `oci://` scheme is required rather than guessing from a
 bare `registry/name:tag` string, since that shape is
-indistinguishable from a HuggingFace repo id (`org/model`) — guessing
+indistinguishable from a HuggingFace repo id (`org/model`); guessing
 would risk hijacking existing HF-backed `vllm serve org/model` calls the
 moment this plugin is installed.
 
@@ -67,7 +67,7 @@ pytest
 vLLM isn't installed in the current environment.
 
 `tests/test_e2e.py` goes further: a real `llmman` binary resolving a
-real `oci://` reference, no mocks — plus, when `vllm` is installed, a
+real `oci://` reference with no mocks, plus, when `vllm` is installed, a
 real `vllm serve oci://qwen3.5:0.8b-safetensors` process, never
 pre-resolved by the test itself, proving this plugin's entry point is
 actually discovered by a real vLLM startup. Excluded from a plain


### PR DESCRIPTION
## Summary

- Replace every em dash in the Markdown documentation with plain punctuation (commas, semicolons, colons or parentheses), chosen per sentence so the meaning is unchanged.
- The lone dashes in the `Labels` column of the metrics table in `docs/metrics.md` now read `(none)`.

Files touched: `README.md`, `docs/aggregation.md`, `docs/configuration.md`, `docs/metrics.md`, `docs/providers.md`, `docs/verification.md`, `packaging/homebrew/README.md`, `vllm-plugin/README.md`.

Source-code comments still contain em dashes; this PR is scoped to documentation only.

## Verification

`rg '—' --glob '*.md'` returns no matches.