### PR TITLE
refactor: de-duplicate overlap function

### DIFF
--- a/src/harmony.rs
+++ b/src/harmony.rs
@@ -143,7 +143,7 @@ impl HarmonyParser {
                     events.push(HarmonyEvent::MessageEnd);
                     (events, true)
                 } else {
-                    let overlap_len = overlap(&self.acc, &self.message_end_tag);
+                     let overlap_len = crate::utils::overlap(&self.acc, &self.message_end_tag);
                     if overlap_len > 0 {
                         let split = self.acc.len() - overlap_len;
                         let content = self.acc[..split].to_string();
@@ -219,15 +219,7 @@ fn parse_header(raw: &str) -> HarmonyHeader {
 }
 
 /// Longest overlap between a suffix of `s` and a prefix of `delim`.
-fn overlap(s: &str, delim: &str) -> usize {
-    let max = delim.len().min(s.len());
-    for i in (1..=max).rev() {
-        if s.ends_with(&delim[..i]) {
-            return i;
-        }
-    }
-    0
-}
+
 
 // ---------------------------------------------------------------------------
 // HarmonyMessageHandler — maps low-level events onto (content, thinking,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub mod metrics;
 pub mod modelpack;
 pub mod oauth;
 pub mod providers;
-pub mod shortnames;
+pub mod utils;
 pub mod sources;
 pub mod storage;
 pub mod thinking;

--- a/src/thinking.rs
+++ b/src/thinking.rs
@@ -127,7 +127,7 @@ impl Parser {
                     };
                     (thinking, remaining, false)
                 } else {
-                    let overlap_len = overlap(&acc, &self.closing_tag);
+                     let overlap_len = crate::utils::overlap(&acc, &self.closing_tag);
                     if overlap_len > 0 {
                         let split = acc.len() - overlap_len;
                         let thinking = acc[..split].to_string();
@@ -171,15 +171,7 @@ fn strip_all_leading_occurrences<'a>(trimmed: &'a str, tag: &str) -> Option<&'a 
 }
 
 /// Longest overlap between a suffix of `s` and a prefix of `delim`.
-fn overlap(s: &str, delim: &str) -> usize {
-    let max = delim.len().min(s.len());
-    for i in (1..=max).rev() {
-        if s.ends_with(&delim[..i]) {
-            return i;
-        }
-    }
-    0
-}
+
 
 #[cfg(test)]
 mod tests {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,10 @@
+//! General string and other utilities.
+pub fn overlap(s: &str, delim: &str) -> usize {
+    let max = delim.len().min(s.len());
+    for i in (1..=max).rev() {
+        if s.ends_with(&delim[..i]) {
+            return i;
+        }
+    }
+    0
+}


### PR DESCRIPTION
Moved the overlap function from harmony.rs and thinking.rs to a new utils module in src.