### PR TITLE
de-duplicate OCI types: one shared Descriptor/Manifest/CNCF config definition

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -8147,6 +8147,7 @@ mod tests {
             digest: "sha256:a1b2".into(),
             size: 0,
             annotations: None,
+            ..Default::default()
         };
         OciStore::open(&dir)
             .unwrap()
@@ -10000,6 +10001,7 @@ mod tests {
             digest: "sha256:a1b2".into(),
             size: 0,
             annotations: None,
+            ..Default::default()
         };
         OciStore::open(&dir)
             .unwrap()
@@ -10105,6 +10107,7 @@ mod tests {
             digest: digest.into(),
             size: 0,
             annotations: None,
+            ..Default::default()
         };
         let store = OciStore::open(&dir).unwrap();
         store
@@ -10181,6 +10184,7 @@ mod tests {
             digest: "sha256:0000".into(),
             size: 0,
             annotations: None,
+            ..Default::default()
         };
         OciStore::open(&dir)
             .unwrap()
@@ -10247,6 +10251,7 @@ mod tests {
             digest: digest.into(),
             size: 0,
             annotations: None,
+            ..Default::default()
         };
         store
             .tag(desc("sha256:aaaa"), "docker.io/ai/m-key:v9")
@@ -10304,6 +10309,7 @@ mod tests {
             digest: "sha256:d16e".into(),
             size: 0,
             annotations: None,
+            ..Default::default()
         };
         OciStore::open(&dir)
             .unwrap()
@@ -10366,6 +10372,7 @@ mod tests {
             digest: "sha256:0000".into(),
             size: 0,
             annotations: None,
+            ..Default::default()
         };
         OciStore::open(&dir)
             .unwrap()

--- a/src/hf/oci.rs
+++ b/src/hf/oci.rs
@@ -1,4 +1,4 @@
-//! Local OCI layout types and read/write helpers — a Rust equivalent of
+//! Local OCI layout read/write helpers — a Rust equivalent of
 //! go-shim/shared_oci.go's blob helpers and manifest_ref.go, plus the
 //! CNCF ModelPack manifest construction the Go shim's own (since
 //! deleted) `buildCNCFManifest` used to do.
@@ -9,6 +9,11 @@
 //! pointer files, `oci-layout`) — a from-scratch equivalent, not a
 //! replacement, so a native pull never needs to call into Go.
 //!
+//! The OCI image-spec types themselves (`Descriptor`, `Manifest`, and the
+//! CNCF model-spec config document) are defined once in
+//! `crate::storage::oci` and re-exported here, so the pull path and the
+//! local store path share one definition.
+//!
 //! Shared with `crate::sources`, which stores the ModelScope/NGC/S3/GCS/
 //! local-directory sources in exactly this format too.
 
@@ -17,66 +22,26 @@ use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
-// ---------------------------------------------------------------------------
-// OCI image-spec types — just enough of the public spec to round-trip
-// what this codebase actually produces/reads (mirrors
-// opencontainers/image-spec's Go structs field-for-field).
-// ---------------------------------------------------------------------------
+use crate::storage::oci::{
+    ref_path_segments, CncfCapabilities, CncfConfigConfig, CncfConfigDescriptor, CncfModelConfig,
+    CncfModelFs,
+};
 
 pub const MEDIA_TYPE_IMAGE_MANIFEST: &str = "application/vnd.oci.image.manifest.v1+json";
 pub const ANNOTATION_REF_NAME: &str = "org.opencontainers.image.ref.name";
 pub const ANNOTATION_TITLE: &str = "org.opencontainers.image.title";
 
-/// Matches `ocispec.Descriptor`'s JSON shape exactly.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct Descriptor {
-    #[serde(rename = "mediaType")]
-    pub media_type: String,
-    pub digest: String,
-    pub size: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub urls: Option<Vec<String>>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<BTreeMap<String, String>>,
-    #[serde(
-        rename = "artifactType",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub artifact_type: Option<String>,
-}
-
-impl Descriptor {
-    pub fn annotation(&self, key: &str) -> Option<&str> {
-        self.annotations.as_ref()?.get(key).map(String::as_str)
-    }
-}
-
-/// Matches `ocispec.Manifest`'s JSON shape exactly.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Manifest {
-    #[serde(rename = "schemaVersion")]
-    pub schema_version: i32,
-    #[serde(rename = "mediaType")]
-    pub media_type: String,
-    #[serde(
-        rename = "artifactType",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub artifact_type: Option<String>,
-    pub config: Descriptor,
-    pub layers: Vec<Descriptor>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<BTreeMap<String, String>>,
-}
+/// The single shared OCI image-spec types, defined in
+/// `crate::storage::oci` — re-exported so `crate::hf` and
+/// `crate::sources` keep their existing import paths.
+pub use crate::storage::oci::{Descriptor, Manifest};
 
 // ---------------------------------------------------------------------------
-// CNCF ModelPack config (github.com/modelpack/model-spec) — just the
-// fields buildCNCFManifest actually populates.
+// CNCF ModelPack config (github.com/modelpack/model-spec) — built on the
+// shared `Cncf*` types in `crate::storage::oci`, which `OciStore::build`
+// serializes with too.
 // ---------------------------------------------------------------------------
 
 pub const ARTIFACT_TYPE_MODEL_MANIFEST: &str = "application/vnd.cncf.model.manifest.v1+json";
@@ -90,49 +55,6 @@ pub const MEDIA_TYPE_MODEL_DOC_RAW: &str = "application/vnd.cncf.model.doc.v1.ra
 /// aren't among the ones `select_downloadable_hf_files` fetches.
 pub const MEDIA_TYPE_MODEL_CODE_RAW: &str = "application/vnd.cncf.model.code.v1.raw";
 pub const ANNOTATION_FILEPATH: &str = "org.cncf.model.filepath";
-
-#[derive(Serialize, Default)]
-struct ModelDescriptor {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    licenses: Vec<String>,
-}
-
-#[derive(Serialize)]
-struct ModelFS {
-    #[serde(rename = "type")]
-    kind: String,
-    #[serde(rename = "diffIds")]
-    diff_ids: Vec<String>,
-}
-
-#[derive(Serialize, Default)]
-struct ModelCapabilities {
-    #[serde(rename = "inputTypes", default, skip_serializing_if = "Vec::is_empty")]
-    input_types: Vec<&'static str>,
-    #[serde(rename = "outputTypes", default, skip_serializing_if = "Vec::is_empty")]
-    output_types: Vec<&'static str>,
-}
-
-#[derive(Serialize, Default)]
-struct ModelConfig {
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    format: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    capabilities: Option<ModelCapabilities>,
-}
-
-#[derive(Serialize)]
-struct Model {
-    #[serde(rename = "descriptor")]
-    descriptor: ModelDescriptor,
-    modelfs: ModelFS,
-    #[serde(default, skip_serializing_if = "is_default_config")]
-    config: ModelConfig,
-}
-
-fn is_default_config(c: &ModelConfig) -> bool {
-    c.format.is_empty() && c.capabilities.is_none()
-}
 
 /// Mirrors `modelMeta` in hf.go: the optional-but-valuable metadata
 /// `build_cncf_manifest` populates beyond the bare config.format+modelfs.
@@ -155,20 +77,21 @@ pub fn build_cncf_manifest(
     filepath_annotation: &str,
     layers: Vec<Descriptor>,
 ) -> Result<Descriptor> {
-    let model = Model {
-        descriptor: ModelDescriptor {
+    let model = CncfModelConfig {
+        descriptor: CncfConfigDescriptor {
+            created_at: None,
             licenses: meta.licenses.clone(),
         },
-        modelfs: ModelFS {
-            kind: "layers".to_string(),
-            diff_ids: layers.iter().map(|l| l.digest.clone()).collect(),
-        },
-        config: ModelConfig {
+        config: CncfConfigConfig {
             format: meta.format.clone(),
-            capabilities: meta.vision.then(|| ModelCapabilities {
-                input_types: vec!["text", "image"],
-                output_types: vec!["text"],
+            capabilities: meta.vision.then(|| CncfCapabilities {
+                input_types: vec!["text".to_string(), "image".to_string()],
+                output_types: vec!["text".to_string()],
             }),
+        },
+        modelfs: CncfModelFs {
+            fs_type: "layers".to_string(),
+            diff_ids: layers.iter().map(|l| l.digest.clone()).collect(),
         },
     };
     let cfg_data = serde_json::to_vec(&model).context("marshal CNCF model config")?;
@@ -351,38 +274,10 @@ impl std::io::Write for HashingWriter<'_> {
 
 const MANIFESTS_DIR_NAME: &str = "manifests";
 
-fn sanitize_ref_segment(s: &str) -> String {
-    if s.is_empty() || s == "." || s == ".." {
-        return "__".to_string();
-    }
-    s.replace([':', '\\'], "_")
-}
-
-/// Splits `reference` into the path segments used to lay it out under
-/// `manifests/` — mirrors `refPathSegments`. A `:` only starts a tag if
-/// it comes after the last `/` (so a registry port, e.g.
-/// "host:5000/owner/repo", isn't mistaken for one); otherwise the tag
-/// defaults to "latest".
-fn ref_path_segments(reference: &str) -> Vec<String> {
-    let last_colon = reference.rfind(':').map(|i| i as isize).unwrap_or(-1);
-    let last_slash = reference.rfind('/').map(|i| i as isize).unwrap_or(-1);
-    let (name, tag) = if last_colon > last_slash {
-        (
-            &reference[..last_colon as usize],
-            &reference[last_colon as usize + 1..],
-        )
-    } else {
-        (reference, "latest")
-    };
-    let mut segs: Vec<String> = name
-        .split('/')
-        .filter(|s| !s.is_empty())
-        .map(sanitize_ref_segment)
-        .collect();
-    segs.push(sanitize_ref_segment(tag));
-    segs
-}
-
+/// The `manifests/` path for `reference` — the segment layout comes from
+/// `crate::storage::oci::ref_path_segments`, the one shared with the local
+/// store, so a reference always lands at the same file whichever path
+/// wrote it.
 fn manifest_ref_path(layout_dir: &Path, reference: &str) -> PathBuf {
     let mut p = layout_dir.join(MANIFESTS_DIR_NAME);
     for seg in ref_path_segments(reference) {

--- a/src/modelpack.rs
+++ b/src/modelpack.rs
@@ -355,13 +355,14 @@ mod tests {
     }
 
     fn descriptor(digest: &str, filepath: &str) -> crate::storage::oci::Descriptor {
-        let mut ann = std::collections::HashMap::new();
+        let mut ann = std::collections::BTreeMap::new();
         ann.insert("org.cncf.model.filepath".to_string(), filepath.to_string());
         crate::storage::oci::Descriptor {
             media_type: "application/vnd.cncf.model.weight.v1.tar".into(),
             digest: digest.to_string(),
             size: 123,
             annotations: Some(ann),
+            ..Default::default()
         }
     }
 

--- a/src/storage/oci.rs
+++ b/src/storage/oci.rs
@@ -22,6 +22,7 @@
 //!                          manifest's own raw JSON bytes
 //! ```
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -37,62 +38,103 @@ static WRITE_REF_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 // ---------------------------------------------------------------------------
 // Minimal OCI spec types (no external crate needed)
+//
+// The single shared definition of the OCI image-spec shapes this
+// codebase reads and writes — `crate::hf::oci` re-exports these rather
+// than keeping its own copy, so the pull path and the local store path
+// can never drift apart.
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+/// Matches `ocispec.Descriptor`'s JSON shape exactly.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Descriptor {
+    #[serde(rename = "mediaType")]
     pub media_type: String,
     pub digest: String,
-    pub size: u64,
+    pub size: i64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<std::collections::HashMap<String, String>>,
+    pub urls: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<BTreeMap<String, String>>,
+    #[serde(
+        rename = "artifactType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub artifact_type: Option<String>,
 }
 
+impl Descriptor {
+    pub fn annotation(&self, key: &str) -> Option<&str> {
+        self.annotations.as_ref()?.get(key).map(String::as_str)
+    }
+}
+
+/// Matches `ocispec.Manifest`'s JSON shape exactly.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct Manifest {
-    pub schema_version: u32,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: i32,
+    #[serde(rename = "mediaType")]
     pub media_type: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "artifactType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub artifact_type: Option<String>,
     pub config: Descriptor,
     pub layers: Vec<Descriptor>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<std::collections::HashMap<String, String>>,
+    pub annotations: Option<BTreeMap<String, String>>,
 }
 
 /// `application/vnd.cncf.model.config.v1+json` — the CNCF Model Format Spec
-/// (<https://github.com/modelpack/model-spec>) config document. The
-/// deserializing counterpart of what `crate::hf::oci::build_cncf_manifest`
-/// writes for HuggingFace/cloud-source pulls; this is the equivalent for
-/// `llmman build`'s local-directory packaging path.
+/// (<https://github.com/modelpack/model-spec>) config document. Written by
+/// both `crate::hf::oci::build_cncf_manifest` (HuggingFace/cloud-source
+/// pulls) and `OciStore::build`'s local-directory packaging path.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
 pub struct CncfConfigDescriptor {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub created_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub licenses: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct CncfConfigConfig {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub format: Option<String>,
+pub struct CncfCapabilities {
+    #[serde(rename = "inputTypes", default, skip_serializing_if = "Vec::is_empty")]
+    pub input_types: Vec<String>,
+    #[serde(rename = "outputTypes", default, skip_serializing_if = "Vec::is_empty")]
+    pub output_types: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CncfConfigConfig {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub format: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<CncfCapabilities>,
+}
+
+fn is_default_cncf_config(c: &CncfConfigConfig) -> bool {
+    c.format.is_empty() && c.capabilities.is_none()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CncfModelFs {
     #[serde(rename = "type")]
     pub fs_type: String,
     pub diff_ids: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CncfModelConfig {
+    #[serde(default)]
     pub descriptor: CncfConfigDescriptor,
+    #[serde(default, skip_serializing_if = "is_default_cncf_config")]
     pub config: CncfConfigConfig,
+    #[serde(default)]
     pub modelfs: CncfModelFs,
 }
 
@@ -245,8 +287,8 @@ impl OciStore {
         Ok(Descriptor {
             media_type: media_type.into(),
             digest,
-            size: data.len() as u64,
-            annotations: None,
+            size: data.len() as i64,
+            ..Default::default()
         })
     }
 
@@ -291,8 +333,8 @@ impl OciStore {
         Ok(Descriptor {
             media_type: media_type.into(),
             digest,
-            size,
-            annotations: None,
+            size: size as i64,
+            ..Default::default()
         })
     }
 
@@ -369,8 +411,8 @@ impl OciStore {
     /// error over what's only ever used for display.
     pub fn total_size(&self, desc: &Descriptor) -> u64 {
         self.read_manifest(&desc.digest)
-            .map(|manifest| manifest.layers.iter().map(|l| l.size).sum())
-            .unwrap_or(desc.size)
+            .map(|manifest| manifest.layers.iter().map(|l| l.size).sum::<i64>() as u64)
+            .unwrap_or(desc.size as u64)
     }
 
     // ------------------------------------------------------------------
@@ -506,7 +548,7 @@ impl OciStore {
             let tar_data = make_single_file_tar(entry.path(), &rel)?;
             let mut desc = self.write_blob(media_type, &tar_data)?;
             desc.annotations = Some({
-                let mut m = std::collections::HashMap::new();
+                let mut m = BTreeMap::new();
                 m.insert("org.cncf.model.filepath".into(), rel.clone());
                 m.insert("org.opencontainers.image.title".into(), rel);
                 m
@@ -524,9 +566,11 @@ impl OciStore {
         let cncf_config = CncfModelConfig {
             descriptor: CncfConfigDescriptor {
                 created_at: Some(chrono::Utc::now().to_rfc3339()),
+                ..Default::default()
             },
             config: CncfConfigConfig {
-                format: format.map(str::to_string),
+                format: format.unwrap_or_default().to_string(),
+                ..Default::default()
             },
             modelfs: CncfModelFs {
                 fs_type: "layers".into(),
@@ -542,7 +586,7 @@ impl OciStore {
         let manifest_annotations = if labels.is_empty() {
             None
         } else {
-            Some(labels.clone())
+            Some(labels.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
         };
 
         // Manifest
@@ -746,7 +790,7 @@ fn stored_ref_name(desc: &Descriptor) -> Option<&str> {
 /// empty, "." or ".." segment (e.g. an empty tag from "repo:") becomes
 /// "__" instead, since any of those would otherwise produce a malformed
 /// or unintended path — see `sanitize_ref_segment`.
-fn ref_path_segments(reference: &str) -> Vec<String> {
+pub(crate) fn ref_path_segments(reference: &str) -> Vec<String> {
     let tagged = default_tag(reference);
     let (name, tag): (&str, &str) = match tagged.rfind(':') {
         Some(pos) if pos > tagged.rfind('/').unwrap_or(0) => (&tagged[..pos], &tagged[pos + 1..]),
@@ -766,7 +810,7 @@ fn ref_path_segments(reference: &str) -> Vec<String> {
 /// `://`) becomes `_`, and a segment that's exactly `..` is neutralized,
 /// so no reference can ever escape the `manifests/` tree it's rooted
 /// under.
-fn sanitize_ref_segment(s: &str) -> String {
+pub(crate) fn sanitize_ref_segment(s: &str) -> String {
     if s.is_empty() || s == "." || s == ".." {
         return "__".to_string();
     }
@@ -891,7 +935,7 @@ mod tests {
     use super::*;
 
     fn desc_with_ref(ref_name: &str) -> Descriptor {
-        let mut ann = std::collections::HashMap::new();
+        let mut ann = BTreeMap::new();
         ann.insert(
             "org.opencontainers.image.ref.name".to_string(),
             ref_name.to_string(),
@@ -901,6 +945,7 @@ mod tests {
             digest: "sha256:deadbeef".into(),
             size: 123,
             annotations: Some(ann),
+            ..Default::default()
         }
     }
 
@@ -1149,6 +1194,7 @@ mod tests {
             digest: "sha256:deadbeef".into(),
             size: 123,
             annotations: None,
+            ..Default::default()
         };
         assert!(!ref_matches_precise(&d, "docker.io/ai/qwen3.5:0.8b"));
     }


### PR DESCRIPTION
## What

`src/storage/oci.rs` and `src/hf/oci.rs` each defined their own copies of the OCI image-spec types (`Descriptor`, `Manifest`) and of the CNCF Model Format Spec config-document types, plus duplicate `ref_path_segments`/`sanitize_ref_segment` helpers. The two `Descriptor`s had already drifted (u64 vs i64 `size`, `HashMap` vs `BTreeMap` annotations, missing `urls`/`artifactType`), which is exactly the kind of duplication that bit the store when the pull path needed fields the store path didn't have.

This makes `src/storage/oci.rs` the single home of all of those types; `src/hf/oci.rs` re-exports them (`pub use crate::storage::oci::{Descriptor, Manifest};`) so `crate::hf` and `crate::sources` keep their existing import paths, and `build_cncf_manifest` now builds on the shared `Cncf*` types.

Note: this is a redo of `47c5bc5` (reverted by `e796b6f`), which only half-landed — it changed the store types without removing the `hf` copies or updating the consumers, so it broke the build. This version updates every call site.

## Changes

- `Descriptor`: superset of both previous shapes — `i64` size, optional `urls`/`artifactType`, `BTreeMap` annotations, `annotation()` helper; same camelCase JSON keys as before.
- `Manifest`: `i32` schemaVersion, identical JSON keys.
- CNCF config types unified into one set covering both previous ones (`createdAt` + `licenses`; `format` + `capabilities`), skipping the whole `config` object when empty, as the pull path already did.
- `hf/oci.rs`: duplicate type definitions and `ref_path_segments`/`sanitize_ref_segment` removed in favor of the storage versions (behavior-identical; the storage variant also guards non-registry sources via `default_tag`).
- `total_size()` sums `i64` layer sizes; `build()` carries its labels as sorted `BTreeMap` annotations (previously HashMap iteration order, which made labeled manifest bytes nondeterministic).

## On-disk compatibility

- Existing pointer files, manifest blobs, and previously written config blobs all deserialize unchanged.
- For freshly written content the only differences: JSON key order in CNCF config blobs (semantically identical), and a format-less `llmman build` omitting an empty `"config":{}` object.

## Verification

- `cargo build` — clean
- `cargo test --lib` — 608 passed
- `cargo test --test launch_e2e` — 9 passed
- `cargo test --bin llmman-bench` — 13 passed
- `cargo fmt --all -- --check` — clean
- `cargo clippy --features fuzzing --lib -- -D warnings` — clean
- `cargo check --manifest-path fuzz/Cargo.toml` — clean