### PR TITLE
test(go-shim): add docker login/logout tests mirroring podman's

### DIFF
--- a/go-shim/backend_docker.go
+++ b/go-shim/backend_docker.go
@@ -368,10 +368,20 @@ func pushStreamLazy(ctx context.Context, pusher remotes.Pusher, desc ocispec.Des
 //
 //export llmman_login
 func llmman_login(cServer, cUsername, cPassword *C.char) *C.char {
-	server := C.GoString(cServer)
-	username := C.GoString(cUsername)
-	password := C.GoString(cPassword)
+	if err := dockerLogin(C.GoString(cServer), C.GoString(cUsername), C.GoString(cPassword)); err != nil {
+		return errResp(err)
+	}
+	return okResp("")
+}
 
+// dockerLogin is llmman_login's implementation, factored out so a test
+// can reach it — Go forbids cgo in _test.go files. Mirrors podmanLogin
+// in backend_podman.go.
+//
+// Unlike podman's commonauth.Login this never contacts the registry: it
+// only writes to the credential store, which is what makes its success
+// path testable offline (see backend_docker_auth_test.go).
+func dockerLogin(server, username, password string) error {
 	cfg := dockercliconfig.LoadDefaultConfigFile(io.Discard)
 	store := cfg.GetCredentialsStore(server)
 
@@ -380,29 +390,36 @@ func llmman_login(cServer, cUsername, cPassword *C.char) *C.char {
 		Username:      username,
 		Password:      password,
 	}); err != nil {
-		return errResp(fmt.Errorf("store credentials: %w", err))
+		return fmt.Errorf("store credentials: %w", err)
 	}
 	if err := cfg.Save(); err != nil {
-		return errResp(fmt.Errorf("save config: %w", err))
+		return fmt.Errorf("save config: %w", err)
 	}
-	return okResp("")
+	return nil
 }
 
 // llmman_logout removes credentials for a registry from the Docker credential store.
 //
 //export llmman_logout
 func llmman_logout(cServer *C.char) *C.char {
-	server := C.GoString(cServer)
+	if err := dockerLogout(C.GoString(cServer)); err != nil {
+		return errResp(err)
+	}
+	return okResp("")
+}
 
+// dockerLogout is llmman_logout's implementation. Factored out for the
+// same reason as dockerLogin above; mirrors podmanLogout.
+func dockerLogout(server string) error {
 	cfg := dockercliconfig.LoadDefaultConfigFile(io.Discard)
 	store := cfg.GetCredentialsStore(server)
 	if err := store.Erase(server); err != nil {
-		return errResp(fmt.Errorf("erase credentials: %w", err))
+		return fmt.Errorf("erase credentials: %w", err)
 	}
 	if err := cfg.Save(); err != nil {
-		return errResp(fmt.Errorf("save config: %w", err))
+		return fmt.Errorf("save config: %w", err)
 	}
-	return okResp("")
+	return nil
 }
 
 // llmman_push pushes an image from a local OCI layout directory to a registry.

--- a/go-shim/backend_docker_auth_test.go
+++ b/go-shim/backend_docker_auth_test.go
@@ -1,0 +1,141 @@
+//go:build !podman
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	dockercliconfig "github.com/docker/cli/cli/config"
+)
+
+// Docker counterpart of backend_podman_auth_test.go. Unlike podman's
+// commonauth.Login, dockerLogin never contacts the registry — it only
+// writes the credential store — so both halves of the round-trip are
+// reachable offline here, not just logout.
+//
+// A t.TempDir() keeps each test off the developer's real
+// ~/.docker/config.json. No credsStore/credHelpers are configured in
+// that fresh directory, so docker/cli falls back to its plain-file store
+// and the "auths" map is inspectable on disk.
+
+// isolatedDockerConfigDir points docker/cli at a throwaway config dir
+// for the duration of one test. SetDir rather than t.Setenv("DOCKER_CONFIG"):
+// docker/cli reads that env var exactly once per process (sync.Once in
+// config.Dir()), so the second test to set it would silently keep
+// writing into the first test's already-deleted TempDir.
+func isolatedDockerConfigDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	prev := dockercliconfig.Dir()
+	dockercliconfig.SetDir(dir)
+	t.Cleanup(func() { dockercliconfig.SetDir(prev) })
+	return dir
+}
+
+func dockerConfigJSON(t *testing.T, dir string) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(dir, "config.json"))
+	if err != nil {
+		t.Fatalf("read config.json: %v", err)
+	}
+	return string(body)
+}
+
+func TestDockerLoginStoresCredentials(t *testing.T) {
+	const registry = "registry.example.com"
+	dir := isolatedDockerConfigDir(t)
+
+	if err := dockerLogin(registry, "user", "pass"); err != nil {
+		t.Fatalf("dockerLogin(%q): %v", registry, err)
+	}
+
+	raw := dockerConfigJSON(t, dir)
+	var cfg struct {
+		Auths map[string]struct {
+			Auth string `json:"auth"`
+		} `json:"auths"`
+	}
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("parse config.json %q: %v", raw, err)
+	}
+	if _, ok := cfg.Auths[registry]; !ok {
+		t.Fatalf("no auths entry for %s after login: %s", registry, raw)
+	}
+	// docker/cli's file store base64-encodes "user:pass" into "auth";
+	// the round-trip below via dockerCredentials is what asserts the
+	// value decodes back correctly, so only presence is checked here.
+
+	// The same lookup path pull/push use must see what login stored.
+	user, pass, err := dockerCredentials(registry)
+	if err != nil {
+		t.Fatalf("dockerCredentials(%q): %v", registry, err)
+	}
+	if user != "user" || pass != "pass" {
+		t.Fatalf("dockerCredentials(%q) = (%q, %q), want (user, pass)", registry, user, pass)
+	}
+}
+
+// TestDockerLogoutRemovesCredentials is the direct equivalent of
+// TestPodmanLogoutDoesNotPanicOnSuccess: seed a credential, log out,
+// and assert the registry is gone from the store afterwards.
+func TestDockerLogoutRemovesCredentials(t *testing.T) {
+	const registry = "registry.example.com"
+	dir := isolatedDockerConfigDir(t)
+
+	if err := dockerLogin(registry, "user", "pass"); err != nil {
+		t.Fatalf("seed via dockerLogin(%q): %v", registry, err)
+	}
+	if !strings.Contains(dockerConfigJSON(t, dir), registry) {
+		t.Fatalf("precondition: %s missing from config.json after login", registry)
+	}
+
+	if err := dockerLogout(registry); err != nil {
+		t.Fatalf("dockerLogout(%q): %v", registry, err)
+	}
+
+	if after := dockerConfigJSON(t, dir); strings.Contains(after, registry) {
+		t.Fatalf("credentials for %s still present after logout: %s", registry, after)
+	}
+	if user, pass, err := dockerCredentials(registry); err != nil || user != "" || pass != "" {
+		t.Fatalf("dockerCredentials(%q) after logout = (%q, %q, %v), want empty", registry, user, pass, err)
+	}
+}
+
+// TestDockerHubLoginIsVisibleUnderConnectionHost pins the normalization
+// dockerCredentials exists for: `llmman login docker.io` stores under
+// "docker.io", but containerd hands the Credentials callback the actual
+// connection host "registry-1.docker.io". Without dockerHubCredentialKeys
+// every authenticated Hub push would silently run anonymously.
+func TestDockerHubLoginIsVisibleUnderConnectionHost(t *testing.T) {
+	isolatedDockerConfigDir(t)
+
+	if err := dockerLogin("docker.io", "hubuser", "hubpass"); err != nil {
+		t.Fatalf("dockerLogin(docker.io): %v", err)
+	}
+
+	for _, host := range []string{"registry-1.docker.io", "index.docker.io", "docker.io"} {
+		user, pass, err := dockerCredentials(host)
+		if err != nil {
+			t.Fatalf("dockerCredentials(%q): %v", host, err)
+		}
+		if user != "hubuser" || pass != "hubpass" {
+			t.Fatalf("dockerCredentials(%q) = (%q, %q), want (hubuser, hubpass)", host, user, pass)
+		}
+	}
+
+	// A non-Hub host must not pick up Hub credentials.
+	if user, pass, err := dockerCredentials("ghcr.io"); err != nil || user != "" || pass != "" {
+		t.Fatalf("dockerCredentials(ghcr.io) = (%q, %q, %v), want empty", user, pass, err)
+	}
+
+	if err := dockerLogout("docker.io"); err != nil {
+		t.Fatalf("dockerLogout(docker.io): %v", err)
+	}
+	if user, pass, err := dockerCredentials("registry-1.docker.io"); err != nil || user != "" || pass != "" {
+		t.Fatalf("dockerCredentials(registry-1.docker.io) after logout = (%q, %q, %v), want empty", user, pass, err)
+	}
+}


### PR DESCRIPTION
## Why

`backend_podman_auth_test.go` covers podman's logout path, but the default docker backend (`//go:build !podman`) had no equivalent — `llmman login`/`logout` on the backend most users get was untested at the Go level. Anywhere podman is tested, docker should be too.

## What

- Factor `llmman_login`/`llmman_logout` bodies in `backend_docker.go` out into `dockerLogin`/`dockerLogout`. cgo can't be called from `_test.go`, which is the same reason `podmanLogin`/`podmanLogout` exist. The exported C symbols and their behaviour are unchanged.
- Add `backend_docker_auth_test.go` (`//go:build !podman`):
  - `TestDockerLoginStoresCredentials` — login writes an `auths` entry that `dockerCredentials` (the lookup path pull/push actually use) reads back.
  - `TestDockerLogoutRemovesCredentials` — direct equivalent of `TestPodmanLogoutDoesNotPanicOnSuccess`: seed, log out, assert gone from `config.json` and from `dockerCredentials`.
  - `TestDockerHubLoginIsVisibleUnderConnectionHost` — pins the `dockerHubCredentialKeys` normalisation: `login docker.io` is visible under `registry-1.docker.io`/`index.docker.io`, and `ghcr.io` does not pick up Hub credentials.

Docker's login never contacts the registry (it only writes the store), so unlike podman both halves of the round-trip are covered offline.

## Note on isolation

Tests use `config.SetDir` on a `t.TempDir()` rather than `t.Setenv("DOCKER_CONFIG", ...)`: docker/cli reads that env var exactly once per process (`sync.Once` in `config.Dir()`), so the second test to set it silently kept writing into the first test's already-deleted directory. `SetDir` is restored in `t.Cleanup`.

## Verification

```
cd go-shim
go test -tags docker -count=1 ./...          # ok, incl. 3 new tests
go vet -tags docker ./...
go build -tags podman,containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper ./...
```

The `lint` job already runs `go test -tags docker ./...` on every PR, so these run in PR CI alongside the podman ones.
