### PR TITLE
fix(ci): stop launch_e2e's daemon before the vllm-plugin e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1306,6 +1306,50 @@ jobs:
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
 
+      # The step above leaves its shared `llmman serve` daemon (see
+      # tests/launch_e2e.rs) running with qwen3.5:0.8b resident at the
+      # 256k default --ctx-size — several GiB nothing below needs (`llmman
+      # resolve` never talks to the daemon). On a real aarch64 run that
+      # left `vllm serve` only 3.3 of 15.6 GiB, under the KV arena it
+      # demands up front (see test_e2e.py's VLLM_CPU_KVCACHE_SPACE).
+      #
+      # Signals the daemon's process group, which its llama-server shares,
+      # the same way daemon::kill_daemon does: pid from /api/version,
+      # `pkill -f` fallback. Never fails the job: a daemon that never
+      # started (every launch_e2e test skipped) is fine here.
+      - name: Stop the launch_e2e daemon (free RAM for vllm-plugin e2e)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -uo pipefail
+          host="${LLMMAN_HOST:-127.0.0.1:17434}"
+          pid=$(curl -fsS --max-time 5 "http://$host/api/version" 2>/dev/null \
+            | python3 -c 'import json, sys; print(json.load(sys.stdin).get("pid") or "")' 2>/dev/null) || pid=""
+          # Only signal a pid that is numeric and still an llmman process.
+          case "$pid" in ''|*[!0-9]*) pid="" ;; esac
+          if [ -n "$pid" ] && ! ps -o command= -p "$pid" 2>/dev/null | grep -q 'llmman'; then
+            echo "pid $pid from /api/version is not an llmman process; ignoring"
+            pid=""
+          fi
+          if [ -n "$pid" ]; then
+            echo "stopping llmman serve (pid $pid) and its process group"
+            kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+          else
+            echo "no llmman serve daemon at $host; falling back to pkill"
+            pkill -TERM -f 'llmman serve' 2>/dev/null || true
+          fi
+          # A SIGTERM'd process still holds its memory until it has exited.
+          for _ in $(seq 1 30); do
+            pgrep -f 'llmman serve|llama-server' >/dev/null 2>&1 || break
+            sleep 1
+          done
+          if pgrep -f 'llmman serve|llama-server' >/dev/null 2>&1; then
+            echo "::warning::llmman serve/llama-server still alive 30s after SIGTERM; sending SIGKILL"
+            pkill -KILL -f 'llmman serve|llama-server' 2>/dev/null || true
+            sleep 2
+          fi
+          if [ "${{ runner.os }}" = "Linux" ]; then free -m; else vm_stat; fi
+
       # ── vllm-plugin e2e (Linux + macOS) ──────────────────────────────────
       # `vllm-plugin/tests/test_e2e.py` against this job's own installed
       # `llmman` binary and a real `vllm serve` — CPU-only on Linux,

--- a/vllm-plugin/tests/test_e2e.py
+++ b/vllm-plugin/tests/test_e2e.py
@@ -300,9 +300,12 @@ def test_vllm_serve_resolves_and_serves_a_real_oci_reference(tmp_path):
         env.setdefault("VLLM_METAL_MEMORY_FRACTION", "0.8")
     else:
         cmd += ["--dtype", "bfloat16", "--enforce-eager"]
-        # Bounds vLLM CPU's own KV-cache arena, well under its default
-        # sizing heuristic, to avoid OOM on a shared/constrained CI runner.
-        env.setdefault("VLLM_CPU_KVCACHE_SPACE", "4")
+        # vLLM CPU's KV-cache arena, in GiB. A demand, not a cap: the CPU
+        # worker refuses to start unless this much is free right then (a
+        # real aarch64 CI run failed at 4 with only 3.3 GiB left). Unset,
+        # vLLM 0.28 demands 0.9 of total RAM instead. 1 GiB still fits
+        # dozens of --max-model-len 1024 sequences of a 0.8B model.
+        env.setdefault("VLLM_CPU_KVCACHE_SPACE", "1")
 
     log_file = open(log_path, "wb")
     try:


### PR DESCRIPTION
## Failure

[Run 33992445429](https://github.com/llmmanorg/llmman/actions/runs/33992445429) on main, job **E2E — aarch64-unknown-linux-gnu (podman)**, step `pytest -m e2e (vllm-plugin)`:

```
Available memory on node 0 (3.33/15.57 GiB) on kv cache allocation is less than requested memory for kv (4.0 GiB)
```

## Cause

`cargo test --test launch_e2e` spawns a shared `llmman serve` daemon and never stops it. Its serve.log shows llama-server at `n_ctx_slot = 262144` — the 256k default `--ctx-size` from #416 — holding several GiB that nothing later in the job uses (`llmman resolve` never talks to the daemon). vLLM 0.28's CPU worker treats `VLLM_CPU_KVCACHE_SPACE` as a hard "must be free now" demand. The x86_64 leg passed with the same daemon alive, so this is a headroom flake, not a deterministic break.

## Fix (either alone suffices)

1. **ci.yml**: new step after `launch_e2e` that SIGTERMs the daemon's process group (pid from `/api/version`, validated as numeric and an llmman process; `pkill -f` fallback; SIGKILL after 30s), waits for exit, and prints `free -m`/`vm_stat`.
2. **test_e2e.py**: `VLLM_CPU_KVCACHE_SPACE` 4 → 1 GiB. Still fits dozens of `--max-model-len 1024` sequences of a 0.8B model. The old comment claiming 4 was "well under" the default was wrong: unset, vLLM 0.28 demands 0.9 of total RAM.

## Verification

- YAML parses; actionlint/shellcheck clean on the new step.
- Kill-by-pgid, pid parsing and pid validation exercised locally.
- vllm-plugin non-e2e suite: 23 passed, 1 skipped.
- The E2E job only runs on pushes to main, so the step's first real run will be after merge.
