### PR TITLE
Simplify the nvm lookup and trim the qwen doc comments

### DIFF
--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -1036,8 +1036,8 @@ fn find_qwen() -> Option<PathBuf> {
 /// and, on Windows, its `%LOCALAPPDATA%\qwen-code\bin`
 /// (`Get-QwenInstallBinDir` in Qwen Code's
 /// `scripts/installation/install-qwen-standalone.ps1`); the
-/// `~/.npm-global` prefix its older npm installer set; nvm's newest node
-/// that has it; Homebrew's prefixes and `/usr/local/bin`; and the rest of
+/// `~/.npm-global` prefix its older npm installer set; any node under
+/// `~/.nvm` that has it; Homebrew's prefixes and `/usr/local/bin`; and the rest of
 /// what ollama's `cmd/launch/qwen.go` probes, `~/.cargo/bin`, macOS's
 /// `~/Library/Application Support/qwen/bin`, and on Windows npm's global
 /// directory under both `%APPDATA%` and `%LOCALAPPDATA%`,
@@ -1084,7 +1084,7 @@ fn qwen_fallback_paths() -> Vec<PathBuf> {
                     .join("qwen"),
             );
         }
-        paths.extend(nvm_dirs(h).iter().filter_map(|d| nvm_qwen(d)));
+        paths.extend(nvm_qwen(h));
     }
     if cfg!(target_os = "macos") {
         paths.push(PathBuf::from("/opt/homebrew/bin/qwen"));
@@ -1095,49 +1095,14 @@ fn qwen_fallback_paths() -> Vec<PathBuf> {
     paths
 }
 
-/// `$NVM_DIR`, `$XDG_CONFIG_HOME/nvm`, `~/.config/nvm` and `~/.nvm`: which
-/// one an install took depends on the environment nvm was installed in,
-/// not on this process's, so all are probed.
-fn nvm_dirs(home: &Path) -> Vec<PathBuf> {
-    let mut dirs = Vec::new();
-    if let Some(dir) = std::env::var_os("NVM_DIR").filter(|d| !d.is_empty()) {
-        dirs.push(PathBuf::from(dir));
-    }
-    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME").filter(|d| !d.is_empty()) {
-        dirs.push(PathBuf::from(xdg).join("nvm"));
-    }
-    dirs.push(home.join(".config").join("nvm"));
-    dirs.push(home.join(".nvm"));
-    dirs
-}
-
-/// The `qwen` under the newest node version nvm holds one for; nvm keeps
-/// one tree per version and picks between them by editing `PATH` in the
-/// shell.
-fn nvm_qwen(nvm_dir: &Path) -> Option<PathBuf> {
-    let node = nvm_dir.join("versions").join("node");
-    let mut versions: Vec<String> = std::fs::read_dir(&node)
+/// The `qwen` under any node version in `~/.nvm`, the way ollama's
+/// `cmd/launch/qwen.go` globs for it.
+fn nvm_qwen(home: &Path) -> Option<PathBuf> {
+    std::fs::read_dir(home.join(".nvm").join("versions").join("node"))
         .ok()?
         .filter_map(|e| e.ok())
-        .map(|e| e.file_name().to_string_lossy().into_owned())
-        .collect();
-    sort_node_versions_newest_first(&mut versions);
-    versions
-        .into_iter()
-        .map(|v| node.join(v).join("bin").join("qwen"))
+        .map(|e| e.path().join("bin").join("qwen"))
         .find(|p| p.is_file())
-}
-
-/// `v22.14.0` before `v22.9.1` before `v9.0.0`; a name that is not a
-/// version sorts last.
-fn sort_node_versions_newest_first(names: &mut [String]) {
-    fn key(name: &str) -> Option<Vec<u64>> {
-        name.strip_prefix('v')?
-            .split('.')
-            .map(|part| part.parse().ok())
-            .collect()
-    }
-    names.sort_by_key(|name| std::cmp::Reverse(key(name)));
 }
 
 /// `$QWEN_HOME` if set, else `~/.qwen`: `Storage.getGlobalQwenDir` in
@@ -1605,24 +1570,10 @@ mod tests {
         );
     }
 
-    /// Newest node first; the directory order is not by version.
+    /// Any node version under `~/.nvm` that has qwen.
     #[test]
-    fn node_versions_sort_newest_first_with_other_names_last() {
-        let mut names: Vec<String> = ["v9.0.0", "v20.19.0", ".DS_Store", "v22.14.0", "v22.9.1"]
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
-        sort_node_versions_newest_first(&mut names);
-        assert_eq!(
-            names,
-            ["v22.14.0", "v22.9.1", "v20.19.0", "v9.0.0", ".DS_Store"]
-        );
-    }
-
-    /// Over nvm's layout, the newest version that has qwen wins.
-    #[test]
-    fn nvm_qwen_picks_the_newest_version_that_has_it() {
-        let dir = std::env::temp_dir().join(format!(
+    fn nvm_qwen_finds_it_under_a_node_version() {
+        let home = std::env::temp_dir().join(format!(
             "llmman-nvm-{}-{}",
             std::process::id(),
             std::time::SystemTime::now()
@@ -1630,15 +1581,13 @@ mod tests {
                 .unwrap()
                 .as_nanos()
         ));
-        let node = dir.join("versions").join("node");
-        for v in ["v20.19.0", "v22.14.0", "v22.9.1"] {
-            std::fs::create_dir_all(node.join(v).join("bin")).unwrap();
-        }
-        std::fs::write(node.join("v20.19.0/bin/qwen"), "").unwrap();
-        std::fs::write(node.join("v22.9.1/bin/qwen"), "").unwrap();
-        assert_eq!(nvm_qwen(&dir), Some(node.join("v22.9.1/bin/qwen")));
-        assert_eq!(nvm_qwen(&dir.join("nowhere")), None);
-        let _ = std::fs::remove_dir_all(&dir);
+        let bin = home.join(".nvm/versions/node/v22.9.1/bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::create_dir_all(home.join(".nvm/versions/node/v20.19.0/bin")).unwrap();
+        std::fs::write(bin.join("qwen"), "").unwrap();
+        assert_eq!(nvm_qwen(&home), Some(bin.join("qwen")));
+        assert_eq!(nvm_qwen(&home.join("nowhere")), None);
+        let _ = std::fs::remove_dir_all(&home);
     }
 
     /// The documented targets are on the list (see `find_qwen`).

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -929,25 +929,15 @@ fn launch_openclaw(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
 
 /// qwen: Qwen Code's OpenAI-compatible mode, pointed at our /v1 by the
 /// command line, the environment and its settings file together, since
-/// it reads the three in a different order for each value.
-///
-/// `--auth-type` and `--model` go on the command line: for those it
-/// reads `argv`, then `~/.qwen/settings.json`, then the `OPENAI_*`
-/// variables, and it writes that file itself on `/auth` and `/model`, so
-/// for anyone who has used it before the variables alone lose. For the
-/// base URL a `modelProviders` entry in the settings file whose id is the
-/// model beats both flag and variable (`resolveModelConfig` in its
-/// `packages/core/src/models/modelConfigResolver.ts`), which is what
-/// `write_qwen_settings` is for. The key stays in the environment: on the
-/// command line it shows in `ps`, and the file only names the variable,
-/// `LLMMAN_API_KEY`, exported with the same value as `OPENAI_API_KEY` so
-/// that llmman's entry is told from any other by its key name, the way
-/// ollama's is by `OLLAMA_API_KEY`. Ollama's `cmd/launch/qwen.go` does
-/// the same three. `--model` is
-/// required; `check_model_flag` refuses a launch without one before the
-/// daemon starts. A `--model` after `--` is the one Qwen Code will use
-/// (`qwen_args` yields to it), so the settings and `OPENAI_MODEL` follow
-/// it; `run` has resolved and preloaded the top-level one regardless.
+/// Qwen Code reads the three in a different order for each value:
+/// `--auth-type` and `--model` win on the command line, the base URL is
+/// won by a `modelProviders` entry for the model (`resolveModelConfig` in
+/// its `packages/core/src/models/modelConfigResolver.ts`), which is what
+/// `write_qwen_settings` is for, and the key stays in the environment,
+/// named in that entry as `LLMMAN_API_KEY` so llmman's entry is told from
+/// any other. Ollama's `cmd/launch/qwen.go` does the same three. A
+/// `--model` after `--` is the one Qwen Code uses, so the settings and
+/// `OPENAI_MODEL` follow it.
 fn launch_qwen(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
     let bin = find_qwen().ok_or_else(|| anyhow::anyhow!("qwen is not installed"))?;
     let model = forwarded_model(extra_args).unwrap_or(model);
@@ -1136,16 +1126,11 @@ fn write_qwen_settings(model: &str) -> anyhow::Result<()> {
 }
 
 /// Read as Qwen Code reads it, comments stripped and an empty file as
-/// `{}`. What is still not a JSON object is left alone, with a line to
-/// say so, and the launch goes on: Qwen Code moves a file it cannot parse
-/// to `settings.json.corrupted` and resets it to `{}`, so no entry in it
-/// survives to outrank the flags and variables `launch_qwen` passes. A
-/// file that parses but cannot be written is an error, since an entry in
-/// it may be exactly what the write was to outrank.
-/// The file as it was before llmman first wrote
-/// it stays as `settings.json.bak`, and a later one carrying comments,
-/// which the rewrite drops, replaces that copy; llmman's own renderings
-/// and Qwen Code's do not.
+/// `{}`. A file that is not a JSON object is left alone with a line
+/// printed, since Qwen Code resets such a file to `{}` itself; one that
+/// parses but cannot be written is an error, since an entry in it may be
+/// the one this write was to outrank. The user's own file, and any later
+/// one carrying comments, is kept as `settings.json.bak`.
 fn write_qwen_settings_at(dir: &Path, model: &str, base_url: &str) -> anyhow::Result<()> {
     let path = dir.join("settings.json");
     let raw = match std::fs::read_to_string(&path) {
@@ -1238,18 +1223,12 @@ fn strip_json_comments(raw: &str) -> String {
 /// as llmman's: a user can rename it in `/model`, but not re-key it.
 const QWEN_ENV_KEY: &str = "LLMMAN_API_KEY";
 
-/// `existing` with llmman's entry merged in; pure, so it is testable on a
-/// literal document. The keys are the ones Qwen Code's own `/auth` and
-/// `/model` write, and ollama's `applyQwenOllamaConfig` in
-/// `cmd/launch/qwen.go`: llmman's entry first in `modelProviders.openai`,
-/// with an earlier one of its own for this daemon replaced, the rest
-/// kept, and a `{ protocol, models }` wrapper an older Qwen Code wrote
-/// unwrapped as its `V5ToV4Migration` does, `$version` set to 4 with it;
-/// `security.auth.selectedType` and `baseUrl`; `model.name` with
-/// `model.baseUrl`, which Qwen Code sets together. Otherwise no
-/// `$version`, which Qwen Code stamps itself, and no key: the
-/// entry names `QWEN_ENV_KEY`, which `launch_qwen` exports. A value of
-/// the wrong type on the way down is replaced, as ollama's `qwenMap` does.
+/// `existing` with llmman's entry merged in, pure so a test can hand it
+/// a literal. The keys follow Qwen Code's own `/auth` and `/model` and
+/// ollama's `applyQwenOllamaConfig` in `cmd/launch/qwen.go`: the entry
+/// first in `modelProviders.openai`, an earlier one of llmman's replaced,
+/// the rest kept and a `{ protocol, models }` wrapper unwrapped with
+/// `$version` set to 4; `security.auth`; `model.name` and `model.baseUrl`.
 fn qwen_settings_merged(
     existing: &serde_json::Value,
     model: &str,

--- a/tests/launch_e2e.rs
+++ b/tests/launch_e2e.rs
@@ -992,7 +992,12 @@ fn launch_qwen_without_a_model_is_refused_before_the_daemon() {
         !stderr.contains("exited during startup"),
         "the daemon was started first\n{stderr}"
     );
-    assert!(elapsed < Duration::from_secs(5), "refusal took {elapsed:?}");
+    // 30s, like the dead-daemon test: the refusal takes milliseconds, but
+    // a runner busy with the model tests beside it does not.
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "refusal took {elapsed:?}"
+    );
 }
 
 /// A fresh `HOME` in which any daemon `llmman` spawns dies at startup, a


### PR DESCRIPTION
`find_qwen` now looks under `~/.nvm/versions/node/*/bin` with one directory scan, the way ollama does; the `NVM_DIR` and `XDG_CONFIG_HOME` variants and the version sort are gone. The doc comments on `launch_qwen`, `write_qwen_settings_at` and `qwen_settings_merged` are cut to a few lines each. The pre-flight e2e's elapsed bound is 30s, like the dead-daemon test, so it does not flake next to the model tests.

follow up #379 