### PR TITLE
fix(ci): smoke-test wingetcreate with info, not version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1813,9 +1813,13 @@ jobs:
           Invoke-WebRequest -Uri $url -OutFile wingetcreate.exe
           $got = (Get-FileHash wingetcreate.exe -Algorithm SHA256).Hash
           if ($got -ne $env:WINGETCREATE_SHA256) { throw "wingetcreate.exe sha256 $got != $env:WINGETCREATE_SHA256" }
-          # `version` is a subcommand; `--version` prints help and exits 1.
-          .\wingetcreate.exe version
-          if ($LASTEXITCODE -ne 0) { throw "wingetcreate version failed with exit code $LASTEXITCODE" }
+          # Smoke test. `info` is the only real "print the version" command:
+          # `version` and `help` are listed in the help text by
+          # CommandLineParser but are not registered verbs, so they (like
+          # `--version`) print help and exit 1. `info` also skips the GitHub
+          # client, so it needs no token or network.
+          .\wingetcreate.exe info
+          if ($LASTEXITCODE -ne 0) { throw "wingetcreate info failed with exit code $LASTEXITCODE" }
 
       # WINGET_CREATE_GITHUB_TOKEN is wingetcreate's env var for CI
       # (https://aka.ms/winget-create-token); --token may be logged.


### PR DESCRIPTION
## Summary

The `Publish winget manifest` job fails on every push to `main` (e.g. [run 33988700998](https://github.com/llmmanorg/llmman/actions/runs/33988700998)): the post-download smoke test `wingetcreate.exe version` prints the help screen and exits 1.

## Root cause

In wingetcreate v1.12.13.0, `version` and `help` are only *advertised* in the help text by the CommandLineParser library; they are not registered verbs in [`Program.cs`](https://github.com/microsoft/winget-create/blob/v1.12.13.0/src/WingetCreateCLI/Program.cs). Any unrecognized verb falls through to `DisplayHelp` and `return args.Any() ? 1 : 0`. This is the same trap `--version` hit before #413, which is why that fix did not resolve it.

## Fix

Use `wingetcreate.exe info` instead. `InfoCommand` is a real command that prints the tool version, and it has `AcceptsGitHubToken => false`, so it skips the GitHub client and needs no token or network. The comment is rewritten so nobody re-tries `version`/`--version`.

## Verification

- Workflow YAML parses; `actionlint` reports only a pre-existing, unrelated SC2016 note at line 978 that is also present on `main`.
- This job only runs on `push` to `main` after `release`, so it cannot be exercised from this PR; it will be confirmed on the next push to `main` after merge.
