### PR TITLE
Attach image paths in `llmman run` prompts like ollama

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,6 +2027,7 @@ dependencies = [
  "libc",
  "libloading",
  "multer",
+ "regex",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ serde_json = "1"
 sha2       = "0.10"
 hex        = "0.4"
 base64     = "0.22"
+# `llmman run`'s image-path detection is a verbatim port of ollama's
+# extractFileNames regex (cmd/interactive.go) — see cmd::run.
+regex      = "1"
 anyhow     = "1"
 walkdir    = "2"
 chrono     = { version = "0.4", features = ["serde"] }

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -24,11 +24,19 @@
 //! prompt — mirrors `readline.Instance.Readline()`'s own enter/`defer`
 //! restore — which is why Ctrl-C while typing is read as byte 3 (ISIG
 //! off) but Ctrl-C during a response is a real SIGINT (ISIG back on).
+//!
+//! Image attachments are ported from ollama's `cmd/interactive.go`: when
+//! `/api/show` reports `vision`, image/audio paths in the prompt are
+//! read, base64-encoded onto the message's `images`, and removed from
+//! the text.
 
-use std::io::{self, IsTerminal, Write};
+use std::io::{self, IsTerminal, Read, Seek, Write};
+use std::path::Path;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use anyhow::Context;
+use base64::Engine as _;
 use clap::Args;
 use futures::TryStreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -95,6 +103,9 @@ struct ChatOptions<'a> {
     /// `provider_model`), `None` for a local model. Applied as a default
     /// header, not a body field — see `chat_client`.
     api_key: Option<&'a str>,
+    /// Ollama's `runOptions.MultiModal`, from `/api/show`'s capabilities:
+    /// only then is a prompt scanned for image paths.
+    multimodal: bool,
 }
 
 impl Default for ChatOptions<'_> {
@@ -104,6 +115,7 @@ impl Default for ChatOptions<'_> {
             num_predict: None,
             word_wrap: true,
             api_key: None,
+            multimodal: false,
         }
     }
 }
@@ -147,8 +159,12 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
     // validates against, and it forwards the chat upstream.
     crate::daemon::ensure_server("")?;
 
-    let (model, api_key) = match route {
-        Route::Provider(provider) => provider_model(provider, &args.model)?,
+    let (model, api_key, multimodal) = match route {
+        Route::Provider(provider) => {
+            let (model, key) = provider_model(provider, &args.model)?;
+            // /api/show has no capabilities for a provider-routed model.
+            (model, key, false)
+        }
         Route::Local(model) => {
             // Fail fast on a bad/unresolvable reference — mirrors ollama's
             // RunHandler, which resolves (Show, falling back to Pull) the
@@ -156,9 +172,10 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
             // this, an error like an invalid `hf.co/...` reference wouldn't
             // surface until the first message was submitted to /api/chat,
             // well after the `> ` prompt had already been shown and read
-            // from.
-            crate::daemon::ensure_model_pulled(&model)?;
-            (model, None)
+            // from. The same Show also answers ollama's `opts.MultiModal`.
+            let info = crate::daemon::ensure_model_pulled(&model)?;
+            let multimodal = info.multimodal();
+            (model, None, multimodal)
         }
     };
 
@@ -171,6 +188,7 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
         num_predict: args.num_predict,
         word_wrap: !args.nowordwrap,
         api_key: api_key.as_deref(),
+        multimodal,
     };
 
     if interactive {
@@ -256,6 +274,20 @@ struct Msg {
     content: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     thinking: Option<String>,
+    /// Ollama's `api.Message.Images`: standard base64, one per image.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    images: Option<Vec<String>>,
+}
+
+impl Msg {
+    fn text(role: &str, content: String) -> Self {
+        Self {
+            role: role.into(),
+            content,
+            thinking: None,
+            images: None,
+        }
+    }
 }
 
 /// Async, not `reqwest::blocking`, so a chat turn's response can be raced
@@ -302,6 +334,173 @@ struct ChatChunk {
     message: Option<Msg>,
     #[serde(default)]
     done: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Image attachments — ported from ollama's cmd/interactive.go
+// ---------------------------------------------------------------------------
+
+/// Ollama's `normalizeFilePath`: undoes shell escaping from a drag-and-drop
+/// (`My\ Photo.jpg` → `My Photo.jpg`). Same table and order as its
+/// `strings.NewReplacer`.
+fn normalize_file_path(fp: &str) -> String {
+    const PAIRS: &[(&str, &str)] = &[
+        ("\\ ", " "),
+        ("\\(", "("),
+        ("\\)", ")"),
+        ("\\[", "["),
+        ("\\]", "]"),
+        ("\\{", "{"),
+        ("\\}", "}"),
+        ("\\$", "$"),
+        ("\\&", "&"),
+        ("\\;", ";"),
+        ("\\'", "'"),
+        ("\\\\", "\\"),
+        ("\\*", "*"),
+        ("\\?", "?"),
+        ("\\~", "~"),
+    ];
+    let mut out = String::with_capacity(fp.len());
+    let mut rest = fp;
+    'outer: while !rest.is_empty() {
+        for (from, to) in PAIRS {
+            if let Some(tail) = rest.strip_prefix(from) {
+                out.push_str(to);
+                rest = tail;
+                continue 'outer;
+            }
+        }
+        let ch = rest.chars().next().expect("non-empty");
+        out.push(ch);
+        rest = &rest[ch.len_utf8()..];
+    }
+    out
+}
+
+/// Ollama's `extractFileNames`, regex verbatim. Over-matches on purpose;
+/// `extract_file_data` drops anything that isn't a real file.
+fn extract_file_names(input: &str) -> Vec<&str> {
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        regex::Regex::new(r"(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b")
+            .expect("valid regex")
+    });
+    re.find_iter(input).map(|m| m.as_str()).collect()
+}
+
+/// Ollama's `extractFileData`: base64-encodes every existing image/audio
+/// file named in `input` and strips the paths (and surrounding single
+/// quotes) from the text. A missing path is left in place; an existing
+/// file of an unsupported type is an error.
+fn extract_file_data(input: &str) -> anyhow::Result<(String, Vec<String>)> {
+    let mut out = input.to_string();
+    let mut imgs = Vec::new();
+
+    for fp in extract_file_names(input) {
+        let nfp = normalize_file_path(fp);
+        let data = match get_image_data(&nfp) {
+            Ok(data) => data,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                eprintln!("Couldn't process file: {:?}", e.to_string());
+                return Err(e.into());
+            }
+        };
+        let ext = Path::new(&nfp)
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_lowercase())
+            .unwrap_or_default();
+        match ext.as_str() {
+            "wav" => eprintln!("Added audio '{nfp}'"),
+            _ => eprintln!("Added image '{nfp}'"),
+        }
+        out = out.replace(&format!("'{nfp}'"), "");
+        out = out.replace(&format!("'{fp}'"), "");
+        out = out.replace(fp, "");
+        imgs.push(base64::engine::general_purpose::STANDARD.encode(&data));
+    }
+    Ok((out.trim().to_string(), imgs))
+}
+
+/// Ollama's `getImageData`: sniff the first 512 bytes, cap at 100MB, then
+/// read exactly the stat'd size (its `io.ReadFull` into a sized buffer).
+fn get_image_data(file_path: &str) -> io::Result<Vec<u8>> {
+    let mut file = std::fs::File::open(file_path)?;
+
+    let mut buf = [0u8; 512];
+    if file.read(&mut buf)? == 0 {
+        // Go's Read on an empty file is io.EOF: an error, not a skip.
+        return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "EOF"));
+    }
+
+    let content_type = detect_content_type(&buf);
+    const ALLOWED: &[&str] = &[
+        "image/jpeg",
+        "image/jpg",
+        "image/png",
+        "image/webp",
+        "audio/wave",
+    ];
+    if !ALLOWED.contains(&content_type) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid file type: {content_type}"),
+        ));
+    }
+
+    let size = file.metadata()?.len();
+    const MAX_SIZE: u64 = 100 * 1024 * 1024;
+    if size > MAX_SIZE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "file size exceeds maximum limit (100MB)",
+        ));
+    }
+
+    let mut data = Vec::with_capacity(size as usize);
+    file.seek(io::SeekFrom::Start(0))?;
+    file.take(size).read_to_end(&mut data)?;
+    if data.len() as u64 != size {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "unexpected EOF",
+        ));
+    }
+    Ok(data)
+}
+
+/// The cases of Go's `http.DetectContentType` that `get_image_data` can
+/// accept; everything else is the sniffer's `application/octet-stream`.
+fn detect_content_type(data: &[u8]) -> &'static str {
+    fn masked(data: &[u8], mask: &[u8], pat: &[u8]) -> bool {
+        data.len() >= pat.len()
+            && data
+                .iter()
+                .zip(mask)
+                .zip(pat)
+                .all(|((d, m), p)| d & m == *p)
+    }
+    if data.starts_with(b"\xFF\xD8\xFF") {
+        "image/jpeg"
+    } else if data.starts_with(b"\x89PNG\x0D\x0A\x1A\x0A") {
+        "image/png"
+    } else if masked(
+        data,
+        b"\xFF\xFF\xFF\xFF\x00\x00\x00\x00\xFF\xFF\xFF\xFF\xFF\xFF",
+        b"RIFF\x00\x00\x00\x00WEBPVP",
+    ) {
+        "image/webp"
+    } else if masked(
+        data,
+        b"\xFF\xFF\xFF\xFF\x00\x00\x00\x00\xFF\xFF\xFF\xFF",
+        b"RIFF\x00\x00\x00\x00WAVE",
+    ) {
+        "audio/wave"
+    } else {
+        "application/octet-stream"
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -552,8 +751,18 @@ fn run_interactive_unix(model: &str, opts: ChatOptions<'_>) -> anyhow::Result<()
                 continue;
             }
             s if s.starts_with('/') => {
-                eprintln!("Commands: /bye  /clear  \"\"\" (multiline)");
-                continue;
+                // Ollama: a line starting with an image path is a prompt,
+                // not an unknown command, when the model is multimodal.
+                let first_word = s.split_whitespace().next().unwrap_or(s);
+                let is_file = opts.multimodal
+                    && extract_file_names(s)
+                        .iter()
+                        .any(|f| f.starts_with(first_word));
+                if !is_file {
+                    eprintln!("Unknown command '{first_word}'.");
+                    eprintln!("Commands: /bye  /clear  \"\"\" (multiline)");
+                    continue;
+                }
             }
             _ => {}
         }
@@ -629,11 +838,17 @@ async fn chat_submit_async(
     content: String,
     opts: ChatOptions<'_>,
 ) -> anyhow::Result<()> {
-    messages.push(Msg {
-        role: "user".into(),
-        content,
-        thinking: None,
-    });
+    // Ollama: `if opts.MultiModal { ... extractFileData(opts.Prompt) }`.
+    // A non-vision model gets the path as plain text, as there.
+    let mut user = Msg::text("user", content);
+    if opts.multimodal {
+        let (text, images) = extract_file_data(&user.content)?;
+        user.content = text;
+        if !images.is_empty() {
+            user.images = Some(images);
+        }
+    }
+    messages.push(user);
 
     // Mirrors ollama's `progress.NewSpinner("")`: ticks on stderr until
     // the first token/thinking chunk arrives, so `llmman run` doesn't sit
@@ -745,11 +960,7 @@ async fn chat_submit_async(
     }
 
     println!("\n");
-    messages.push(Msg {
-        role: "assistant".into(),
-        content: full,
-        thinking: None,
-    });
+    messages.push(Msg::text("assistant", full));
     Ok(())
 }
 
@@ -1082,6 +1293,188 @@ mod tests {
         assert_eq!(opts.think, None);
         assert_eq!(opts.num_predict, None);
         assert!(opts.word_wrap);
+        assert!(!opts.multimodal);
+    }
+
+    // -- image attachments: ports of ollama's cmd/interactive_test.go ------
+
+    /// Ollama's `TestExtractFilenames`, unix-style half.
+    #[test]
+    fn extract_file_names_unix_style_paths() {
+        let input = " some preamble \n \
+./relative\\ path/one.png inbetween1 ./not a valid two.jpg inbetween2 ./1.svg\n\
+/unescaped space /three.jpeg inbetween3 /valid\\ path/dir/four.png \"./quoted with spaces/five.JPG\n\
+/unescaped space /six.webp inbetween6 /valid\\ path/dir/seven.WEBP";
+        let res = extract_file_names(input);
+        assert_eq!(res.len(), 7, "{res:?}");
+        assert!(res[0].contains("one.png"));
+        assert!(res[1].contains("two.jpg"));
+        assert!(res[2].contains("three.jpeg"));
+        assert!(res[3].contains("four.png"));
+        assert!(res[4].contains("five.JPG"));
+        assert!(res[5].contains("six.webp"));
+        assert!(res[6].contains("seven.WEBP"));
+        assert!(!res[4].contains('"'));
+        assert!(!res.contains(&"inbetween1"));
+        assert!(!res.contains(&"./1.svg"));
+    }
+
+    /// Ollama's `TestExtractFilenames`, windows-style half.
+    #[test]
+    fn extract_file_names_windows_style_paths() {
+        let input = " some preamble\n \
+c:/users/jdoe/one.png inbetween1 c:/program files/someplace/two.jpg inbetween2 \n \
+/absolute/nospace/three.jpeg inbetween3 /absolute/with space/four.png inbetween4\n\
+./relative\\ path/five.JPG inbetween5 \"./relative with/spaces/six.png inbetween6\n\
+d:\\path with\\spaces\\seven.JPEG inbetween7 c:\\users\\jdoe\\eight.png inbetween8 \n \
+d:\\program files\\someplace\\nine.png inbetween9 \"E:\\program files\\someplace\\ten.PNG\n\
+c:/users/jdoe/eleven.webp inbetween11 c:/program files/someplace/twelve.WebP inbetween12\n\
+d:\\path with\\spaces\\thirteen.WEBP some ending\n";
+        let res = extract_file_names(input);
+        assert_eq!(res.len(), 13, "{res:?}");
+        assert!(!res.contains(&"inbetween2"));
+        assert!(res[0].contains("one.png") && res[0].contains("c:"));
+        assert!(res[1].contains("two.jpg") && res[1].contains("c:"));
+        assert!(res[2].contains("three.jpeg"));
+        assert!(res[3].contains("four.png"));
+        assert!(res[4].contains("five.JPG"));
+        assert!(res[5].contains("six.png"));
+        assert!(res[6].contains("seven.JPEG") && res[6].contains("d:"));
+        assert!(res[7].contains("eight.png") && res[7].contains("c:"));
+        assert!(res[8].contains("nine.png") && res[8].contains("d:"));
+        assert!(res[9].contains("ten.PNG") && res[9].contains("E:"));
+        assert!(res[10].contains("eleven.webp") && res[10].contains("c:"));
+        assert!(res[11].contains("twelve.WebP") && res[11].contains("c:"));
+        assert!(res[12].contains("thirteen.WEBP") && res[12].contains("d:"));
+    }
+
+    #[test]
+    fn normalize_file_path_undoes_shell_escapes() {
+        assert_eq!(
+            normalize_file_path("/My\\ Photos/a\\(1\\)\\[x\\]\\{y\\}\\$\\&\\;\\'\\*\\?\\~.png"),
+            "/My Photos/a(1)[x]{y}$&;'*?~.png"
+        );
+        assert_eq!(normalize_file_path("a\\\\b"), "a\\b");
+        assert_eq!(normalize_file_path("/plain/path.jpg"), "/plain/path.jpg");
+    }
+
+    #[test]
+    fn detect_content_type_matches_gos_sniffer_for_the_allowed_types() {
+        assert_eq!(
+            detect_content_type(b"\xFF\xD8\xFF\xE0\x00\x10JFIF"),
+            "image/jpeg"
+        );
+        assert_eq!(
+            detect_content_type(b"\x89PNG\x0D\x0A\x1A\x0A\x00\x00\x00\x0DIHDR"),
+            "image/png"
+        );
+        assert_eq!(
+            detect_content_type(b"RIFF\x24\x00\x00\x00WEBPVP8 "),
+            "image/webp"
+        );
+        assert_eq!(
+            detect_content_type(b"RIFF\x58\x02\x00\x00WAVEfmt "),
+            "audio/wave"
+        );
+        assert_eq!(detect_content_type(b"GIF89a"), "application/octet-stream");
+        assert_eq!(detect_content_type(b"hello"), "application/octet-stream");
+        assert_eq!(detect_content_type(b"RIFF"), "application/octet-stream");
+    }
+
+    fn temp_file(name: &str, data: &[u8]) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "llmman-run-img-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let fp = dir.join(name);
+        std::fs::write(&fp, data).unwrap();
+        fp
+    }
+
+    fn jpeg_bytes() -> Vec<u8> {
+        let mut data = vec![0u8; 600];
+        data[..22].copy_from_slice(&[
+            0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, b'J', b'F', b'I', b'F', 0x00, 0x01, 0x01, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xd9,
+        ]);
+        data
+    }
+
+    /// Ollama's `TestExtractFileDataRemovesQuotedFilepath`.
+    #[test]
+    fn extract_file_data_removes_quoted_filepath() {
+        let fp = temp_file("img.jpg", &jpeg_bytes());
+        let input = format!("before '{}' after", fp.display());
+        let (cleaned, imgs) = extract_file_data(&input).unwrap();
+        assert_eq!(imgs.len(), 1);
+        assert_eq!(cleaned, "before  after");
+    }
+
+    /// Ollama's `TestExtractFileDataWAV`.
+    #[test]
+    fn extract_file_data_wav() {
+        let mut data = vec![0u8; 600];
+        data[..44].copy_from_slice(&[
+            b'R', b'I', b'F', b'F', //
+            0x58, 0x02, 0x00, 0x00, // file size - 8
+            b'W', b'A', b'V', b'E', //
+            b'f', b'm', b't', b' ', //
+            0x10, 0x00, 0x00, 0x00, // fmt chunk size
+            0x01, 0x00, // PCM
+            0x01, 0x00, // mono
+            0x80, 0x3e, 0x00, 0x00, // 16000 Hz
+            0x00, 0x7d, 0x00, 0x00, // byte rate
+            0x02, 0x00, // block align
+            0x10, 0x00, // 16-bit
+            b'd', b'a', b't', b'a', //
+            0x34, 0x02, 0x00, 0x00, // data size
+        ]);
+        let fp = temp_file("sample.wav", &data);
+        let input = format!("before {} after", fp.display());
+        let (cleaned, imgs) = extract_file_data(&input).unwrap();
+        assert_eq!(imgs.len(), 1);
+        assert_eq!(cleaned, "before  after");
+    }
+
+    #[test]
+    fn extract_file_data_encodes_the_file_as_standard_base64() {
+        let bytes = jpeg_bytes();
+        let fp = temp_file("img.jpg", &bytes);
+        let (_, imgs) = extract_file_data(&format!("look: {}", fp.display())).unwrap();
+        assert_eq!(
+            imgs,
+            vec![base64::engine::general_purpose::STANDARD.encode(&bytes)]
+        );
+    }
+
+    #[test]
+    fn extract_file_data_leaves_a_nonexistent_path_in_the_prompt() {
+        let input = "what is in /definitely/not/here.png then";
+        let (cleaned, imgs) = extract_file_data(input).unwrap();
+        assert!(imgs.is_empty());
+        assert_eq!(cleaned, input);
+    }
+
+    #[test]
+    fn extract_file_data_rejects_an_existing_file_of_the_wrong_type() {
+        let fp = temp_file("fake.png", b"this is not a png at all, just text");
+        let err = extract_file_data(&format!("see {}", fp.display())).unwrap_err();
+        assert!(err.to_string().contains("invalid file type"), "{err:#}");
+    }
+
+    #[test]
+    fn msg_images_is_omitted_from_json_when_none() {
+        let json = serde_json::to_string(&Msg::text("user", "hi".into())).unwrap();
+        assert_eq!(json, r#"{"role":"user","content":"hi"}"#);
+        let mut with = Msg::text("user", "hi".into());
+        with.images = Some(vec!["QUJD".into()]);
+        let json = serde_json::to_string(&with).unwrap();
+        assert_eq!(json, r#"{"role":"user","content":"hi","images":["QUJD"]}"#);
     }
 
     #[test]

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -1049,6 +1049,9 @@ struct OllamaShowRequest {
 struct OllamaShowResponse {
     model_info: serde_json::Value,
     details: OllamaModelDetails,
+    /// Ollama's `api.ShowResponse.Capabilities`; see
+    /// `crate::modelpack::capabilities`.
+    capabilities: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1289,10 +1292,19 @@ fn ollama_message_to_oai(m: &OllamaMessage) -> OAIMessage {
                 parts.push(serde_json::json!({ "type": "text", "text": m.content }));
             }
             for image in images {
-                parts.push(serde_json::json!({
-                    "type": "image_url",
-                    "image_url": { "url": image_data_uri(image) }
-                }));
+                // Ollama's `images` also carries audio; llama-server
+                // wants that as `input_audio`, not `image_url`.
+                if is_wav_base64(image) {
+                    parts.push(serde_json::json!({
+                        "type": "input_audio",
+                        "input_audio": { "data": image, "format": "wav" }
+                    }));
+                } else {
+                    parts.push(serde_json::json!({
+                        "type": "image_url",
+                        "image_url": { "url": image_data_uri(image) }
+                    }));
+                }
             }
             serde_json::Value::Array(parts)
         }
@@ -1339,6 +1351,18 @@ fn image_data_uri(base64_bytes: &str) -> String {
     } else {
         format!("data:image/png;base64,{base64_bytes}")
     }
+}
+
+/// True if bare base64 decodes to a RIFF/WAVE header (16 chars = 12 bytes).
+fn is_wav_base64(base64_bytes: &str) -> bool {
+    use base64::Engine as _;
+    let Some(head) = base64_bytes.get(..16) else {
+        return false;
+    };
+    base64::engine::general_purpose::STANDARD
+        .decode(head)
+        .map(|b| b.starts_with(b"RIFF") && b[8..].starts_with(b"WAVE"))
+        .unwrap_or(false)
 }
 
 #[derive(Debug, Serialize, Default)]
@@ -5040,7 +5064,7 @@ async fn handle_show(
         .unwrap_or(&req.model);
     // A provider-routed model is served by someone else and is never in
     // the local store, so the lookup below would report it missing and
-    // send every caller that treats a 500 here as "needs pulling" — most
+    // send every caller that treats a 404 here as "needs pulling" — most
     // of all `daemon::ensure_model_pulled`, which `llmman launch` and
     // `llmman run` both call before their first request — off to pull a
     // reference that names no registry. Answer for it directly instead.
@@ -5057,6 +5081,8 @@ async fn handle_show(
                 parameter_size: String::new(),
                 quantization_level: String::new(),
             },
+            // Nothing local to inspect.
+            capabilities: Vec::new(),
         }));
     }
     // Resolve the same way handle_pull stored it — otherwise a bare name
@@ -5067,12 +5093,20 @@ async fn handle_show(
     let model_ref = model_ref.as_str();
     eprintln!("[llmman] /api/show model={model_ref:?}");
     let store = OciStore::open(&state.0.store_path)?;
-    let desc = store.find(model_ref).map_err(|_| {
-        AppError(
-            anyhow!("model not found: {model_ref}"),
-            StatusCode::INTERNAL_SERVER_ERROR,
-        )
+    // 404 like ollama (`showOrPullModel` pulls only on not-found); a
+    // broken store entry stays a 500.
+    let desc = store.find(model_ref).map_err(|e| {
+        if e.downcast_ref::<crate::storage::oci::NotFound>().is_some() {
+            AppError::status(
+                StatusCode::NOT_FOUND,
+                format!("model not found: {model_ref}"),
+            )
+        } else {
+            AppError::from(e)
+        }
     })?;
+    let manifest = store.read_manifest(&desc.digest)?;
+    let capabilities = crate::modelpack::capabilities(&store, &manifest);
     Ok(Json(OllamaShowResponse {
         model_info: serde_json::json!({ "digest": desc.digest, "size": desc.size }),
         details: OllamaModelDetails {
@@ -5081,6 +5115,7 @@ async fn handle_show(
             parameter_size: String::new(),
             quantization_level: String::new(),
         },
+        capabilities,
     }))
 }
 
@@ -8795,6 +8830,30 @@ mod tests {
     }
 
     #[test]
+    fn ollama_message_to_oai_sends_wav_as_input_audio() {
+        use base64::Engine as _;
+        let mut wav = b"RIFF\x58\x02\x00\x00WAVEfmt ".to_vec();
+        wav.resize(64, 0);
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&wav);
+        let m = OllamaMessage {
+            role: "user".into(),
+            content: "transcribe".into(),
+            images: Some(vec![b64.clone()]),
+            ..Default::default()
+        };
+        let oai = ollama_message_to_oai(&m);
+        assert_eq!(
+            oai.content,
+            serde_json::json!([
+                { "type": "text", "text": "transcribe" },
+                { "type": "input_audio", "input_audio": { "data": b64, "format": "wav" } }
+            ])
+        );
+        assert!(!is_wav_base64("Zm9v"));
+        assert!(!is_wav_base64("data:image/png;base64,Zm9v"));
+    }
+
+    #[test]
     fn image_data_uri_wraps_bare_base64_and_passes_through_existing_data_uris() {
         assert_eq!(image_data_uri("Zm9v"), "data:image/png;base64,Zm9v");
         assert_eq!(
@@ -11878,6 +11937,17 @@ mod tests {
         };
         let resp = handle_show(State(state), Json(req)).await.into_response();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn handle_show_answers_404_for_a_model_not_in_the_store() {
+        let state = test_state();
+        let req = OllamaShowRequest {
+            model: "docker.io/ai/nothing-here".to_string(),
+            name: None,
+        };
+        let resp = handle_show(State(state), Json(req)).await.into_response();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
     /// Regression: a call site that drops its guard but not its own `Arc`

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -997,33 +997,56 @@ pub fn stream_progress_with(path: &str, reference: &str) -> anyhow::Result<Optio
     Ok(pushed_digest)
 }
 
-/// POSTs `{"model": reference}` to `/api/show` and reports whether the
-/// daemon's local store already has it — a read-only existence check with
-/// no download/pull side effects.
-fn model_exists(reference: &str) -> anyhow::Result<bool> {
+/// The part of Ollama's `api.ShowResponse` that `llmman run` reads.
+#[derive(Debug, Default, Deserialize)]
+pub struct ShowResponse {
+    /// `"completion"`, `"vision"`, … — see `crate::modelpack::capabilities`.
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+}
+
+impl ShowResponse {
+    /// Ollama's `RunHandler`: `opts.MultiModal` = vision or audio.
+    pub fn multimodal(&self) -> bool {
+        self.capabilities
+            .iter()
+            .any(|c| c == crate::modelpack::CAPABILITY_VISION || c == "audio")
+    }
+}
+
+/// Ollama's `client.Show`: a read-only `/api/show` lookup. `Ok(None)` is
+/// a 404 only; any other failure is an error, as in `showOrPullModel`.
+pub fn show(reference: &str) -> anyhow::Result<Option<ShowResponse>> {
     let resp = reqwest::blocking::Client::new()
         .post(format!("{}/api/show", server()))
         .json(&serde_json::json!({"model": reference}))
         .send()
         .with_context(|| format!("request /api/show for {reference}"))?;
-    Ok(resp.status().is_success())
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    if !resp.status().is_success() {
+        let body = resp.text().unwrap_or_default();
+        anyhow::bail!("{}", api_error(&body).unwrap_or(body));
+    }
+    // An older daemon omits `capabilities`; serde(default) handles it.
+    let body = resp
+        .json::<ShowResponse>()
+        .with_context(|| format!("decode /api/show for {reference}"))?;
+    Ok(Some(body))
 }
 
-/// Ensures `reference` is present in the daemon's local store, pulling it
-/// (and streaming progress the same way `llmman pull` does) if it isn't.
+/// Ensures `reference` is in the daemon's local store, pulling it (with
+/// `llmman pull`'s progress) if not, and returns its `/api/show` info.
 ///
-/// Mirrors ollama's `RunHandler`, which calls `client.Show` before ever
-/// entering the interactive/one-shot prompt loop and only falls back to
-/// `PullHandler` on a miss — so a bad reference (typo'd tag, malformed
-/// `hf.co/...` name, etc.) is reported and aborts the command immediately,
-/// instead of only surfacing once the first message is submitted to
-/// `/api/chat` (by which point the interactive `> ` prompt has already
-/// been shown and read from).
-pub fn ensure_model_pulled(reference: &str) -> anyhow::Result<()> {
-    if model_exists(reference).unwrap_or(false) {
-        return Ok(());
+/// Mirrors ollama's `showOrPullModel`: Show, Pull on a 404, Show again —
+/// so a bad reference fails before the prompt loop.
+pub fn ensure_model_pulled(reference: &str) -> anyhow::Result<ShowResponse> {
+    if let Some(info) = show(reference)? {
+        return Ok(info);
     }
-    stream_progress("/api/pull", reference)
+    stream_progress("/api/pull", reference)?;
+    show(reference)?.ok_or_else(|| anyhow::anyhow!("{reference}: not found after pull"))
 }
 
 /// Pushes `reference` via the daemon's `/api/push` and returns the

--- a/src/modelpack.rs
+++ b/src/modelpack.rs
@@ -182,6 +182,67 @@ fn extract_gguf_layer(
     Err(anyhow!("no .gguf in tar layer {}", layer.digest))
 }
 
+/// Ollama's `model.Capability` values reported in `/api/show`'s
+/// `capabilities` array (`ollama run` reads them to set `opts.MultiModal`).
+pub const CAPABILITY_COMPLETION: &str = "completion";
+pub const CAPABILITY_VISION: &str = "vision";
+
+/// The part of ollama's `Model.Capabilities()` (server/images.go) a
+/// manifest alone can answer, without extracting or opening a GGUF:
+/// `"completion"` always, plus `"vision"` when a companion mmproj layer
+/// is present (`projectorCapabilities`) or the CNCF config's
+/// `config.capabilities.inputTypes` lists `"image"` (`configCapabilities`).
+pub fn capabilities(store: &OciStore, manifest: &crate::storage::oci::Manifest) -> Vec<String> {
+    let mut caps = vec![CAPABILITY_COMPLETION.to_string()];
+
+    let has_mmproj = gguf_layers(manifest).is_some_and(|(_, mmproj)| mmproj.is_some());
+
+    // Shape written by crate::hf::oci::build_cncf_manifest.
+    let config_says_image = store
+        .read_blob(&manifest.config.digest)
+        .ok()
+        .and_then(|b| serde_json::from_slice::<serde_json::Value>(&b).ok())
+        .and_then(|v| {
+            v.get("config")?
+                .get("capabilities")?
+                .get("inputTypes")?
+                .as_array()
+                .map(|a| a.iter().any(|t| t.as_str() == Some("image")))
+        })
+        .unwrap_or(false);
+
+    if has_mmproj || config_says_image {
+        caps.push(CAPABILITY_VISION.to_string());
+    }
+    caps
+}
+
+/// The manifest's primary GGUF layer and its companion mmproj layer, if
+/// any. Prefers a non-mmproj-named layer as primary so an mmproj file
+/// that sorts first isn't taken for the model; falls back to the first
+/// layer if every one looks like mmproj.
+fn gguf_layers(
+    manifest: &crate::storage::oci::Manifest,
+) -> Option<(
+    &crate::storage::oci::Descriptor,
+    Option<&crate::storage::oci::Descriptor>,
+)> {
+    let layers: Vec<&crate::storage::oci::Descriptor> = manifest
+        .layers
+        .iter()
+        .filter(|l| is_gguf_layer(l))
+        .collect();
+    let primary = *layers
+        .iter()
+        .find(|l| !is_mmproj_layer(l))
+        .or(layers.first())?;
+    let mmproj = layers
+        .iter()
+        .copied()
+        .find(|l| is_mmproj_layer(l) && l.digest != primary.digest);
+    Some((primary, mmproj))
+}
+
 /// Resolve `model_ref` (already present in the `OciStore` at `store_path`)
 /// to either a `.gguf` file or an extracted safetensors directory, caching
 /// any extraction under `cache_path`.
@@ -197,25 +258,7 @@ pub fn resolve_model(
     let manifest = store.read_manifest(&desc.digest)?;
 
     // ── GGUF → llama-server ────────────────────────────────────────────────
-    let gguf_layers: Vec<&crate::storage::oci::Descriptor> = manifest
-        .layers
-        .iter()
-        .filter(|l| is_gguf_layer(l))
-        .collect();
-    if !gguf_layers.is_empty() {
-        // Prefer a non-mmproj-named layer as the primary model, so an
-        // mmproj file that happens to sort first (e.g. "mmproj-F16.gguf"
-        // before "model-Q4_K_M.gguf") isn't picked as the model itself.
-        // Falls back to the first layer if every one looks like mmproj.
-        let primary = *gguf_layers
-            .iter()
-            .find(|l| !is_mmproj_layer(l))
-            .unwrap_or(&gguf_layers[0]);
-        let mmproj = gguf_layers
-            .iter()
-            .copied()
-            .find(|l| is_mmproj_layer(l) && l.digest != primary.digest);
-
+    if let Some((primary, mmproj)) = gguf_layers(&manifest) {
         let primary_path = extract_gguf_layer(&store, store_path, cache_path, primary)?;
         let mmproj_path = mmproj
             .map(|l| extract_gguf_layer(&store, store_path, cache_path, l))
@@ -376,6 +419,89 @@ mod tests {
             "sha256:c",
             "model.Q4_K_M.gguf"
         )));
+    }
+
+    fn manifest_with(
+        layers: Vec<crate::storage::oci::Descriptor>,
+    ) -> (OciStore, crate::storage::oci::Manifest) {
+        let dir = std::env::temp_dir().join(format!(
+            "llmman-modelpack-caps-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let store = OciStore::open(&dir).unwrap();
+        let config = store
+            .write_blob("application/vnd.cncf.model.config.v1+json", b"{}")
+            .unwrap();
+        let manifest = crate::storage::oci::Manifest {
+            schema_version: 2,
+            media_type: "application/vnd.oci.image.manifest.v1+json".into(),
+            artifact_type: None,
+            config,
+            layers,
+            annotations: None,
+        };
+        (store, manifest)
+    }
+
+    #[test]
+    fn capabilities_is_completion_only_without_a_projector() {
+        let (store, m) = manifest_with(vec![descriptor("sha256:a", "model.Q4_K_M.gguf")]);
+        assert_eq!(capabilities(&store, &m), vec!["completion"]);
+    }
+
+    #[test]
+    fn capabilities_adds_vision_when_a_companion_mmproj_layer_is_present() {
+        // Mirrors ollama's projectorCapabilities: any projector ⇒ vision.
+        let (store, m) = manifest_with(vec![
+            descriptor("sha256:a", "mmproj-F16.gguf"),
+            descriptor("sha256:b", "model.Q4_K_M.gguf"),
+        ]);
+        assert_eq!(capabilities(&store, &m), vec!["completion", "vision"]);
+    }
+
+    #[test]
+    fn capabilities_a_lone_mmproj_named_gguf_is_the_model_not_a_projector() {
+        let (store, m) = manifest_with(vec![descriptor("sha256:a", "mmproj-only.gguf")]);
+        assert_eq!(capabilities(&store, &m), vec!["completion"]);
+    }
+
+    #[test]
+    fn capabilities_two_mmproj_named_ggufs_load_with_a_projector_so_report_vision() {
+        // resolve_model's fallback: first is primary, second is its mmproj.
+        let (store, m) = manifest_with(vec![
+            descriptor("sha256:a", "mmproj-model.gguf"),
+            descriptor("sha256:b", "mmproj-F16.gguf"),
+        ]);
+        assert_eq!(capabilities(&store, &m), vec!["completion", "vision"]);
+    }
+
+    #[test]
+    fn capabilities_honours_cncf_config_input_types_image() {
+        // The exact shape hf::oci::build_cncf_manifest writes.
+        let (store, mut m) = manifest_with(vec![descriptor("sha256:a", "model.gguf")]);
+        m.config = store
+            .write_blob(
+                "application/vnd.cncf.model.config.v1+json",
+                br#"{"descriptor":{},"modelfs":{"type":"layers","diffIds":[]},"config":{"format":"gguf","capabilities":{"inputTypes":["text","image"],"outputTypes":["text"]}}}"#,
+            )
+            .unwrap();
+        assert_eq!(capabilities(&store, &m), vec!["completion", "vision"]);
+    }
+
+    #[test]
+    fn capabilities_ignores_input_types_at_the_document_root() {
+        let (store, mut m) = manifest_with(vec![descriptor("sha256:a", "model.gguf")]);
+        m.config = store
+            .write_blob(
+                "application/vnd.cncf.model.config.v1+json",
+                br#"{"capabilities":{"inputTypes":["text","image"]}}"#,
+            )
+            .unwrap();
+        assert_eq!(capabilities(&store, &m), vec!["completion"]);
     }
 
     #[test]

--- a/src/storage/oci.rs
+++ b/src/storage/oci.rs
@@ -96,6 +96,19 @@ pub struct CncfModelConfig {
     pub modelfs: CncfModelFs,
 }
 
+/// `find`'s "no such reference" error, distinct from a broken store so
+/// callers (e.g. `/api/show`) can answer 404 for one and 500 for the other.
+#[derive(Debug)]
+pub struct NotFound(pub String);
+
+impl std::fmt::Display for NotFound {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "image not found: {}", self.0)
+    }
+}
+
+impl std::error::Error for NotFound {}
+
 /// Summary of a locally stored image shown by `list`.
 #[derive(Debug)]
 pub struct ImageSummary {
@@ -358,7 +371,7 @@ impl OciStore {
         let refs = self.list_refs();
         matching_index(&refs, reference)
             .map(|i| refs[i].clone())
-            .ok_or_else(|| anyhow!("image not found: {}", reference))
+            .ok_or_else(|| NotFound(reference.to_string()).into())
     }
 
     /// The real total size of an image: the sum of its layer sizes, not


### PR DESCRIPTION
`llmman run gemma4:e4b "Describe this image: /path/cat.jpg"` sent the path as text, so vision models never saw the image. The server already accepted Ollama's `images` on `/api/chat`; the CLI never populated it.

## Changes

- **`run.rs`**: ports ollama's `cmd/interactive.go` — `extractFileNames` (regex verbatim), `normalizeFilePath`, `getImageData`, `extractFileData`. Runs only when the model is multimodal, like ollama's `opts.MultiModal`.
- **`serve.rs`, `modelpack.rs`, `oci.rs`**: `/api/show` returns ollama's `capabilities` (`completion`, plus `vision` from an mmproj layer or the CNCF config's `inputTypes`), 404s a missing model (typed `NotFound`; a broken store entry stays 500). A WAV in `images` is sent to llama-server as `input_audio`.
- **`daemon.rs`**: `ensure_model_pulled` mirrors ollama's `showOrPullModel` — Show, Pull only on 404, Show — and returns the capabilities.
- **`Cargo.toml`**: adds `regex`.

## Verification

```
$ llmman run gemma4:e4b --think false "Describe this image in one sentence: /Users/ecurtin/Downloads/unlivable.jpg"
Added image '/Users/ecurtin/Downloads/unlivable.jpg'
This three-panel meme, a parody of *The Lion King*, depicts Simba ...

$ curl -s -XPOST localhost:17434/api/show -d '{"model":"gemma4:e4b"}' | jq -c .capabilities
["completion","vision"]
$ curl -s -o /dev/null -w '%{http_code}' -XPOST localhost:17434/api/show -d '{"model":"docker.io/ai/nope"}'
404
```

Tests port ollama's `TestExtractFilenames`, `TestExtractFileDataRemovesQuotedFilepath`, `TestExtractFileDataWAV`, plus the helpers, `modelpack::capabilities`, the 404, and WAV → `input_audio`. fmt, clippy `-D warnings`, `cargo test --lib --bins` pass.

Not addressed: `embedding` for embedding GGUFs needs GGUF metadata parsing (ollama reads `pooling_type`); out of scope, doesn't affect `run`.

Restart `llmman serve` after upgrading: an older daemon reports no capabilities, so paths stay as text.
