### PR TITLE
docs: add Docker Compose deployment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ so it works from any client on every inference endpoint. Details in
 | [docs/api.md](docs/api.md) | Every HTTP endpoint, and per-API notes |
 | [docs/aggregation.md](docs/aggregation.md) | Pooling several machines into one endpoint |
 | [docs/backends.md](docs/backends.md) | llama.cpp, vLLM, MLX, containers, and building from source |
+| [docs/compose.md](docs/compose.md) | Compose deployment behind a gateway, with persistent model storage |
 | [docs/configuration.md](docs/configuration.md) | `llmman.conf`, `llmman config`, environment variables, store layout |
 | [docs/providers.md](docs/providers.md) | Hosted providers, API keys, and which integrations can use them |
 | [docs/verification.md](docs/verification.md) | Signing models and pull-time trust policy |

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -1,0 +1,57 @@
+# Docker Compose
+
+[`examples/compose`](../examples/compose) runs `llmman serve` behind a Caddy
+gateway. The same gateway exposes the built-in web UI and the Ollama, OpenAI,
+and Anthropic-compatible APIs. A named volume keeps pulled models and the
+downloaded `llama-server` between container replacements.
+
+From the repository root:
+
+```sh
+docker compose -f examples/compose/compose.yaml up --build
+```
+
+Open <http://localhost:8080/> for the web UI. Clients can use the same address
+as their API base URL. For example:
+
+```sh
+curl http://localhost:8080/api/version
+```
+
+The image includes checksum-verified, pinned llmman and llama.cpp CPU binaries.
+Override the llmman version at build time when needed:
+
+```sh
+LLMMAN_VERSION=0.1.336 docker compose \
+  -f examples/compose/compose.yaml build --pull
+```
+
+To update llama.cpp, change `LLAMA_CPP_VERSION` and both architecture checksums
+in the Dockerfile together. A mismatched archive fails the image build.
+
+Bundling the pinned backend avoids depending on GitHub's rate-limited release
+API during startup. The defaults match versions exercised by this repository.
+
+The `llmman-data` volume is mounted at `/var/lib/llmman`. Its model store is
+`/var/lib/llmman/store`; the parent mount also preserves downloaded backend
+binaries and caches. Remove the deployment while retaining its models with
+`docker compose -f examples/compose/compose.yaml down`. Add `--volumes` only
+when the stored models should be deleted as well.
+
+## CPU limits and container backends
+
+`LLMMAN_CPUS` controls the Compose CPU limit and defaults to `4`. The example
+uses llmman's default local backend, so the `llama-server` child shares the
+service's cgroup and llmman can derive its thread count from that limit.
+
+This differs from `llmman serve --ociman docker` or `--ociman podman`: those
+modes create a separate backend container, and the service's CPU quota is not
+forwarded to it yet ([#324](https://github.com/llmmanorg/llmman/issues/324)). If
+you adapt this example to use `--ociman`, set `LLAMA_ARG_THREADS` explicitly or
+apply a CPU limit to the backend container separately.
+
+## Customizing the gateway
+
+The example only publishes Caddy's port. Add authentication and TLS to the
+[`Caddyfile`](../examples/compose/Caddyfile) before exposing it outside a trusted
+network; the llmman API itself does not authenticate requests.

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -2,8 +2,8 @@
 
 [`examples/compose`](../examples/compose) runs `llmman serve` behind a Caddy
 gateway. The same gateway exposes the built-in web UI and the Ollama, OpenAI,
-and Anthropic-compatible APIs. A named volume keeps pulled models and the
-downloaded `llama-server` between container replacements.
+and Anthropic-compatible APIs. A named volume keeps pulled models between
+container replacements.
 
 From the repository root:
 
@@ -32,9 +32,8 @@ in the Dockerfile together. A mismatched archive fails the image build.
 Bundling the pinned backend avoids depending on GitHub's rate-limited release
 API during startup. The defaults match versions exercised by this repository.
 
-The `llmman-data` volume is mounted at `/var/lib/llmman`. Its model store is
-`/var/lib/llmman/store`; the parent mount also preserves downloaded backend
-binaries and caches. Remove the deployment while retaining its models with
+The `llmman-data` volume is mounted at `/var/lib/llmman`, and its model store is
+`/var/lib/llmman/store`. Remove the deployment while retaining its models with
 `docker compose -f examples/compose/compose.yaml down`. Add `--volumes` only
 when the stored models should be deleted as well.
 

--- a/examples/compose/Caddyfile
+++ b/examples/compose/Caddyfile
@@ -1,0 +1,3 @@
+:80 {
+	reverse_proxy llmman:17434
+}

--- a/examples/compose/Dockerfile
+++ b/examples/compose/Dockerfile
@@ -1,0 +1,64 @@
+FROM debian:trixie-slim AS download
+
+ARG LLMMAN_VERSION=0.1.336
+ARG LLAMA_CPP_VERSION=b10293
+ARG TARGETARCH
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && case "$TARGETARCH" in \
+         amd64) \
+           target=x86_64-unknown-linux-gnu; \
+           llama_asset=ubuntu-x64.tar.gz; \
+           llama_sha256=dfca6141b016d1557297ba960861ed8bf43f9e18e405c0e8aaad35fbdf76ba9d \
+           ;; \
+         arm64) \
+           target=aarch64-unknown-linux-gnu; \
+           llama_asset=ubuntu-arm64.tar.gz; \
+           llama_sha256=f996d1f336bb5f96e04bd7a4de9699d88c9ce09885349bdc92652aea2f1f30d3 \
+           ;; \
+         *) echo "unsupported architecture: $TARGETARCH" >&2; exit 1 ;; \
+       esac \
+    && base="https://github.com/llmmanorg/llmman/releases/download/v${LLMMAN_VERSION}" \
+    && curl -fsSL --retry 16 --retry-all-errors \
+         "$base/checksums.txt" -o /tmp/checksums.txt \
+    && curl -fsSL --retry 16 --retry-all-errors \
+         "$base/llmman-$target" -o "/tmp/llmman-$target" \
+    && cd /tmp \
+    && grep "  llmman-$target$" checksums.txt | sha256sum --check --strict \
+    && mv "llmman-$target" /usr/local/bin/llmman \
+    && chmod 0755 /usr/local/bin/llmman \
+    && llama_archive="llama-${LLAMA_CPP_VERSION}-bin-${llama_asset}" \
+    && llama_base="https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_CPP_VERSION}" \
+    && curl -fsSL --retry 16 --retry-all-errors \
+         "$llama_base/$llama_archive" -o "/tmp/${llama_archive}" \
+    && echo "$llama_sha256  /tmp/$llama_archive" | sha256sum --check --strict \
+    && mkdir -p /tmp/llama /opt/llama.cpp \
+    && tar -xf "/tmp/${llama_archive}" -C /tmp/llama \
+    && llama_server="$(find /tmp/llama -type f -name llama-server -print -quit)" \
+    && test -n "$llama_server" \
+    && cp -a "$(dirname "$llama_server")/." /opt/llama.cpp/
+
+FROM debian:trixie-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libgomp1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 1000 llmman \
+    && mkdir -p /var/lib/llmman/store \
+    && chown -R llmman:llmman /var/lib/llmman
+
+COPY --from=download /usr/local/bin/llmman /usr/local/bin/llmman
+COPY --from=download /opt/llama.cpp /opt/llama.cpp
+
+USER llmman
+ENV LLMMAN_HOST=0.0.0.0:17434 \
+    LLMMAN_MODELS=/var/lib/llmman/store \
+    LD_LIBRARY_PATH=/opt/llama.cpp \
+    PATH=/opt/llama.cpp:$PATH
+VOLUME ["/var/lib/llmman"]
+EXPOSE 17434
+
+ENTRYPOINT ["llmman"]
+CMD ["serve"]

--- a/examples/compose/compose.yaml
+++ b/examples/compose/compose.yaml
@@ -1,0 +1,23 @@
+services:
+  llmman:
+    build:
+      context: .
+      args:
+        LLMMAN_VERSION: ${LLMMAN_VERSION:-0.1.336}
+    cpus: ${LLMMAN_CPUS:-4}
+    restart: unless-stopped
+    volumes:
+      - llmman-data:/var/lib/llmman
+
+  gateway:
+    image: caddy:2-alpine
+    depends_on:
+      - llmman
+    ports:
+      - "${LLMMAN_PORT:-8080}:80"
+    restart: unless-stopped
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+
+volumes:
+  llmman-data:


### PR DESCRIPTION
Closes #364

Adds a runnable Compose example with Caddy in front of `llmman serve`, the built-in web UI, and a named model-store volume. The image supports amd64 and arm64, verifies both downloaded binaries, and documents the `--ociman` CPU-limit caveat from #324.

Validation:
- `docker compose config`
- live `/api/version` and web UI requests through Caddy
- arm64 and amd64 image builds and `llama-server --version`
- writable persistent volume and four-CPU cgroup limit

AI assistance: I used Codex to implement and validate this change, then reviewed the final diff.
