### PR TITLE
Consolidate small duplicated helpers across modules

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -262,6 +262,19 @@ pub struct LlamaOptions<'a> {
     pub threads: Option<u32>,
 }
 
+/// Appends `-e VAR=val` to `args` for every name in `vars` that is set in
+/// this process's environment, so `docker run`/`podman run` (which does
+/// not inherit the host environment on its own) forwards it into the
+/// container. Silently skips a name that isn't set.
+fn forward_env_vars(args: &mut Vec<String>, vars: &[&str]) {
+    for var in vars {
+        if let Ok(val) = std::env::var(var) {
+            args.push("-e".into());
+            args.push(format!("{var}={val}"));
+        }
+    }
+}
+
 /// Callers must stop this gracefully (SIGTERM, not the default
 /// `Child::kill()`/`kill_on_drop`, which sends SIGKILL) — see
 /// `cmd::serve::ModelProcess`'s Drop impl. SIGKILL cannot be caught or
@@ -347,21 +360,10 @@ pub fn spawn(
     // own — forward the same GPU device-selection vars Ollama documents
     // (see cmd::serve::GPU_VISIBLE_DEVICE_VARS) so `GGML_VK_VISIBLE_DEVICES=1`
     // etc. set on the host actually reaches llama-server inside the
-    // container too.
-    for var in crate::cmd::serve::GPU_VISIBLE_DEVICE_VARS {
-        if let Ok(val) = std::env::var(var) {
-            args.push("-e".into());
-            args.push(format!("{var}={val}"));
-        }
-    }
-    // Same as above, for llama.cpp's own env-configurable arguments —
-    // see LLAMA_CPP_ENV_PASSTHROUGH_VARS's doc comment.
-    for var in crate::cmd::serve::LLAMA_CPP_ENV_PASSTHROUGH_VARS {
-        if let Ok(val) = std::env::var(var) {
-            args.push("-e".into());
-            args.push(format!("{var}={val}"));
-        }
-    }
+    // container too, plus llama.cpp's own env-configurable arguments (see
+    // LLAMA_CPP_ENV_PASSTHROUGH_VARS's doc comment).
+    forward_env_vars(&mut args, crate::cmd::serve::GPU_VISIBLE_DEVICE_VARS);
+    forward_env_vars(&mut args, crate::cmd::serve::LLAMA_CPP_ENV_PASSTHROUGH_VARS);
     args.push(image);
     args.extend([
         "-m".into(),

--- a/src/harmony.rs
+++ b/src/harmony.rs
@@ -143,7 +143,7 @@ impl HarmonyParser {
                     events.push(HarmonyEvent::MessageEnd);
                     (events, true)
                 } else {
-                    let overlap_len = overlap(&self.acc, &self.message_end_tag);
+                    let overlap_len = crate::strutil::overlap(&self.acc, &self.message_end_tag);
                     if overlap_len > 0 {
                         let split = self.acc.len() - overlap_len;
                         let content = self.acc[..split].to_string();
@@ -216,17 +216,6 @@ fn parse_header(raw: &str) -> HarmonyHeader {
     }
 
     header
-}
-
-/// Longest overlap between a suffix of `s` and a prefix of `delim`.
-fn overlap(s: &str, delim: &str) -> usize {
-    let max = delim.len().min(s.len());
-    for i in (1..=max).rev() {
-        if s.ends_with(&delim[..i]) {
-            return i;
-        }
-    }
-    0
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod providers;
 pub mod shortnames;
 pub mod sources;
 pub mod storage;
+pub mod strutil;
 pub mod thinking;
 pub mod verify;
 pub mod webui;

--- a/src/shortnames.rs
+++ b/src/shortnames.rs
@@ -173,7 +173,13 @@ fn check_digest(digest: &str) -> Result<(), String> {
 /// "localhost:5000"; a real repository name never contains a colon itself,
 /// matching docker/distribution's own reference grammar) or equals
 /// "localhost" outright.
-fn is_host_component(first: &str) -> bool {
+///
+/// Shared with [`crate::verify::canonical_repository`], which applies the
+/// identical rule to tell a registry host from a namespace component; kept
+/// in one place so the two cannot drift (case-sensitivity of the
+/// "localhost" match, in particular, used to differ between the two
+/// copies).
+pub(crate) fn is_host_component(first: &str) -> bool {
     first.contains('.') || first.contains(':') || first.eq_ignore_ascii_case("localhost")
 }
 

--- a/src/strutil.rs
+++ b/src/strutil.rs
@@ -1,0 +1,32 @@
+//! Small string helpers shared by more than one module — kept in one
+//! place rather than duplicated per-file so a fix or behavior change
+//! only has to happen once.
+
+/// Length of the longest suffix of `s` that is also a prefix of `delim`.
+///
+/// Used by streaming parsers ([`crate::harmony`], [`crate::thinking`]) to
+/// decide how many trailing bytes of already-seen text might be the start
+/// of a delimiter split across two chunks (e.g. one chunk ending in
+/// `<thi` and the next starting with `nk>`), so those bytes can be held
+/// back instead of emitted early.
+pub fn overlap(s: &str, delim: &str) -> usize {
+    let max = delim.len().min(s.len());
+    for i in (1..=max).rev() {
+        if s.ends_with(&delim[..i]) {
+            return i;
+        }
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overlap_finds_longest_suffix_prefix_match() {
+        assert_eq!(overlap("abc</thi", "</think>"), 5);
+        assert_eq!(overlap("abcdef", "</think>"), 0);
+        assert_eq!(overlap("", "</think>"), 0);
+    }
+}

--- a/src/thinking.rs
+++ b/src/thinking.rs
@@ -127,7 +127,7 @@ impl Parser {
                     };
                     (thinking, remaining, false)
                 } else {
-                    let overlap_len = overlap(&acc, &self.closing_tag);
+                    let overlap_len = crate::strutil::overlap(&acc, &self.closing_tag);
                     if overlap_len > 0 {
                         let split = acc.len() - overlap_len;
                         let thinking = acc[..split].to_string();
@@ -168,17 +168,6 @@ fn strip_all_leading_occurrences<'a>(trimmed: &'a str, tag: &str) -> Option<&'a 
         return None;
     }
     trimmed.strip_prefix(tag)
-}
-
-/// Longest overlap between a suffix of `s` and a prefix of `delim`.
-fn overlap(s: &str, delim: &str) -> usize {
-    let max = delim.len().min(s.len());
-    for i in (1..=max).rev() {
-        if s.ends_with(&delim[..i]) {
-            return i;
-        }
-    }
-    0
 }
 
 #[cfg(test)]
@@ -301,12 +290,5 @@ mod tests {
             p.add_content("  more content"),
             ("".into(), "more content".into())
         );
-    }
-
-    #[test]
-    fn overlap_finds_longest_suffix_prefix_match() {
-        assert_eq!(overlap("abc</thi", "</think>"), 5);
-        assert_eq!(overlap("abcdef", "</think>"), 0);
-        assert_eq!(overlap("", "</think>"), 0);
     }
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -329,9 +329,9 @@ fn canonical_repository(repo: &str) -> String {
         Some((first, rest)) => (first, Some(rest)),
         None => (repo, None),
     };
-    // Docker's own rule for telling a registry host from a namespace.
-    let has_host = first.contains('.') || first.contains(':') || first == "localhost";
-    if !has_host {
+    // Docker's own rule for telling a registry host from a namespace,
+    // shared with `shortnames::is_host_component` so the two cannot drift.
+    if !crate::shortnames::is_host_component(first) {
         return match rest {
             Some(rest) => format!("docker.io/{first}/{rest}"),
             None => format!("docker.io/library/{first}"),


### PR DESCRIPTION
## Summary

Consolidates a few small pieces of logic that were copy-pasted across unrelated modules and had already started to drift.

- **`overlap()` streaming-delimiter helper** — `harmony.rs` and `thinking.rs` each defined a byte-identical `overlap()` (longest suffix-of-`s`/prefix-of-`delim` match) used by their respective streaming parsers to hold back partial delimiter matches. Moved to a new `src/strutil.rs` module shared by both.
- **"Is this a registry host?" check** — `shortnames::is_host_component()` and an inline check in `verify::canonical_repository()` implemented the same rule but had drifted: `shortnames` used `eq_ignore_ascii_case` for the `"localhost"` match while `verify` used a case-sensitive `==`. `verify.rs` now calls the shared `shortnames::is_host_component`, so the two can't diverge again.
- **GPU/env-var passthrough loop** — `container::spawn()` forwarded two different env-var allowlists (`GPU_VISIBLE_DEVICE_VARS`, `LLAMA_CPP_ENV_PASSTHROUGH_VARS`) into the container args with an identical loop body written out twice. Extracted into a `forward_env_vars()` helper called once per list.

No intentional behavior change other than the case-sensitivity fix above, which is strictly more permissive (an uppercase `Localhost` path component is now recognized as a host by `canonical_repository`, matching `shortnames`' existing behavior) and isn't covered by any test expecting the old case-sensitive behavior.

Left out of this PR (noted as future work, higher risk/effort for a standalone refactor):
- The "where does a tag start" ref-parsing primitive reimplemented ~7 times across `verify.rs`, `storage/oci.rs`, `hf/api.rs`, `hf/oci.rs`, `hf/mod.rs`, and `cmd/list.rs` — each has a different return shape, so unifying is a real refactor rather than a mechanical extraction.
- `hf/pull.rs` vs `hf/transfer.rs`'s shared GGUF/safetensors file-selection logic (~60 duplicated lines) — best bundled with other work in that area.

## Test plan
- `cargo build --lib`
- `cargo test --lib` (657 passed, 0 failed, 2 ignored)
- `cargo clippy --lib` (clean)