### PR TITLE
Treat only a model-not-found 404 as a missing model in llmman stop

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -10747,7 +10747,10 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            crate::daemon::is_model_not_found_body(std::str::from_utf8(&body).unwrap()),
+            crate::daemon::is_model_not_found_body(
+                std::str::from_utf8(&body).unwrap(),
+                "docker.io/ai/nothing-here"
+            ),
             "daemon::is_model_not_found_body must accept the body unload_model sends"
         );
     }

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -10741,6 +10741,15 @@ mod tests {
             .await
             .expect_err("an unknown model must not report a successful unload");
         assert_eq!(err.1, StatusCode::NOT_FOUND);
+        // `llmman stop` tells this 404 from any other by its body, so the
+        // body as rendered has to pass the check on the client side.
+        let body = axum::body::to_bytes(err.into_response().into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(
+            crate::daemon::is_model_not_found_body(std::str::from_utf8(&body).unwrap()),
+            "daemon::is_model_not_found_body must accept the body unload_model sends"
+        );
     }
 
     /// The 404 above is keyed on a model being absent from `running` and

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1066,26 +1066,34 @@ pub fn push(reference: &str) -> anyhow::Result<Option<String>> {
 /// Ollama's own `ollama stop` (`cmd/cmd.go`'s `loadOrUnloadModel`). Used
 /// by `llmman stop`.
 ///
-/// `Ok(false)` reports the daemon's 404, i.e. it holds no model by that
-/// name — the one outcome `llmman stop` renders as its own error rather
-/// than a transport failure. `Ok(true)` covers both a model that was
-/// loaded and one that simply was not, which the unload does not
-/// distinguish, matching ollama.
+/// `Ok(false)` is the daemon's "no such model" answer, which `llmman
+/// stop` renders as its error; `Ok(true)` covers a model loaded or not,
+/// which the unload does not distinguish, matching ollama. Any other
+/// failure is reported with its status and body, a 404 included: a proxy
+/// in front of the daemon answers 404 too, and "couldn't find model"
+/// would be the wrong story for that.
 pub fn unload(reference: &str) -> anyhow::Result<bool> {
     let resp = reqwest::blocking::Client::new()
         .post(format!("{}/api/generate", server()))
         .json(&serde_json::json!({"model": reference, "keep_alive": 0}))
         .send()
         .with_context(|| format!("request /api/generate (unload) for {reference}"))?;
-    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(true);
+    }
+    let body = resp.text().unwrap_or_default();
+    if status == reqwest::StatusCode::NOT_FOUND && is_model_not_found_body(&body) {
         return Ok(false);
     }
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let body = resp.text().unwrap_or_default();
-        anyhow::bail!("stop {reference}: server returned {status}: {body}");
-    }
-    Ok(true)
+    anyhow::bail!("stop {reference}: server returned {status}: {body}");
+}
+
+/// The ollama-shaped `{"error":"model '…' not found"}` this daemon sends
+/// too (see `unload_model` in cmd::serve), parsed through `api_error` so
+/// an HTML page or a proxy's own JSON does not pass by containing the words.
+pub(crate) fn is_model_not_found_body(body: &str) -> bool {
+    api_error(body).is_some_and(|e| e.starts_with("model '") && e.ends_with("' not found"))
 }
 
 /// A plain `GET {server()}{path}` returning the parsed JSON body — for
@@ -1593,5 +1601,18 @@ mod tests {
             survived,
             "a process outside the targeted group was signalled too"
         );
+    }
+
+    #[test]
+    fn only_the_not_found_error_envelope_means_a_missing_model() {
+        assert!(is_model_not_found_body(
+            r#"{"error":"model 'docker.io/ai/m' not found"}"#
+        ));
+        assert!(!is_model_not_found_body(r#"{"error":"no route"}"#));
+        assert!(!is_model_not_found_body("<html>404 Not Found</html>"));
+        assert!(!is_model_not_found_body(""));
+        assert!(!is_model_not_found_body(
+            r#"{"message":"model 'x' not found"}"#
+        ));
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1083,17 +1083,20 @@ pub fn unload(reference: &str) -> anyhow::Result<bool> {
         return Ok(true);
     }
     let body = resp.text().unwrap_or_default();
-    if status == reqwest::StatusCode::NOT_FOUND && is_model_not_found_body(&body) {
+    if status == reqwest::StatusCode::NOT_FOUND && is_model_not_found_body(&body, reference) {
         return Ok(false);
     }
     anyhow::bail!("stop {reference}: server returned {status}: {body}");
 }
 
-/// The ollama-shaped `{"error":"model '…' not found"}` this daemon sends
-/// too (see `unload_model` in cmd::serve), parsed through `api_error` so
-/// an HTML page or a proxy's own JSON does not pass by containing the words.
-pub(crate) fn is_model_not_found_body(body: &str) -> bool {
-    api_error(body).is_some_and(|e| e.starts_with("model '") && e.ends_with("' not found"))
+/// The `{"error":"model '<name>' not found"}` this daemon sends for
+/// `reference` (see `unload_model` in cmd::serve), with the name the
+/// daemon was asked for, a pair's local half; parsed through `api_error`,
+/// so an HTML page or a proxy's own JSON does not pass by containing the
+/// words, and a 404 about some other model does not pass either.
+pub(crate) fn is_model_not_found_body(body: &str, reference: &str) -> bool {
+    let expected = format!("model '{}' not found", crate::hybrid::local_half(reference));
+    api_error(body).is_some_and(|e| e == expected)
 }
 
 /// A plain `GET {server()}{path}` returning the parsed JSON body — for
@@ -1604,15 +1607,28 @@ mod tests {
     }
 
     #[test]
-    fn only_the_not_found_error_envelope_means_a_missing_model() {
+    fn only_the_not_found_error_envelope_for_that_model_means_a_missing_model() {
+        let m = "docker.io/ai/m";
         assert!(is_model_not_found_body(
-            r#"{"error":"model 'docker.io/ai/m' not found"}"#
+            r#"{"error":"model 'docker.io/ai/m' not found"}"#,
+            m
         ));
-        assert!(!is_model_not_found_body(r#"{"error":"no route"}"#));
-        assert!(!is_model_not_found_body("<html>404 Not Found</html>"));
-        assert!(!is_model_not_found_body(""));
+        // A pair is unloaded by its local half, which is what the daemon
+        // names.
+        assert!(is_model_not_found_body(
+            r#"{"error":"model 'gemma4' not found"}"#,
+            "llmman.hybrid/gemma4,anthropic/claude-sonnet-4-5"
+        ));
         assert!(!is_model_not_found_body(
-            r#"{"message":"model 'x' not found"}"#
+            r#"{"error":"model 'other' not found"}"#,
+            m
+        ));
+        assert!(!is_model_not_found_body(r#"{"error":"no route"}"#, m));
+        assert!(!is_model_not_found_body("<html>404 Not Found</html>", m));
+        assert!(!is_model_not_found_body("", m));
+        assert!(!is_model_not_found_body(
+            r#"{"message":"model 'docker.io/ai/m' not found"}"#,
+            m
         ));
     }
 }


### PR DESCRIPTION
`daemon::unload` read any 404 as "no such model", so a proxy in front of the daemon, or anything else answering on its port, turned into `couldn't find model "x" to stop`. It now takes only the `{"error":"model '…' not found"}` envelope the daemon sends as that answer and reports any other 404 with its status and body. A test renders `unload_model`'s own 404 through `into_response` and checks the client side accepts it, so the two ends cannot drift apart. Verified against a stand-in server answering 404 with an HTML body and with a foreign JSON body: both come back as `server returned 404 Not Found` with the body, and `llmman stop zz/nope` still reports the missing model.

follow up #376