### PR TITLE
feat(serve): speak the Anthropic Messages API to Anthropic

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -60,7 +60,9 @@ streaming SSE and function-tool-call re-mapping. For a local model this
 is a plain pass-through to `llama-server`'s own native `/v1/responses`
 support, so a recent enough `llama-server` build is required for it to
 work. For a [provider](providers.md) without the route, the daemon
-translates to and from `/v1/chat/completions` itself.
+translates to and from `/v1/chat/completions` itself, and for a provider
+that speaks the Anthropic Messages API from there to `/v1/messages` (see
+[wire formats](providers.md#wire-formats)).
 
 `/v1/audio/transcriptions` is likewise a pass-through. The model needs
 audio support (an `--mmproj` projector, supplied when the model image

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -128,8 +128,45 @@ loopback daemon and never for a cross-site browser request. On a shared
 machine prefer an integration that sends its own key.
 
 `codex` speaks only OpenAI's Responses API, which most providers lack
-(`anthropic` 404s it, `opencode` 500s it for non-OpenAI models). The
+(`mistral` 404s it, `opencode` 500s it for non-OpenAI models). The
 daemon tries the provider first and, on a 404/405/501 or 5xx, translates
 the request to a chat completion and the reply back, tool calls included.
 Providers that have the API (`openai`, `groq`, `openrouter`) are used
 natively; any other 4xx is relayed as-is.
+
+## Wire formats
+
+Each provider is spoken to in one of two wire formats, reported as
+`wire` by `/llmman/providers`:
+
+- `openai`: OpenAI Chat Completions with `Authorization: Bearer <key>`.
+  Every `@ai-sdk/openai-compatible` provider, plus the hand-checked
+  endpoints for `openai`, `google`, `groq`, `mistral` and the rest.
+- `anthropic`: the Anthropic Messages API with `x-api-key: <key>`.
+  `anthropic` itself. Other Messages-compatible endpoints are not
+  offered: their auth scheme varies and has not been checked.
+
+Anthropic is never reached through its OpenAI-compatibility shim. What a
+request becomes on the way to a `wire: anthropic` provider depends on
+the surface it arrived on:
+
+| Arrived on | Sent as |
+|------------|---------|
+| `/v1/messages` (Claude Code) | The same request, relayed intact: cache breakpoints, thinking, tools and `anthropic-beta` headers included. Only `model` is rewritten. |
+| `/v1/chat/completions` (OpenCode, Aider, Qwen Code, Hermes), `/api/chat`, `/api/generate` | A Messages request, and the reply back as chat-completion chunks: system turns to `system`, tool calls to `tool_use`/`tool_result`, `reasoning_effort` to a thinking budget, thinking back as `reasoning_content`. |
+| `/v1/responses` (Codex) | The Responses bridge above, then the same translation. The provider is not probed for `/v1/responses`. |
+
+`max_tokens` is required by the Messages API; a translated request
+without one gets the model's `limit.output` from the catalog, or 4096
+(a relayed `/v1/messages` request is the client's own to complete). `/v1/completions`,
+`/v1/embeddings`, `/api/embed`, `/api/embeddings` and
+`/v1/responses/input_tokens` have no Messages equivalent and are refused
+with a 501.
+
+The translation also does what the API needs that an OpenAI client would
+not know to: prompt caching is on (breakpoints on the last tool, system
+block and user block), a `response_format` JSON schema becomes a forced
+tool whose arguments are returned as the reply, tools used earlier in
+the history are declared back when the client offers none, an unanswered
+tool call gets a placeholder result, and thinking is left off for the
+continuation of a tool call or a forced tool.

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -28,11 +28,12 @@ use tokio::time::{sleep, Duration, Instant};
 use crate::default_store;
 use crate::metrics::{self, UnloadReason};
 use crate::modelpack::{resolve_model, ModelPath};
-use crate::providers::PLACEHOLDER_API_KEY;
+use crate::providers::{Wire, PLACEHOLDER_API_KEY};
 use crate::storage::OciStore;
 use crate::webui;
 
 mod aggregation;
+mod anthropic;
 mod responses;
 
 // ---------------------------------------------------------------------------
@@ -3184,7 +3185,7 @@ enum Target {
     /// Another `llmman serve`, by origin; speaks our dialect, so not
     /// `is_remote`.
     Peer(String),
-    /// A remote provider's OpenAI-compatible API.
+    /// A remote provider's API, in whichever [`Wire`] it speaks.
     Remote(Arc<RemoteTarget>),
 }
 
@@ -3197,14 +3198,20 @@ enum Target {
 struct RemoteTarget {
     /// models.dev provider id, for diagnostics.
     provider: String,
-    /// OpenAI-compatible base URL, without a trailing slash.
+    /// Base URL the wire's route is appended to, without a trailing slash.
     base_url: String,
+    /// What is spoken at `base_url`: route, credential header, and
+    /// whether a chat completion is translated (see `anthropic`).
+    wire: Wire,
     /// The model id as the *provider* knows it — i.e. the incoming
     /// reference with its [`crate::providers::REMOTE_PREFIX`] and
     /// provider segment stripped back off.
     model: String,
-    /// Bearer token for this request. See [`resolve_remote_target`] for
-    /// where it comes from.
+    /// The catalog's output ceiling, for a wire that requires
+    /// `max_tokens` (see [`anthropic::DEFAULT_MAX_TOKENS`]).
+    max_output: Option<u32>,
+    /// API key for this request. See [`resolve_remote_target`] for where
+    /// it comes from.
     api_key: String,
 }
 
@@ -3213,6 +3220,7 @@ impl std::fmt::Debug for RemoteTarget {
         f.debug_struct("RemoteTarget")
             .field("provider", &self.provider)
             .field("base_url", &self.base_url)
+            .field("wire", &self.wire)
             .field("model", &self.model)
             .field("api_key", &"<redacted>")
             .finish()
@@ -3235,7 +3243,8 @@ impl Target {
     }
 
     /// Attaches this target's credentials to an outgoing request, or for
-    /// a peer the hop marker.
+    /// a peer the hop marker: `Authorization: Bearer` for OpenAI,
+    /// `x-api-key` plus the API version for Anthropic.
     ///
     /// A no-op for [`Target::Local`]: a loopback `llama-server` has no
     /// auth, which is why nothing below ever forwarded the client's own
@@ -3245,12 +3254,31 @@ impl Target {
         match self {
             Self::Local(_) => req,
             Self::Peer(_) => req.header(aggregation::HOP, "1"),
-            Self::Remote(remote) => req.bearer_auth(&remote.api_key),
+            Self::Remote(remote) => match remote.wire {
+                Wire::OpenAi => req.bearer_auth(&remote.api_key),
+                Wire::Anthropic => req
+                    .header("x-api-key", &remote.api_key)
+                    .header("anthropic-version", anthropic::VERSION),
+            },
         }
     }
 
     fn is_remote(&self) -> bool {
         matches!(self, Self::Remote(_))
+    }
+
+    /// The wire a remote target speaks; `None` for a local backend or a
+    /// peer, which speak llmman's own OpenAI dialect.
+    fn wire(&self) -> Option<Wire> {
+        match self {
+            Self::Remote(remote) => Some(remote.wire),
+            _ => None,
+        }
+    }
+
+    /// Whether a chat completion here is translated to the Messages API.
+    fn is_anthropic(&self) -> bool {
+        self.wire() == Some(Wire::Anthropic)
     }
 
     /// Names this target for an error message. "inference backend" is
@@ -3270,7 +3298,9 @@ impl Target {
 /// The one route every typed request in this daemon is sent to: the
 /// Ollama and Anthropic surfaces are both translated into an OpenAI chat
 /// completion first (see `stream_ollama` / `handle_anthropic_messages`),
-/// so `post_chat` never needs any other.
+/// so `post_chat` never needs any other. A [`Wire::Anthropic`] target
+/// gets that completion translated once more in [`send_chat_completion`],
+/// the only place the wire is consulted for generation.
 const CHAT_COMPLETIONS_ROUTE: &str = "/v1/chat/completions";
 
 /// Extracts the caller's own API key from a request, in either spelling
@@ -3411,14 +3441,23 @@ async fn resolve_remote_target(
     let target = RemoteTarget {
         provider: provider_id,
         base_url: provider.base_url.clone(),
+        wire: provider.wire,
+        max_output: provider
+            .models
+            .iter()
+            .find(|m| m.id == model)
+            .and_then(|m| m.max_output),
         model,
         api_key,
     };
     // No key on this line: it is the one piece of a remote target that
     // must never reach a log file.
     eprintln!(
-        "[llmman] routing {} to provider {} ({})",
-        target.model, target.provider, target.base_url
+        "[llmman] routing {} to provider {} ({}, {} wire)",
+        target.model,
+        target.provider,
+        target.base_url,
+        target.wire.as_str()
     );
     Ok(Some(Target::Remote(Arc::new(target))))
 }
@@ -4141,9 +4180,12 @@ fn set_response_model(value: &mut serde_json::Value, canonical_model: &str) {
         value["model"] = serde_json::Value::String(canonical_model.to_string());
     }
     // A Responses API event nests it: `response.created`'s `response`.
-    if let Some(response) = value.get_mut("response") {
-        if response.get("model").is_some() {
-            response["model"] = serde_json::Value::String(canonical_model.to_string());
+    // So does a Messages API stream: `message_start`'s `message`.
+    for key in ["response", "message"] {
+        if let Some(nested) = value.get_mut(key) {
+            if nested.get("model").is_some() {
+                nested["model"] = serde_json::Value::String(canonical_model.to_string());
+            }
         }
     }
 }
@@ -4299,11 +4341,12 @@ fn relay_stream_rewriting_model(
     canonical_model: String,
 ) -> Response {
     let status = resp.status();
-    // Only content-type is meaningful to forward for a stream the
-    // caller is about to reconstruct line by line — content-length
-    // (absent anyway for a real chunked/streamed response) would be
-    // stale the same way proxy_rewriting_model's is, if present.
-    let content_type = resp.headers().get(reqwest::header::CONTENT_TYPE).cloned();
+    // Every header but the ones describing a body about to be rewritten
+    // line by line: a provider's `request-id`, rate limits and
+    // `Retry-After` matter to the client.
+    let mut resp_headers = resp.headers().clone();
+    resp_headers.remove(reqwest::header::CONTENT_LENGTH);
+    resp_headers.remove(reqwest::header::TRANSFER_ENCODING);
 
     let stream = bytes_to_lines(resp.bytes_stream()).map(move |line| {
         // See `proxy`'s own comment on this same pattern.
@@ -4316,8 +4359,8 @@ fn relay_stream_rewriting_model(
     });
 
     let mut builder = Response::builder().status(status.as_u16());
-    if let Some(ct) = content_type {
-        builder = builder.header(reqwest::header::CONTENT_TYPE, ct);
+    for (k, v) in &resp_headers {
+        builder = builder.header(k, v);
     }
     builder.body(Body::from_stream(stream)).unwrap()
 }
@@ -4417,8 +4460,183 @@ fn repeat_penalty_applies(target: &Target) -> bool {
     !target.is_remote()
 }
 
-/// POSTs oai_req to url and returns the still-streaming response, converting
-/// a non-2xx status into an AppError carrying the backend's error body.
+/// A chat completion's body from any target: OpenAI-shaped bytes,
+/// whatever the provider spoke.
+type ChatBody = futures::stream::BoxStream<'static, reqwest::Result<Bytes>>;
+
+/// A chat completion's answer from upstream, before anything reads it.
+/// Always OpenAI-shaped: a [`Wire::Anthropic`] reply has already been
+/// translated (see [`send_chat_completion`]), so every consumer reads
+/// one dialect.
+struct ChatUpstream {
+    status: StatusCode,
+    /// The provider's response headers (`request-id`, rate limits,
+    /// `Retry-After`), minus any describing a body since replaced.
+    headers: HeaderMap,
+    body: ChatBody,
+}
+
+impl ChatUpstream {
+    /// Wraps a provider's answer unchanged.
+    fn relay(resp: reqwest::Response) -> Self {
+        Self {
+            status: resp.status(),
+            headers: resp.headers().clone(),
+            body: resp.bytes_stream().boxed(),
+        }
+    }
+
+    /// The provider's headers with a translated body of `content_type`
+    /// in place of the one they described.
+    fn translated(resp: &reqwest::Response, content_type: &'static str) -> HeaderMap {
+        let mut headers = resp.headers().clone();
+        headers.remove(reqwest::header::CONTENT_LENGTH);
+        headers.remove(reqwest::header::TRANSFER_ENCODING);
+        headers.insert(
+            reqwest::header::CONTENT_TYPE,
+            reqwest::header::HeaderValue::from_static(content_type),
+        );
+        headers
+    }
+
+    /// Reads the whole body; a read error ends it early.
+    async fn text(self) -> String {
+        String::from_utf8_lossy(&collect_body(self.body).await).into_owned()
+    }
+}
+
+/// Everything a body stream yields until it ends or fails.
+async fn collect_body(mut body: ChatBody) -> Vec<u8> {
+    let mut out = Vec::new();
+    while let Some(Ok(chunk)) = body.next().await {
+        out.extend_from_slice(&chunk);
+    }
+    out
+}
+
+/// POSTs one OpenAI chat-completion request to `target` in the wire it
+/// speaks and returns the answer OpenAI-shaped.
+///
+/// An OpenAI target, local backend or peer gets `req` as-is on
+/// [`CHAT_COMPLETIONS_ROUTE`]. An Anthropic target gets it translated by
+/// [`anthropic::from_chat_request`] onto [`anthropic::MESSAGES_ROUTE`]
+/// and the reply translated back by [`anthropic::StreamConverter`]:
+/// streamed when the caller streams, folded into one object otherwise.
+/// `response_model` is the name that translation echoes back.
+///
+/// A non-2xx is returned as-is so a caller can relay the provider's own
+/// error. Only a request the Messages API cannot carry fails here (400).
+async fn send_chat_completion<T: Serialize + ?Sized>(
+    client: &Client,
+    target: &Target,
+    req: &T,
+    response_model: &str,
+) -> Result<ChatUpstream, AppError> {
+    if !target.is_anthropic() {
+        let resp = target
+            .authorize(client.post(target.url(CHAT_COMPLETIONS_ROUTE)).json(req))
+            .send()
+            .await
+            .with_context(|| format!("send to {}", target.describe()))?;
+        return Ok(ChatUpstream::relay(resp));
+    }
+
+    let req = serde_json::to_value(req).context("serialize chat request")?;
+    let streaming = req
+        .get("stream")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let default_max_tokens = match target {
+        Target::Remote(remote) => remote.max_output,
+        _ => None,
+    }
+    .unwrap_or(anthropic::DEFAULT_MAX_TOKENS);
+    let messages_req = anthropic::from_chat_request(&req, default_max_tokens)
+        .map_err(|e| AppError(e, StatusCode::BAD_REQUEST))?;
+    let mut upstream = target.authorize(client.post(target.url(anthropic::MESSAGES_ROUTE)));
+    if anthropic::thinks(&messages_req) {
+        upstream = upstream.header("anthropic-beta", anthropic::INTERLEAVED_THINKING_BETA);
+    }
+    let resp = upstream
+        .json(&messages_req)
+        .send()
+        .await
+        .with_context(|| format!("send to {}", target.describe()))?;
+    if !resp.status().is_success() {
+        return Ok(ChatUpstream::relay(resp));
+    }
+
+    let mut converter =
+        anthropic::StreamConverter::new(response_model).json_tool(anthropic::json_tool_name(&req));
+    if !streaming {
+        let headers = ChatUpstream::translated(&resp, "application/json");
+        let lines: Vec<String> = bytes_to_lines(resp.bytes_stream()).collect().await;
+        for line in &lines {
+            converter.line(line);
+        }
+        converter.finish();
+        // A 200 whose stream errored or ended early is a gateway failure,
+        // not a truncated success.
+        let (status, body) = match converter.error() {
+            Some(error) => (
+                StatusCode::BAD_GATEWAY,
+                serde_json::json!({ "error": error }),
+            ),
+            None if !converter.finished() => (
+                StatusCode::BAD_GATEWAY,
+                serde_json::json!({ "error": {
+                    "message": format!("{} closed the stream before finishing", target.describe()),
+                    "type": "server_error",
+                } }),
+            ),
+            None => (StatusCode::OK, converter.completion()),
+        };
+        let body = Bytes::from(serde_json::to_vec(&body).unwrap_or_default());
+        return Ok(ChatUpstream {
+            status,
+            headers,
+            body: futures::stream::once(futures::future::ready(Ok(body))).boxed(),
+        });
+    }
+
+    // A trailing `None` lets the converter close a stream the provider
+    // ended without `message_stop`.
+    let headers = ChatUpstream::translated(&resp, "text/event-stream");
+    let body = bytes_to_lines(resp.bytes_stream())
+        .map(Some)
+        .chain(futures::stream::once(futures::future::ready(None)))
+        .map(move |line| {
+            let out = match line {
+                Some(line) => converter.line(&line),
+                None => converter.finish(),
+            };
+            Ok(Bytes::from(out))
+        })
+        .boxed();
+    Ok(ChatUpstream {
+        status: StatusCode::OK,
+        headers,
+        body,
+    })
+}
+
+/// [`relay`] for a [`ChatUpstream`]: `activity` lives until the whole
+/// body has been relayed (see `ActivityGuard`).
+fn relay_chat_upstream(upstream: ChatUpstream, activity: ActivityGuard) -> Response {
+    let stream = upstream.body.map(move |item| {
+        let _activity = &activity;
+        item.map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+    });
+    let mut builder = Response::builder().status(upstream.status.as_u16());
+    for (k, v) in &upstream.headers {
+        builder = builder.header(k, v);
+    }
+    builder.body(Body::from_stream(stream)).unwrap()
+}
+
+/// POSTs oai_req to url and returns the still-streaming, OpenAI-shaped
+/// body, converting a non-2xx status into an AppError carrying the
+/// backend's error body.
 /// The *only* function that actually sends an `OAIChatRequest` to
 /// llama-server — every caller (`collect_completion`, `stream_ollama`,
 /// `stream_anthropic`, and `handle_anthropic_messages`'s non-streaming
@@ -4429,24 +4647,17 @@ async fn post_chat(
     client: &Client,
     target: &Target,
     oai_req: &mut OAIChatRequest,
-) -> Result<reqwest::Response, AppError> {
+) -> Result<ChatBody, AppError> {
     if repeat_penalty_applies(target) {
         apply_default_repeat_penalty_typed(oai_req);
     } else {
         oai_req.repeat_penalty = None;
     }
-    let resp = target
-        .authorize(
-            client
-                .post(target.url(CHAT_COMPLETIONS_ROUTE))
-                .json(oai_req),
-        )
-        .send()
-        .await
-        .with_context(|| format!("send to {}", target.describe()))?;
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
+    // Typed callers build their own chunks and never read the model.
+    let upstream = send_chat_completion(client, target, &*oai_req, &oai_req.model).await?;
+    if !upstream.status.is_success() {
+        let status = upstream.status;
+        let body = upstream.text().await;
         let message = format!("{} {status}: {body}", target.describe());
         // Same message either way; the marker lets a hybrid pair retry
         // on its hosted half (see send_with_hybrid_fallback).
@@ -4462,7 +4673,7 @@ async fn post_chat(
         // keeps the blanket 500 it always returned.
         return Err(AppError(error, remote_status(target, status)));
     }
-    Ok(resp)
+    Ok(upstream.body)
 }
 
 /// A local backend's refusal of a request as larger than its context,
@@ -4790,7 +5001,7 @@ async fn stream_ollama<T: Serialize + Send + 'static>(
         let _activity = activity;
         let decoder = OllamaLineDecoder::new();
         let mut fold = OllamaFold::default();
-        let mut lines = Box::pin(bytes_to_lines(resp.bytes_stream()));
+        let mut lines = Box::pin(bytes_to_lines(resp));
         while let Some(line) = lines.next().await {
             if let Some(delta) = decoder.decode(&line) {
                 fold.push(delta);
@@ -4817,7 +5028,7 @@ async fn stream_ollama<T: Serialize + Send + 'static>(
     }
 
     let decoder = OllamaLineDecoder::new();
-    let stream = bytes_to_lines(resp.bytes_stream()).map(move |line| {
+    let stream = bytes_to_lines(resp).map(move |line| {
         // Moved into this closure purely to keep it alive — see
         // ActivityGuard's doc comment — until the stream itself is
         // dropped, not referenced otherwise.
@@ -4880,7 +5091,7 @@ async fn stream_anthropic(
             Bytes::from(preamble),
         )));
 
-    let sse_stream = bytes_to_lines(resp.bytes_stream()).map(move |line| {
+    let sse_stream = bytes_to_lines(resp).map(move |line| {
         let out = if let Some(payload) = line.strip_prefix("data: ") {
             if payload == "[DONE]" {
                 let msg_delta = serde_json::json!({
@@ -5070,6 +5281,9 @@ struct ProviderSummary {
     name: String,
     base_url: String,
     key_env: String,
+    /// What is spoken at `base_url`: `openai` or `anthropic` (see
+    /// [`crate::providers::Wire`]).
+    wire: &'static str,
     /// Whether *this daemon's* environment holds `key_env`.
     key_set: bool,
     /// Whether it would actually spend it for a request that presents no
@@ -5088,6 +5302,7 @@ impl From<&crate::providers::Provider> for ProviderSummary {
             name: p.name.clone(),
             base_url: p.base_url.clone(),
             key_env: p.key_env.clone(),
+            wire: p.wire.as_str(),
             key_set: p.api_key().is_some(),
             key_usable: daemon_key_usable(p),
             models: p.models.len(),
@@ -5115,6 +5330,8 @@ struct ProviderResponse {
     name: String,
     base_url: String,
     key_env: String,
+    /// See [`ProviderSummary::wire`].
+    wire: &'static str,
     key_set: bool,
     /// See [`ProviderSummary::key_usable`].
     key_usable: bool,
@@ -5146,6 +5363,7 @@ impl From<&crate::providers::Provider> for ProviderResponse {
             name: p.name.clone(),
             base_url: p.base_url.clone(),
             key_env: p.key_env.clone(),
+            wire: p.wire.as_str(),
             key_set: p.api_key().is_some(),
             key_usable: daemon_key_usable(p),
             models: p
@@ -6358,6 +6576,9 @@ async fn embed_via_backend(
     if !target.is_remote() && would_use_mlx(state, &model).await.is_some() {
         return Err(mlx_unsupported(&model));
     }
+    if let Some(refusal) = wire_refusal(&target, "/v1/embeddings") {
+        return Err(AppError::status(StatusCode::NOT_IMPLEMENTED, refusal));
+    }
     let keep_alive = resolve_keep_alive(keep_alive);
     if inputs.is_empty() {
         refresh_activity(guard, keep_alive).await;
@@ -6823,6 +7044,10 @@ async fn proxy_openai_generation_to(
 ) -> Result<Response, AppError> {
     let (mut req, target, activity, response_model_override) =
         prepare_openai_request(state, req, model, target, guard).await?;
+    if let Some(refusal) = unsupported_on_wire(&target, llama_path) {
+        drop(activity);
+        return Ok(refusal);
+    }
     if llama_path == RESPONSES_ROUTE && target.is_remote() {
         // See repeat_penalty_applies: a strict provider 400s on it.
         if let Some(req) = req.as_object_mut() {
@@ -6832,6 +7057,16 @@ async fn proxy_openai_generation_to(
         let canonical = response_model_override
             .unwrap_or_else(|| req["model"].as_str().unwrap_or_default().to_string());
         return remote_responses(&state.0.client, &target, headers, req, activity, canonical).await;
+    }
+    if llama_path == CHAT_COMPLETIONS_ROUTE && target.is_anthropic() {
+        if let Some(req) = req.as_object_mut() {
+            req.remove("repeat_penalty");
+        }
+        let canonical = response_model_override
+            .unwrap_or_else(|| req["model"].as_str().unwrap_or_default().to_string());
+        // The translated reply already names the canonical model.
+        let upstream = send_chat_completion(&state.0.client, &target, &req, &canonical).await?;
+        return Ok(relay_chat_upstream(upstream, activity));
     }
     if is_responses_route(llama_path) && !target.is_remote() {
         sanitize_responses_request(&mut req);
@@ -6941,6 +7176,10 @@ async fn proxy_openai_passthrough(
     }
     let (mut req, target, activity, response_model_override) =
         resolve_openai_request(state, headers, body).await?;
+    if let Some(refusal) = unsupported_on_wire(&target, llama_path) {
+        drop(activity);
+        return Ok(refusal);
+    }
     if is_responses_route(llama_path) && !target.is_remote() {
         sanitize_responses_request(&mut req);
     }
@@ -7173,53 +7412,49 @@ async fn remote_responses(
     canonical_model: String,
 ) -> Result<Response, AppError> {
     let streaming = req.get("stream").and_then(|v| v.as_bool()).unwrap_or(false);
-    let body = Bytes::from(serde_json::to_vec(&req).context("re-serialize OpenAI request body")?);
-    let mut native = target.authorize(client.post(target.url(RESPONSES_ROUTE)).body(body));
-    if let Some(ct) = headers.get("content-type") {
-        native = native.header("content-type", ct);
+    // The Messages API has no Responses route; skip the 404 round trip.
+    if !target.is_anthropic() {
+        let body =
+            Bytes::from(serde_json::to_vec(&req).context("re-serialize OpenAI request body")?);
+        let mut native = target.authorize(client.post(target.url(RESPONSES_ROUTE)).body(body));
+        if let Some(ct) = headers.get("content-type") {
+            native = native.header("content-type", ct);
+        }
+        let resp = native
+            .send()
+            .await
+            .with_context(|| format!("proxy request to {}", target.describe()))?;
+        let status = resp.status();
+        if status.is_success() {
+            return if streaming {
+                Ok(relay_stream_rewriting_model(
+                    resp,
+                    activity,
+                    canonical_model,
+                ))
+            } else {
+                relay_rewriting_model(resp, activity, &canonical_model).await
+            };
+        }
+        if !responses::falls_back(status) {
+            return Ok(relay(resp, activity));
+        }
+        eprintln!(
+            "[llmman] {} answered {RESPONSES_ROUTE} with {status}; retrying as a chat completion",
+            target.describe()
+        );
     }
-    let resp = native
-        .send()
-        .await
-        .with_context(|| format!("proxy request to {}", target.describe()))?;
-    let status = resp.status();
-    if status.is_success() {
-        return if streaming {
-            Ok(relay_stream_rewriting_model(
-                resp,
-                activity,
-                canonical_model,
-            ))
-        } else {
-            relay_rewriting_model(resp, activity, &canonical_model).await
-        };
-    }
-    if !responses::falls_back(status) {
-        return Ok(relay(resp, activity));
-    }
-    eprintln!(
-        "[llmman] {} answered {RESPONSES_ROUTE} with {status}; retrying as a chat completion",
-        target.describe()
-    );
 
     let chat_req = responses::from_responses_request(&req)
         .map_err(|e| AppError(e, StatusCode::BAD_REQUEST))?;
-    let resp = target
-        .authorize(
-            client
-                .post(target.url(CHAT_COMPLETIONS_ROUTE))
-                .json(&chat_req),
-        )
-        .send()
-        .await
-        .with_context(|| format!("send to {}", target.describe()))?;
-    let status = resp.status();
+    let upstream = send_chat_completion(client, target, &chat_req, &canonical_model).await?;
+    let status = upstream.status;
     if status.is_client_error() {
         // The provider's own error object, intact for a client that reads it.
-        return Ok(relay(resp, activity));
+        return Ok(relay_chat_upstream(upstream, activity));
     }
     if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
+        let body = upstream.text().await;
         return Err(AppError(
             anyhow!("{} {status}: {body}", target.describe()),
             remote_status(target, status),
@@ -7228,7 +7463,7 @@ async fn remote_responses(
 
     let mut converter = responses::StreamConverter::new(&canonical_model, &req);
     if !streaming {
-        let lines: Vec<String> = bytes_to_lines(resp.bytes_stream()).collect().await;
+        let lines: Vec<String> = bytes_to_lines(upstream.body).collect().await;
         drop(activity);
         let response = converter.fold(lines);
         let status = if converter.failed() {
@@ -7241,7 +7476,7 @@ async fn remote_responses(
 
     // A trailing `None` lets the converter close a stream the provider
     // ended without `[DONE]`.
-    let sse_stream = bytes_to_lines(resp.bytes_stream())
+    let sse_stream = bytes_to_lines(upstream.body)
         .map(Some)
         .chain(futures::stream::once(futures::future::ready(None)))
         .map(move |line| {
@@ -7288,15 +7523,41 @@ fn is_responses_route(llama_path: &str) -> bool {
     llama_path.starts_with("/v1/responses")
 }
 
+/// Routes the Messages API has no equivalent of (legacy completions,
+/// embeddings, Responses token counting), refused with a 501 instead of
+/// a round trip that could only 404.
+fn unsupported_on_wire(target: &Target, route: &str) -> Option<Response> {
+    let message = wire_refusal(target, route)?;
+    let body = serde_json::json!({
+        "error": { "message": message, "type": "invalid_request_error" }
+    });
+    Some((StatusCode::NOT_IMPLEMENTED, Json(body)).into_response())
+}
+
+/// The message behind [`unsupported_on_wire`], for the Ollama embedding
+/// routes.
+fn wire_refusal(target: &Target, route: &str) -> Option<String> {
+    let Target::Remote(remote) = target else {
+        return None;
+    };
+    if remote.wire != Wire::Anthropic || matches!(route, CHAT_COMPLETIONS_ROUTE | RESPONSES_ROUTE) {
+        return None;
+    }
+    Some(format!(
+        "provider {} speaks the Anthropic Messages API, which has no equivalent of {route}; \
+         only chat completions, /v1/responses and /v1/messages reach it",
+        remote.provider
+    ))
+}
+
 /// Explains a provider's bare 404 on the Responses API.
 ///
 /// Being OpenAI-wire-format does not mean implementing every OpenAI
 /// route: `openai`, `groq` and `openrouter` answer `/v1/responses*`,
-/// `anthropic` and `mistral` 404. Generation is bridged by
-/// [`remote_responses`], so this only fires for
-/// `/v1/responses/input_tokens`, which has no chat-completions
-/// equivalent. It reports the 404 actually received rather than
-/// predicting one from a list that would go stale.
+/// `mistral` 404s. Generation is bridged by [`remote_responses`], so
+/// this only fires for `/v1/responses/input_tokens`, which has no
+/// chat-completions equivalent. It reports the 404 actually received
+/// rather than predicting one from a list that would go stale.
 fn explain_missing_route(target: &Target, route: &str, resp: Response) -> Response {
     if resp.status() != StatusCode::NOT_FOUND || !is_responses_route(route) {
         return resp;
@@ -7460,29 +7721,40 @@ fn build_anthropic_messages(req: &AnthropicRequest) -> Vec<OAIMessage> {
     messages
 }
 
+/// The Anthropic Messages surface. The body is kept raw until the target
+/// is known: a [`Wire::Anthropic`] provider gets it relayed as sent (see
+/// [`relay_anthropic_messages`]); anything else gets the
+/// [`AnthropicRequest`] subset translated into a chat completion.
 async fn handle_anthropic_messages(
     State(state): State<AppState>,
     headers: HeaderMap,
-    Json(req): Json<AnthropicRequest>,
+    body: Bytes,
 ) -> Result<Response, AppError> {
+    let raw: serde_json::Value = serde_json::from_slice(&body).map_err(|e| {
+        AppError(
+            anyhow!("parse Anthropic request: {e}"),
+            StatusCode::BAD_REQUEST,
+        )
+    })?;
+    let model_ref = raw["model"].as_str().unwrap_or("").to_string();
     // No `request_threads`: the Anthropic Messages API has no Ollama
     // options blob, so there is no num_thread to forward.
-    let model_ref = req.model.clone();
     send_with_hybrid_fallback(
         &state,
         &model_ref,
         Some(&headers),
         None,
-        |model, target, guard| anthropic_messages_to(&state, &req, model, target, guard),
+        |model, target, guard| anthropic_messages_to(&state, &headers, &raw, model, target, guard),
     )
     .await
 }
 
 /// [`handle_anthropic_messages`] against one resolved target. The
-/// response echoes `req.model` back, unchanged from before.
+/// response echoes the client's own `model` back, unchanged from before.
 async fn anthropic_messages_to(
     state: &AppState,
-    req: &AnthropicRequest,
+    headers: &HeaderMap,
+    raw: &serde_json::Value,
     canonical_model: String,
     target: Target,
     guard: ActivityGuard,
@@ -7492,12 +7764,32 @@ async fn anthropic_messages_to(
     // (see resolve_openai_request's own comment on why).
     let activity = begin_activity(guard, None).await;
 
-    let messages = build_anthropic_messages(req);
-
     // See backend_wire_model's own doc comment — usually just
     // canonical_model itself, but a different value for an Engine::Mlx
     // backend or a remote provider.
     let wire_model = backend_wire_model(state, &target, &canonical_model).await;
+
+    if target.is_anthropic() {
+        return relay_anthropic_messages(
+            &state.0.client,
+            &target,
+            headers,
+            raw,
+            &wire_model,
+            activity,
+        )
+        .await;
+    }
+
+    let req: AnthropicRequest = serde_json::from_value(raw.clone()).map_err(|e| {
+        AppError(
+            anyhow!("parse Anthropic request: {e}"),
+            StatusCode::BAD_REQUEST,
+        )
+    })?;
+    let req = &req;
+    let messages = build_anthropic_messages(req);
+
     let mut oai = OAIChatRequest {
         model: wire_model,
         messages,
@@ -7532,7 +7824,8 @@ async fn anthropic_messages_to(
         // also gets repeat_penalty defaulted instead of needing its own
         // copy of that logic.
         let resp = post_chat(&state.0.client, &target, &mut oai).await?;
-        let body: serde_json::Value = resp.json().await.context("parse llama-server response")?;
+        let body: serde_json::Value = serde_json::from_slice(&collect_body(resp).await)
+            .context("parse llama-server response")?;
         let content = body["choices"][0]["message"]["content"]
             .as_str()
             .unwrap_or("")
@@ -7549,6 +7842,49 @@ async fn anthropic_messages_to(
         }))
         .into_response())
     }
+}
+
+/// Headers a `/v1/messages` caller sets for the provider: opt-in
+/// features and the API version it wrote against. Its credential is not
+/// among them (see `Target::authorize`).
+const ANTHROPIC_PASSTHROUGH_HEADERS: [&str; 2] = ["anthropic-beta", "anthropic-version"];
+
+/// `/v1/messages` to a provider that speaks it: relayed as sent, with
+/// only `model` rewritten out and back. Claude Code's cache breakpoints,
+/// thinking, betas and tools, which the typed [`AnthropicRequest`]
+/// translation drops for llama-server, reach a provider intact.
+async fn relay_anthropic_messages(
+    client: &Client,
+    target: &Target,
+    headers: &HeaderMap,
+    raw: &serde_json::Value,
+    wire_model: &str,
+    activity: ActivityGuard,
+) -> Result<Response, AppError> {
+    let client_model = raw["model"].as_str().unwrap_or_default().to_string();
+    let streaming = raw["stream"].as_bool().unwrap_or(false);
+    let mut body = raw.clone();
+    body["model"] = serde_json::Value::String(wire_model.to_string());
+
+    // `headers()` replaces the `authorize` default; `header()` would
+    // append a second `anthropic-version`.
+    let mut passthrough = HeaderMap::new();
+    for name in ANTHROPIC_PASSTHROUGH_HEADERS {
+        if let Some(value) = headers.get(name) {
+            passthrough.insert(name, value.clone());
+        }
+    }
+    let resp = target
+        .authorize(client.post(target.url(anthropic::MESSAGES_ROUTE)))
+        .headers(passthrough)
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("proxy request to {}", target.describe()))?;
+    if streaming {
+        return Ok(relay_stream_rewriting_model(resp, activity, client_model));
+    }
+    relay_rewriting_model(resp, activity, &client_model).await
 }
 
 // ---------------------------------------------------------------------------
@@ -8320,10 +8656,16 @@ mod tests {
     // -- request targets (local backend vs remote provider) -----------------
 
     fn remote_target(base_url: &str) -> Target {
+        remote_target_on(base_url, Wire::OpenAi)
+    }
+
+    fn remote_target_on(base_url: &str, wire: Wire) -> Target {
         Target::Remote(Arc::new(RemoteTarget {
             provider: "mockprov".into(),
             base_url: base_url.into(),
+            wire,
             model: "mock-model".into(),
+            max_output: None,
             api_key: "sk-test".into(),
         }))
     }
@@ -8610,13 +8952,9 @@ mod tests {
             let (status, headers, body) = call_remote_responses(&base, true).await;
             assert_eq!(status, native);
             assert!(body.contains("\"native\""), "{native}: {body}");
-            // A failure is relayed whole; a success is re-streamed line by
-            // line with only its content-type.
-            assert_eq!(
-                headers.contains_key("x-provider"),
-                !native.is_success(),
-                "{native}"
-            );
+            // Relayed whole or re-streamed line by line, the provider's
+            // own headers reach the client either way.
+            assert!(headers.contains_key("x-provider"), "{native}");
         }
     }
 
@@ -8737,7 +9075,7 @@ mod tests {
             tools: None,
             response_format: None,
         };
-        post_chat(&Client::new(), &target, &mut req).await.unwrap();
+        let _body = post_chat(&Client::new(), &target, &mut req).await.unwrap();
 
         let (auth, body) = seen.lock().await.take().expect("provider was not called");
         assert_eq!(auth, "Bearer sk-test");
@@ -8746,6 +9084,235 @@ mod tests {
             body.get("repeat_penalty").is_none(),
             "llama.cpp-only field sent to a provider: {body}"
         );
+    }
+
+    /// A mock Messages API: records requests, answers `/v1/messages` with
+    /// `reply`, 404s everything else.
+    async fn mock_anthropic(
+        reply: &'static str,
+    ) -> (
+        String,
+        Arc<tokio::sync::Mutex<Vec<(String, HeaderMap, serde_json::Value)>>>,
+    ) {
+        let seen = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let captured = seen.clone();
+        let app = Router::new()
+            .route(
+                "/v1/messages",
+                post(move |headers: HeaderMap, body: Bytes| async move {
+                    let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+                    captured
+                        .lock()
+                        .await
+                        .push(("/v1/messages".to_string(), headers, body));
+                    (
+                        [
+                            ("content-type", "text/event-stream"),
+                            ("request-id", "req_mock"),
+                        ],
+                        reply,
+                    )
+                }),
+            )
+            .fallback(|req: Request| async move {
+                (
+                    StatusCode::NOT_FOUND,
+                    format!("no such route: {}", req.uri().path()),
+                )
+            });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!(
+            "http://127.0.0.1:{}/v1",
+            listener.local_addr().unwrap().port()
+        );
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        (base, seen)
+    }
+
+    const MOCK_MESSAGES_STREAM: &str = "event: message_start\n\
+        data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"model\":\"claude-x\",\"usage\":{\"input_tokens\":3,\"output_tokens\":1}}}\n\n\
+        event: content_block_start\n\
+        data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n\
+        event: content_block_delta\n\
+        data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi there\"}}\n\n\
+        event: message_delta\n\
+        data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\n\
+        event: message_stop\n\
+        data: {\"type\":\"message_stop\"}\n\n";
+
+    /// An Anthropic-wire provider gets `/v1/messages`, `x-api-key`, the
+    /// version header and a Messages body; what comes back is the
+    /// chat-completion SSE every consumer here reads.
+    #[tokio::test]
+    async fn a_typed_request_to_an_anthropic_provider_speaks_messages() {
+        let (base, seen) = mock_anthropic(MOCK_MESSAGES_STREAM).await;
+        let target = remote_target_on(&base, Wire::Anthropic);
+        let mut req = OAIChatRequest {
+            model: "mock-model".into(),
+            messages: vec![
+                OAIMessage::text("system", "be brief"),
+                OAIMessage::text("user", "hello"),
+            ],
+            stream: true,
+            repeat_penalty: Some(1.1),
+            ..Default::default()
+        };
+        let body = post_chat(&Client::new(), &target, &mut req).await.unwrap();
+        let lines: Vec<String> = bytes_to_lines(body).collect().await;
+
+        let calls = seen.lock().await;
+        let (path, headers, sent) = &calls[0];
+        assert_eq!(path, "/v1/messages");
+        assert_eq!(headers["x-api-key"], "sk-test");
+        assert_eq!(headers["anthropic-version"], anthropic::VERSION);
+        assert!(
+            headers.get("authorization").is_none(),
+            "bearer sent to Anthropic"
+        );
+        assert_eq!(sent["model"], "mock-model");
+        assert_eq!(sent["system"][0]["text"], "be brief");
+        assert_eq!(sent["messages"][0]["role"], "user");
+        assert_eq!(sent["messages"][0]["content"][0]["text"], "hello");
+        // Prompt caching on by default; no thinking, so no beta header.
+        assert_eq!(sent["system"][0]["cache_control"]["type"], "ephemeral");
+        assert!(headers.get("anthropic-beta").is_none());
+        assert_eq!(sent["max_tokens"], anthropic::DEFAULT_MAX_TOKENS);
+        assert_eq!(sent["stream"], true);
+        assert!(sent.get("repeat_penalty").is_none(), "{sent}");
+
+        // Decoded exactly as a llama-server stream would be.
+        let fold = fold_ollama_lines(lines);
+        assert_eq!(fold.content, "hi there");
+        assert!(fold.done);
+    }
+
+    /// A `stream: false` caller gets one object, folded from the stream
+    /// the provider was asked for regardless.
+    #[tokio::test]
+    async fn a_non_streaming_request_to_an_anthropic_provider_is_folded() {
+        let (base, seen) = mock_anthropic(MOCK_MESSAGES_STREAM).await;
+        let target = remote_target_on(&base, Wire::Anthropic);
+        let req = serde_json::json!({
+            "model": "mock-model",
+            "messages": [{ "role": "user", "content": "hello" }],
+            "stream": false
+        });
+        let upstream = send_chat_completion(
+            &Client::new(),
+            &target,
+            &req,
+            "llmman.provider/mockprov/mock-model",
+        )
+        .await
+        .unwrap();
+        assert_eq!(upstream.status, StatusCode::OK);
+        assert_eq!(upstream.headers["content-type"], "application/json");
+        assert!(upstream.headers.get("content-length").is_none());
+        // The provider's own headers survive translation.
+        assert_eq!(upstream.headers["request-id"], "req_mock");
+        let body: serde_json::Value = serde_json::from_str(&upstream.text().await).unwrap();
+        assert_eq!(body["object"], "chat.completion");
+        assert_eq!(body["model"], "llmman.provider/mockprov/mock-model");
+        assert_eq!(body["choices"][0]["message"]["content"], "hi there");
+        assert_eq!(body["choices"][0]["finish_reason"], "stop");
+        assert_eq!(body["usage"]["total_tokens"], 5);
+        assert_eq!(seen.lock().await[0].2["stream"], true);
+    }
+
+    /// `/v1/messages` is relayed whole, `model` rewritten, the client's
+    /// `anthropic-beta` forwarded and its credential not.
+    #[tokio::test]
+    async fn an_inbound_messages_request_is_relayed_to_an_anthropic_provider_intact() {
+        let (base, seen) = mock_anthropic(MOCK_MESSAGES_STREAM).await;
+        let target = remote_target_on(&base, Wire::Anthropic);
+        let state = test_state();
+        let raw = serde_json::json!({
+            "model": "llmman.provider/mockprov/mock-model",
+            "max_tokens": 32,
+            "stream": true,
+            "system": [{ "type": "text", "text": "sys", "cache_control": { "type": "ephemeral" } }],
+            "messages": [{ "role": "user", "content": "hi" }],
+            "thinking": { "type": "enabled", "budget_tokens": 1024 },
+            "tools": [{ "name": "f", "input_schema": { "type": "object" } }]
+        });
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "anthropic-beta",
+            "interleaved-thinking-2025-05-14".parse().unwrap(),
+        );
+        headers.insert("anthropic-version", "2024-01-01".parse().unwrap());
+        headers.insert("x-api-key", "the-clients-own-key".parse().unwrap());
+        let activity = begin_activity(ActivityGuard::new(&state, "m"), None).await;
+        let resp = relay_anthropic_messages(
+            &Client::new(),
+            &target,
+            &headers,
+            &raw,
+            "mock-model",
+            activity,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.headers()["request-id"], "req_mock");
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8_lossy(&body);
+        // The provider's `model` echo is rewritten back to the client's.
+        assert!(
+            body.contains("\"model\":\"llmman.provider/mockprov/mock-model\""),
+            "{body}"
+        );
+        assert!(!body.contains("claude-x"), "{body}");
+
+        let calls = seen.lock().await;
+        let (_, sent_headers, sent) = &calls[0];
+        assert_eq!(
+            sent_headers["anthropic-beta"],
+            "interleaved-thinking-2025-05-14"
+        );
+        // The client's version replaces the default: one value only.
+        let versions: Vec<_> = sent_headers.get_all("anthropic-version").iter().collect();
+        assert_eq!(versions, ["2024-01-01"]);
+        // The target's key, never the client's header relayed as-is.
+        assert_eq!(sent_headers["x-api-key"], "sk-test");
+        let mut expected = raw.clone();
+        expected["model"] = serde_json::json!("mock-model");
+        assert_eq!(*sent, expected);
+    }
+
+    /// Routes without a Messages equivalent are refused before any
+    /// request leaves; the two that reach it, and other targets, are not.
+    #[test]
+    fn routes_without_a_messages_equivalent_are_refused_up_front() {
+        let anthropic = remote_target_on("https://api.anthropic.com/v1", Wire::Anthropic);
+        for route in [
+            "/v1/completions",
+            "/v1/embeddings",
+            "/v1/responses/input_tokens",
+        ] {
+            let refusal = unsupported_on_wire(&anthropic, route)
+                .unwrap_or_else(|| panic!("{route} was not refused"));
+            assert_eq!(refusal.status(), StatusCode::NOT_IMPLEMENTED);
+        }
+        for route in [CHAT_COMPLETIONS_ROUTE, RESPONSES_ROUTE] {
+            assert!(unsupported_on_wire(&anthropic, route).is_none(), "{route}");
+        }
+        let openai = remote_target("https://api.openai.com/v1");
+        assert!(unsupported_on_wire(&openai, "/v1/embeddings").is_none());
+        assert!(unsupported_on_wire(&Target::Local(1), "/v1/embeddings").is_none());
+    }
+
+    /// `message_start` nests the model one level down.
+    #[test]
+    fn set_response_model_reaches_a_messages_stream_event() {
+        let mut event = serde_json::json!({
+            "type": "message_start",
+            "message": { "id": "msg_1", "model": "claude-x" }
+        });
+        set_response_model(&mut event, "mine");
+        assert_eq!(event["message"]["model"], "mine");
     }
 
     // -- aggregation (peer daemons) ------------------------------------------
@@ -8839,7 +9406,7 @@ mod tests {
             model: "docker.io/ai/m:latest".into(),
             ..Default::default()
         };
-        post_chat(&Client::new(), &Target::Peer(origin), &mut req)
+        let _body = post_chat(&Client::new(), &Target::Peer(origin), &mut req)
             .await
             .unwrap();
 
@@ -9304,9 +9871,11 @@ mod tests {
                 let m = crate::hybrid::local_half(&m).to_string();
                 let target = if crate::providers::is_remote_ref(&m) {
                     Target::Remote(Arc::new(RemoteTarget {
-                        provider: "anthropic".into(),
+                        provider: "mockprov".into(),
                         base_url: "http://provider".into(),
+                        wire: Wire::OpenAi,
                         model: "claude".into(),
+                        max_output: None,
                         api_key: "k".into(),
                     }))
                 } else {

--- a/src/cmd/serve/anthropic.rs
+++ b/src/cmd/serve/anthropic.rs
@@ -1,0 +1,2005 @@
+//! The Anthropic Messages API, for providers that speak only it.
+//!
+//! Every surface the daemon offers becomes one OpenAI chat completion
+//! internally (see `CHAT_COMPLETIONS_ROUTE` in the parent), so a
+//! [`crate::providers::Wire::Anthropic`] target needs that request
+//! translated to a Messages request and the reply translated back to
+//! chat-completion SSE. Inbound `/v1/messages` is the exception: it is
+//! relayed to such a provider as-is.
+//!
+//! The provider is always asked to stream; a `stream: false` caller gets
+//! the stream folded into one object ([`StreamConverter::completion`]).
+//!
+//! Everything here is pure (JSON in, SSE text out), so it is testable
+//! without a network.
+
+use std::collections::BTreeMap;
+
+use anyhow::Context;
+use serde_json::{json, Value};
+
+/// The generating Messages route, appended to a provider's base URL.
+pub(super) const MESSAGES_ROUTE: &str = "/v1/messages";
+
+/// The API version every request declares. Features arrive as
+/// `anthropic-beta` headers, which a `/v1/messages` caller sends itself.
+pub(super) const VERSION: &str = "2023-06-01";
+
+/// `max_tokens` when neither the caller nor the catalog names one. The
+/// API requires the field and 400s a value above the model's ceiling;
+/// 4096 is the smallest ceiling of any Claude model.
+pub(super) const DEFAULT_MAX_TOKENS: u32 = 4096;
+
+/// Thinking budgets per OpenAI `reasoning_effort` level. The Messages API
+/// has only a token budget, spent from `max_tokens`.
+const THINKING_BUDGETS: [(&str, u32); 5] = [
+    ("minimal", 1024),
+    ("low", 2048),
+    ("medium", 8192),
+    ("high", 16384),
+    ("max", 32768),
+];
+
+/// The smallest budget the API accepts.
+const MIN_THINKING_BUDGET: u32 = 1024;
+
+/// The beta that lets a model think between tool calls, not only before
+/// the first; sent whenever thinking is enabled.
+pub(super) const INTERLEAVED_THINKING_BETA: &str = "interleaved-thinking-2025-05-14";
+
+/// The forced tool a `response_format` JSON schema becomes (the API has
+/// no JSON mode); its arguments come back as the reply's content. See
+/// [`json_tool_name`] for the name actually used.
+const JSON_TOOL: &str = "json_tool_call";
+
+/// Stands in for a `tool_use` the client never answered.
+const MISSING_RESULT: &str = "[tool result not provided]";
+
+// ---------------------------------------------------------------------------
+// Request: chat completions -> Messages
+// ---------------------------------------------------------------------------
+
+/// Translates an OpenAI chat-completion request into a Messages request.
+///
+/// `default_max_tokens` applies when the caller set neither `max_tokens`
+/// nor `max_completion_tokens`. Fails on content the Messages API cannot
+/// carry (audio input) rather than silently dropping part of a prompt.
+pub(super) fn from_chat_request(req: &Value, default_max_tokens: u32) -> anyhow::Result<Value> {
+    let mut system = Vec::<Value>::new();
+    let mut messages = Vec::<Value>::new();
+    for message in req
+        .get("messages")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let role = message
+            .get("role")
+            .and_then(Value::as_str)
+            .unwrap_or("user");
+        match role {
+            // `developer` is OpenAI's newer spelling of the same thing.
+            "system" | "developer" => {
+                system.extend(text_blocks(message.get("content").unwrap_or(&Value::Null))?)
+            }
+            "assistant" => push_turn(&mut messages, "assistant", assistant_blocks(message)?),
+            "tool" => {
+                let block = tool_result_block(message, &messages)?;
+                push_turn(&mut messages, "user", vec![block])
+            }
+            _ => push_turn(&mut messages, "user", user_blocks(message)?),
+        }
+    }
+    answer_orphaned_tool_calls(&mut messages);
+    // The API 400s a final assistant turn (a prefill) ending in whitespace.
+    if let Some(last) = messages.last_mut() {
+        if last["role"] == "assistant" {
+            trim_trailing_text(last);
+            if last["content"].as_array().is_some_and(Vec::is_empty) {
+                messages.pop();
+            }
+        }
+    }
+    anyhow::ensure!(
+        !messages.is_empty(),
+        "messages: at least one user turn is required"
+    );
+
+    let max_tokens = ["max_completion_tokens", "max_tokens"]
+        .into_iter()
+        .find_map(|k| req.get(k).and_then(Value::as_u64))
+        .and_then(|n| u32::try_from(n).ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(default_max_tokens);
+
+    let mut out = json!({
+        "model": req.get("model").cloned().unwrap_or(Value::Null),
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "stream": true,
+    });
+    if !system.is_empty() {
+        out["system"] = Value::Array(system);
+    }
+
+    for (from, to) in [("temperature", "temperature"), ("top_p", "top_p")] {
+        if let Some(v) = req.get(from).filter(|v| v.is_number()) {
+            out[to] = v.clone();
+        }
+    }
+    // The API rejects a whitespace-only stop sequence.
+    let stops: Vec<&Value> = match req.get("stop") {
+        Some(s @ Value::String(_)) => vec![s],
+        Some(Value::Array(a)) => a.iter().collect(),
+        _ => Vec::new(),
+    };
+    let stops: Vec<&Value> = stops
+        .into_iter()
+        .filter(|s| s.as_str().is_some_and(|s| !s.trim().is_empty()))
+        .collect();
+    if !stops.is_empty() {
+        out["stop_sequences"] = json!(stops);
+    }
+    if let Some(user) = req
+        .get("user")
+        .and_then(Value::as_str)
+        .filter(|u| !u.is_empty())
+    {
+        out["metadata"] = json!({ "user_id": user });
+    }
+
+    let mut tools: Vec<Value> = req
+        .get("tools")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(convert_tool)
+        .collect();
+    let offered_none = tools.is_empty();
+    let mut choice = tool_choice(req.get("tool_choice"));
+    if req.get("parallel_tool_calls").and_then(Value::as_bool) == Some(false) {
+        choice["disable_parallel_tool_use"] = json!(true);
+    }
+    if let Some(name) = json_tool_name(req) {
+        tools.push(json!({
+            "name": name,
+            "description": "Record the response in the required format.",
+            "input_schema": req.pointer("/response_format/json_schema/schema"),
+        }));
+        // One instance of the schema, not several concatenated.
+        choice = json!({ "type": "tool", "name": name, "disable_parallel_tool_use": true });
+    }
+    // Every tool the history used must be defined; one the client no
+    // longer offers is declared empty, and forbidden if it offered none.
+    for used in tools_used(&out["messages"]) {
+        if !tools.iter().any(|t| t["name"] == used["name"]) {
+            tools.push(used);
+        }
+    }
+    if offered_none && choice["type"] != "tool" && !tools.is_empty() {
+        choice = json!({ "type": "none" });
+    }
+    if !tools.is_empty() {
+        out["tools"] = Value::Array(tools);
+        out["tool_choice"] = choice;
+    }
+
+    // With thinking on, a final assistant turn holding a tool call must
+    // start with its signed thinking block, which no OpenAI client can
+    // hand back. A tool loop's continuation runs without thinking.
+    let awaiting_tool = out["messages"]
+        .as_array()
+        .and_then(|m| m.iter().rev().find(|m| m["role"] == "assistant"))
+        .is_some_and(|m| has_block(m, "tool_use"));
+    // Nor with a forced tool, which is the caller's output contract.
+    let forced = matches!(
+        out.pointer("/tool_choice/type").and_then(Value::as_str),
+        Some("any" | "tool")
+    );
+    if let Some(budget) = thinking_budget(req, max_tokens).filter(|_| !awaiting_tool && !forced) {
+        out["thinking"] = json!({ "type": "enabled", "budget_tokens": budget });
+        // Thinking forbids sampling overrides.
+        if let Some(o) = out.as_object_mut() {
+            o.remove("temperature");
+            o.remove("top_p");
+        }
+    }
+
+    mark_cache_breakpoints(&mut out);
+    Ok(out)
+}
+
+/// Whether thinking is on in a translated request; the caller adds
+/// [`INTERLEAVED_THINKING_BETA`] for it.
+pub(super) fn thinks(messages_req: &Value) -> bool {
+    messages_req.get("thinking").is_some()
+}
+
+/// The name [`from_chat_request`] injects a schema tool under, or `None`
+/// without a `response_format` schema: [`JSON_TOOL`], suffixed until it
+/// clashes with no tool the request offers or its history used. The
+/// converter is given the same name to read the call back as content.
+pub(super) fn json_tool_name(req: &Value) -> Option<String> {
+    req.pointer("/response_format/json_schema/schema")
+        .filter(|s| s.is_object())?;
+    let offered = req
+        .get("tools")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|t| t.pointer("/function/name"));
+    let used = req
+        .get("messages")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .flat_map(|m| {
+            m.get("tool_calls")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+        })
+        .filter_map(|c| c.pointer("/function/name"));
+    let taken: Vec<&Value> = offered.chain(used).collect();
+    (1..)
+        .map(|n| {
+            if n == 1 {
+                JSON_TOOL.to_string()
+            } else {
+                format!("{JSON_TOOL}_{n}")
+            }
+        })
+        .find(|name| !taken.iter().any(|t| *t == name))
+}
+
+/// Prompt caching: breakpoints on the last tool, last system block and
+/// last block of the last user turn, so an agent loop's next turn reads
+/// the previous one from cache. Below the minimum cacheable length the
+/// markers are ignored, so a short request costs nothing extra.
+fn mark_cache_breakpoints(out: &mut Value) {
+    let marker = json!({ "type": "ephemeral" });
+    // `get_mut`, not indexing: `IndexMut` would insert a null `tools`.
+    for key in ["tools", "system"] {
+        if let Some(last) = out
+            .get_mut(key)
+            .and_then(Value::as_array_mut)
+            .and_then(|a| a.last_mut())
+        {
+            last["cache_control"] = marker.clone();
+        }
+    }
+    let last_user = out["messages"]
+        .as_array_mut()
+        .and_then(|m| m.iter_mut().rev().find(|m| m["role"] == "user"))
+        .and_then(|m| m["content"].as_array_mut())
+        .and_then(|c| c.last_mut());
+    if let Some(last) = last_user {
+        last["cache_control"] = marker;
+    }
+}
+
+/// Whether a turn's content holds a block of `kind`.
+fn has_block(turn: &Value, kind: &str) -> bool {
+    turn["content"]
+        .as_array()
+        .is_some_and(|c| c.iter().any(|b| b["type"] == kind))
+}
+
+/// Empty definitions of every tool the history used.
+fn tools_used(messages: &Value) -> Vec<Value> {
+    let mut names = Vec::<String>::new();
+    for turn in messages.as_array().into_iter().flatten() {
+        for block in turn["content"].as_array().into_iter().flatten() {
+            if block["type"] != "tool_use" {
+                continue;
+            }
+            if let Some(name) = block["name"].as_str() {
+                if !names.iter().any(|n| n == name) {
+                    names.push(name.to_string());
+                }
+            }
+        }
+    }
+    names
+        .into_iter()
+        .map(|name| json!({ "name": name, "input_schema": { "type": "object", "properties": {} } }))
+        .collect()
+}
+
+/// Gives every `tool_use` the `tool_result` the API requires in the next
+/// user turn; a missing one becomes [`MISSING_RESULT`].
+fn answer_orphaned_tool_calls(messages: &mut Vec<Value>) {
+    let mut i = 0;
+    while i < messages.len() {
+        if messages[i]["role"] != "assistant" {
+            i += 1;
+            continue;
+        }
+        let ids: Vec<String> = messages[i]["content"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter(|b| b["type"] == "tool_use")
+            .filter_map(|b| b["id"].as_str().map(str::to_string))
+            .collect();
+        if ids.is_empty() {
+            i += 1;
+            continue;
+        }
+        let answered = |turn: &Value| -> Vec<String> {
+            turn["content"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter(|b| b["type"] == "tool_result")
+                .filter_map(|b| b["tool_use_id"].as_str().map(str::to_string))
+                .collect()
+        };
+        let next_is_user = messages.get(i + 1).is_some_and(|m| m["role"] == "user");
+        let have = if next_is_user {
+            answered(&messages[i + 1])
+        } else {
+            Vec::new()
+        };
+        let missing: Vec<Value> = ids
+            .iter()
+            .filter(|id| !have.contains(id))
+            .map(
+                |id| json!({ "type": "tool_result", "tool_use_id": id, "content": MISSING_RESULT }),
+            )
+            .collect();
+        if !missing.is_empty() {
+            if next_is_user {
+                // Results must lead the turn, before any text.
+                if let Some(content) = messages[i + 1]["content"].as_array_mut() {
+                    content.splice(0..0, missing);
+                }
+            } else {
+                messages.insert(i + 1, json!({ "role": "user", "content": missing }));
+            }
+        }
+        i += 1;
+    }
+}
+
+/// The first unanswered `tool_use` id in the last assistant turn, of
+/// `name` when given.
+fn unanswered_call(messages: &[Value], name: Option<&str>) -> Option<String> {
+    let at = messages.iter().rposition(|m| m["role"] == "assistant")?;
+    let answered: Vec<&str> = messages[at + 1..]
+        .iter()
+        .flat_map(|m| m["content"].as_array().into_iter().flatten())
+        .filter(|b| b["type"] == "tool_result")
+        .filter_map(|b| b["tool_use_id"].as_str())
+        .collect();
+    messages[at]["content"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter(|b| b["type"] == "tool_use")
+        .filter(|b| name.is_none_or(|n| b["name"] == n))
+        .filter_map(|b| b["id"].as_str())
+        .find(|id| !answered.contains(id))
+        .map(str::to_string)
+}
+
+/// The API accepts ids matching `[a-zA-Z0-9_-]+` only. A rewritten id
+/// gets a hash of the original appended, so `call:1` and `call.1` stay
+/// distinct; the same mapping applies to calls and results.
+fn sanitize_id(id: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let out: String = id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if out == id && !out.is_empty() {
+        return out;
+    }
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    id.hash(&mut hasher);
+    format!("{out}_{:016x}", hasher.finish())
+}
+
+/// The budget a `reasoning_effort` asks for, clamped to leave room for
+/// the answer; `None` when not requested or `max_tokens` is too small.
+fn thinking_budget(req: &Value, max_tokens: u32) -> Option<u32> {
+    // `/api/chat` carries Ollama's `think` as `chat_template_kwargs`.
+    let kwargs = req.get("chat_template_kwargs");
+    let effort = match req.get("reasoning_effort").and_then(Value::as_str) {
+        Some(effort) => effort,
+        None => match kwargs
+            .and_then(|k| k.get("enable_thinking"))
+            .and_then(Value::as_bool)?
+        {
+            false => return None,
+            true => kwargs
+                .and_then(|k| k.get("reasoning_effort"))
+                .and_then(Value::as_str)
+                .unwrap_or("medium"),
+        },
+    };
+    if effort == "none" {
+        return None;
+    }
+    let budget = THINKING_BUDGETS
+        .iter()
+        .find(|(name, _)| *name == effort)
+        .map(|(_, b)| *b)
+        .unwrap_or(THINKING_BUDGETS[2].1);
+    // Must be below `max_tokens`; leave as much again for the answer.
+    let budget = budget.min(max_tokens / 2);
+    (budget >= MIN_THINKING_BUDGET).then_some(budget)
+}
+
+/// Appends `blocks` as a turn of `role`, merged into the previous turn
+/// when it has the same role: OpenAI carries each tool result as its own
+/// message, and the API wants them all in the one user turn after the
+/// call. An empty turn is dropped, as the API rejects empty content.
+fn push_turn(messages: &mut Vec<Value>, role: &str, blocks: Vec<Value>) {
+    if blocks.is_empty() {
+        return;
+    }
+    if let Some(last) = messages.last_mut() {
+        if last["role"] == role {
+            if let Some(existing) = last["content"].as_array_mut() {
+                existing.extend(blocks);
+                return;
+            }
+        }
+    }
+    messages.push(json!({ "role": role, "content": blocks }));
+}
+
+/// Strips trailing whitespace from the last text block of a turn.
+fn trim_trailing_text(turn: &mut Value) {
+    let Some(blocks) = turn["content"].as_array_mut() else {
+        return;
+    };
+    let Some(last) = blocks.last_mut() else {
+        return;
+    };
+    if last["type"] != "text" {
+        return;
+    }
+    if let Some(text) = last["text"].as_str() {
+        let trimmed = text.trim_end().to_string();
+        if trimmed.is_empty() {
+            blocks.pop();
+        } else {
+            last["text"] = Value::String(trimmed);
+        }
+    }
+}
+
+/// The `text` blocks of a chat `content` value. A bare string is one
+/// block; empty text yields none, since the API rejects empty blocks.
+fn text_blocks(content: &Value) -> anyhow::Result<Vec<Value>> {
+    match content {
+        Value::String(s) => Ok(text_block(s).into_iter().collect()),
+        Value::Array(parts) => parts
+            .iter()
+            .filter_map(|part| match part.get("type").and_then(Value::as_str) {
+                Some("text") => part
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .and_then(text_block)
+                    .map(Ok),
+                Some(other) => Some(Err(anyhow::anyhow!(
+                    "unsupported content part: {other:?} (only text is accepted here)"
+                ))),
+                None => None,
+            })
+            .collect(),
+        _ => Ok(Vec::new()),
+    }
+}
+
+/// One text block, or `None` for text the API would reject: it wants
+/// non-whitespace in every block.
+fn text_block(text: &str) -> Option<Value> {
+    (!text.trim().is_empty()).then(|| json!({ "type": "text", "text": text }))
+}
+
+/// A user message's blocks: text and images. Audio input has no Messages
+/// equivalent and is refused.
+fn user_blocks(message: &Value) -> anyhow::Result<Vec<Value>> {
+    content_blocks(message.get("content").unwrap_or(&Value::Null))
+}
+
+/// Text and image blocks of a chat `content` value, for a user message
+/// or a tool result.
+fn content_blocks(content: &Value) -> anyhow::Result<Vec<Value>> {
+    let Value::Array(parts) = content else {
+        return text_blocks(content);
+    };
+    parts
+        .iter()
+        .filter_map(|part| match part.get("type").and_then(Value::as_str) {
+            Some("text") => part
+                .get("text")
+                .and_then(Value::as_str)
+                .and_then(text_block)
+                .map(Ok),
+            Some("image_url") => {
+                let url = part
+                    .pointer("/image_url/url")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                Some(image_block(url))
+            }
+            Some(other) => Some(Err(anyhow::anyhow!(
+                "unsupported content part: {other:?} (the Messages API takes text and images)"
+            ))),
+            None => None,
+        })
+        .collect()
+}
+
+/// An `image` block from an OpenAI `image_url`: a `data:` URI becomes a
+/// base64 source, anything else a URL source.
+fn image_block(url: &str) -> anyhow::Result<Value> {
+    let Some(rest) = url.strip_prefix("data:") else {
+        anyhow::ensure!(!url.is_empty(), "image_url without a url");
+        return Ok(json!({ "type": "image", "source": { "type": "url", "url": url } }));
+    };
+    let (meta, data) = rest
+        .split_once(',')
+        .context("image data URI has no payload")?;
+    let media_type = meta.split(';').next().unwrap_or("").trim();
+    anyhow::ensure!(
+        meta.split(';').any(|p| p.trim() == "base64"),
+        "image data URI is not base64"
+    );
+    Ok(json!({
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": if media_type.is_empty() { "image/png" } else { media_type },
+            "data": data,
+        }
+    }))
+}
+
+/// An assistant message's blocks: its text, then a `tool_use` per
+/// `tool_calls` entry. Reasoning is dropped: the API only accepts
+/// thinking blocks back with its own signature.
+fn assistant_blocks(message: &Value) -> anyhow::Result<Vec<Value>> {
+    let mut blocks = text_blocks(message.get("content").unwrap_or(&Value::Null))?;
+    for call in message
+        .get("tool_calls")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let function = call.get("function").unwrap_or(&Value::Null);
+        let arguments = function.get("arguments").unwrap_or(&Value::Null);
+        // OpenAI encodes arguments as a JSON string; the API wants the
+        // object. Non-JSON is kept under one key rather than lost.
+        let input = match arguments {
+            Value::String(s) if s.trim().is_empty() => json!({}),
+            Value::String(s) => serde_json::from_str::<Value>(s)
+                .ok()
+                .filter(Value::is_object)
+                .unwrap_or_else(|| json!({ "input": s })),
+            Value::Object(_) => arguments.clone(),
+            _ => json!({}),
+        };
+        // `gen_id` is clock-based and can repeat back to back; the block
+        // position keeps generated ids distinct within a turn.
+        let id = call
+            .get("id")
+            .and_then(Value::as_str)
+            .map(sanitize_id)
+            .unwrap_or_else(|| format!("toolu_{}_{}", super::gen_id(), blocks.len()));
+        blocks.push(json!({
+            "type": "tool_use",
+            "id": id,
+            "name": function.get("name").cloned().unwrap_or(Value::Null),
+            "input": input,
+        }));
+    }
+    Ok(blocks)
+}
+
+/// A `role: tool` message as a `tool_result` block. `/api/chat` results
+/// carry Ollama's tool `name` and no id; those match the first unanswered
+/// call of that name (or any name) in the last assistant turn.
+fn tool_result_block(message: &Value, messages: &[Value]) -> anyhow::Result<Value> {
+    let id = message
+        .get("tool_call_id")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(sanitize_id)
+        .or_else(|| unanswered_call(messages, message.get("name").and_then(Value::as_str)))
+        .context("a tool message needs a tool_call_id, or a name matching a preceding call")?;
+    let content = match message.get("content") {
+        Some(Value::String(s)) => Value::String(s.clone()),
+        Some(parts @ Value::Array(_)) => Value::Array(content_blocks(parts)?),
+        Some(other) if !other.is_null() => Value::String(other.to_string()),
+        _ => Value::String(String::new()),
+    };
+    Ok(json!({ "type": "tool_result", "tool_use_id": id, "content": content }))
+}
+
+/// One OpenAI `function` tool as a Messages tool; hosted tool types the
+/// provider cannot run are dropped.
+fn convert_tool(tool: &Value) -> Option<Value> {
+    if tool.get("type").and_then(Value::as_str) != Some("function") {
+        return None;
+    }
+    let function = tool.get("function")?;
+    let name = function.get("name").and_then(Value::as_str)?;
+    let mut out = json!({
+        "name": name,
+        // Required; a parameterless function gets the empty schema.
+        "input_schema": function
+            .get("parameters")
+            .filter(|p| p.is_object())
+            .cloned()
+            .unwrap_or_else(|| json!({ "type": "object", "properties": {} })),
+    });
+    if let Some(description) = function.get("description").filter(|d| d.is_string()) {
+        out["description"] = description.clone();
+    }
+    Some(out)
+}
+
+/// OpenAI's `tool_choice` as the API's object form.
+fn tool_choice(choice: Option<&Value>) -> Value {
+    match choice {
+        Some(Value::String(s)) if s == "required" => json!({ "type": "any" }),
+        Some(Value::String(s)) if s == "none" => json!({ "type": "none" }),
+        Some(choice @ Value::Object(o))
+            if o.get("type").and_then(Value::as_str) == Some("function") =>
+        {
+            match choice.pointer("/function/name").and_then(Value::as_str) {
+                Some(name) => json!({ "type": "tool", "name": name }),
+                None => json!({ "type": "auto" }),
+            }
+        }
+        _ => json!({ "type": "auto" }),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Response: Messages SSE -> chat completion SSE
+// ---------------------------------------------------------------------------
+
+/// One tool call, as its `tool_use` block streams in.
+#[derive(Default)]
+struct ToolCall {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+/// Translates a Messages event stream into chat-completion chunks.
+///
+/// Feed each upstream line to [`StreamConverter::line`], then
+/// [`StreamConverter::finish`] at end of stream; each returns SSE text to
+/// relay. Only `data:` lines are read; every payload names its `type`.
+pub(super) struct StreamConverter {
+    id: String,
+    model: String,
+    created: u64,
+
+    /// Messages block index -> chat `tool_calls` index.
+    tool_indices: BTreeMap<u64, usize>,
+    /// The schema tool the request injected, if any (see
+    /// [`json_tool_name`]); its block index once called, and whether any
+    /// arguments arrived.
+    json_tool: Option<String>,
+    json_block: Option<u64>,
+    json_received: bool,
+    started: bool,
+    done: bool,
+
+    // Accumulated for `completion()`.
+    content: String,
+    reasoning: String,
+    tool_calls: Vec<ToolCall>,
+    finish_reason: Option<&'static str>,
+    prompt_tokens: u64,
+    cached_tokens: u64,
+    completion_tokens: u64,
+    error: Option<Value>,
+}
+
+impl StreamConverter {
+    /// `model` is the name the client asked for, echoed into every chunk.
+    pub(super) fn new(model: &str) -> Self {
+        Self::with_id(model, &format!("chatcmpl-{}", super::gen_id()), now_unix())
+    }
+
+    /// Reads a call of `name` back as content (see [`json_tool_name`]).
+    pub(super) fn json_tool(mut self, name: Option<String>) -> Self {
+        self.json_tool = name;
+        self
+    }
+
+    fn with_id(model: &str, id: &str, created: u64) -> Self {
+        Self {
+            id: id.to_string(),
+            model: model.to_string(),
+            created,
+            tool_indices: BTreeMap::new(),
+            json_tool: None,
+            json_block: None,
+            json_received: false,
+            started: false,
+            done: false,
+            content: String::new(),
+            reasoning: String::new(),
+            tool_calls: Vec::new(),
+            finish_reason: None,
+            prompt_tokens: 0,
+            cached_tokens: 0,
+            completion_tokens: 0,
+            error: None,
+        }
+    }
+
+    /// Translates one upstream SSE line, line ending already stripped.
+    pub(super) fn line(&mut self, line: &str) -> String {
+        if self.done {
+            return String::new();
+        }
+        let Some(payload) = line.strip_prefix("data:") else {
+            return String::new();
+        };
+        let Ok(event) = serde_json::from_str::<Value>(payload.trim()) else {
+            return String::new();
+        };
+        match event.get("type").and_then(Value::as_str) {
+            Some("message_start") => {
+                let message = event.get("message").unwrap_or(&Value::Null);
+                if let Some(id) = message.get("id").and_then(Value::as_str) {
+                    self.id = id.to_string();
+                }
+                self.read_usage(message.get("usage"));
+                self.start()
+            }
+            Some("content_block_start") => {
+                let block = event.get("content_block").unwrap_or(&Value::Null);
+                if block.get("type").and_then(Value::as_str) != Some("tool_use") {
+                    return self.start();
+                }
+                if self.json_tool.is_some()
+                    && block.get("name").and_then(Value::as_str) == self.json_tool.as_deref()
+                {
+                    self.json_block = event.get("index").and_then(Value::as_u64);
+                    return self.start();
+                }
+                let index = self.tool_calls.len();
+                if let Some(block_index) = event.get("index").and_then(Value::as_u64) {
+                    self.tool_indices.insert(block_index, index);
+                }
+                let id = block
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                let name = block
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                self.tool_calls.push(ToolCall {
+                    id: id.clone(),
+                    name: name.clone(),
+                    arguments: String::new(),
+                });
+                let mut out = self.start();
+                out.push_str(&self.chunk(
+                    json!({ "tool_calls": [{
+                        "index": index,
+                        "id": id,
+                        "type": "function",
+                        "function": { "name": name, "arguments": "" },
+                    }] }),
+                    None,
+                    None,
+                ));
+                out
+            }
+            Some("content_block_delta") => {
+                let delta = event.get("delta").unwrap_or(&Value::Null);
+                let mut out = self.start();
+                match delta.get("type").and_then(Value::as_str) {
+                    Some("text_delta") => {
+                        let text = delta.get("text").and_then(Value::as_str).unwrap_or("");
+                        if !text.is_empty() {
+                            self.content.push_str(text);
+                            out.push_str(&self.chunk(json!({ "content": text }), None, None));
+                        }
+                    }
+                    Some("thinking_delta") => {
+                        let text = delta.get("thinking").and_then(Value::as_str).unwrap_or("");
+                        if !text.is_empty() {
+                            self.reasoning.push_str(text);
+                            // llama-server's field; every consumer reads it.
+                            out.push_str(&self.chunk(
+                                json!({ "reasoning_content": text }),
+                                None,
+                                None,
+                            ));
+                        }
+                    }
+                    Some("input_json_delta") => {
+                        let partial = delta
+                            .get("partial_json")
+                            .and_then(Value::as_str)
+                            .unwrap_or("");
+                        let block_index = event.get("index").and_then(Value::as_u64);
+                        if block_index.is_some() && block_index == self.json_block {
+                            if !partial.is_empty() {
+                                self.json_received = true;
+                                self.content.push_str(partial);
+                                out.push_str(&self.chunk(
+                                    json!({ "content": partial }),
+                                    None,
+                                    None,
+                                ));
+                            }
+                            return out;
+                        }
+                        let Some(&index) = block_index.and_then(|i| self.tool_indices.get(&i))
+                        else {
+                            return out;
+                        };
+                        if let Some(call) = self.tool_calls.get_mut(index) {
+                            call.arguments.push_str(partial);
+                        }
+                        if !partial.is_empty() {
+                            out.push_str(&self.chunk(
+                                json!({ "tool_calls": [{
+                                    "index": index,
+                                    "function": { "arguments": partial },
+                                }] }),
+                                None,
+                                None,
+                            ));
+                        }
+                    }
+                    // `signature_delta`, and anything newer.
+                    _ => {}
+                }
+                out
+            }
+            Some("content_block_stop") => {
+                // A call with no arguments streams no delta; it still
+                // ends as `{}`, not an unparseable empty string.
+                let block_index = event.get("index").and_then(Value::as_u64);
+                if block_index.is_some() && block_index == self.json_block {
+                    if self.json_received {
+                        return String::new();
+                    }
+                    self.json_received = true;
+                    self.content.push_str("{}");
+                    return self.chunk(json!({ "content": "{}" }), None, None);
+                }
+                let Some(&index) = block_index.and_then(|i| self.tool_indices.get(&i)) else {
+                    return String::new();
+                };
+                let Some(call) = self.tool_calls.get_mut(index) else {
+                    return String::new();
+                };
+                if !call.arguments.is_empty() {
+                    return String::new();
+                }
+                call.arguments.push_str("{}");
+                self.chunk(
+                    json!({ "tool_calls": [{ "index": index, "function": { "arguments": "{}" } }] }),
+                    None,
+                    None,
+                )
+            }
+            Some("message_delta") => {
+                self.read_usage(event.get("usage"));
+                let reason = event
+                    .pointer("/delta/stop_reason")
+                    .and_then(Value::as_str)
+                    .map(finish_reason)
+                    .unwrap_or("stop");
+                // A forced JSON tool is the reply itself, not a tool call.
+                let reason = if reason == "tool_calls" && self.tool_calls.is_empty() {
+                    "stop"
+                } else {
+                    reason
+                };
+                self.finish_reason = Some(reason);
+                let mut out = self.start();
+                out.push_str(&self.chunk(json!({}), Some(reason), Some(self.usage())));
+                out
+            }
+            Some("message_stop") => {
+                self.done = true;
+                let mut out = self.start();
+                out.push_str("data: [DONE]\n\n");
+                out
+            }
+            Some("error") => {
+                let error = event.get("error").cloned().unwrap_or(Value::Null);
+                self.error = Some(error.clone());
+                self.done = true;
+                // In-band, the status being committed, and no `[DONE]`: the
+                // consumers here read that as success.
+                format!("data: {}\n\n", json!({ "error": error }))
+            }
+            // `ping`, and anything newer.
+            _ => String::new(),
+        }
+    }
+
+    /// End of upstream stream without `message_stop`. Emits `[DONE]` if a
+    /// stop reason was seen, else nothing: a stream without `[DONE]` is
+    /// how every consumer recognises truncation.
+    pub(super) fn finish(&mut self) -> String {
+        if self.done {
+            return String::new();
+        }
+        self.done = true;
+        if self.finish_reason.is_some() {
+            return "data: [DONE]\n\n".to_string();
+        }
+        String::new()
+    }
+
+    /// The provider's in-band error, if the stream ended in one.
+    pub(super) fn error(&self) -> Option<&Value> {
+        self.error.as_ref()
+    }
+
+    /// Whether the provider reported a stop reason; `false` means the
+    /// fold below is truncated.
+    pub(super) fn finished(&self) -> bool {
+        self.finish_reason.is_some()
+    }
+
+    /// The one `chat.completion` object a `stream: false` caller expects,
+    /// from everything streamed so far.
+    pub(super) fn completion(&self) -> Value {
+        let mut message = json!({
+            "role": "assistant",
+            "content": if self.content.is_empty() && !self.tool_calls.is_empty() {
+                Value::Null
+            } else {
+                Value::String(self.content.clone())
+            },
+        });
+        if !self.reasoning.is_empty() {
+            message["reasoning_content"] = Value::String(self.reasoning.clone());
+        }
+        if !self.tool_calls.is_empty() {
+            message["tool_calls"] = self
+                .tool_calls
+                .iter()
+                .map(|call| {
+                    json!({
+                        "id": call.id,
+                        "type": "function",
+                        "function": { "name": call.name, "arguments": call.arguments },
+                    })
+                })
+                .collect();
+        }
+        json!({
+            "id": self.id,
+            "object": "chat.completion",
+            "created": self.created,
+            "model": self.model,
+            "choices": [{
+                "index": 0,
+                "message": message,
+                "finish_reason": self.finish_reason.unwrap_or("stop"),
+            }],
+            "usage": self.usage(),
+        })
+    }
+
+    /// The role-announcing first chunk, once.
+    fn start(&mut self) -> String {
+        if self.started {
+            return String::new();
+        }
+        self.started = true;
+        self.chunk(json!({ "role": "assistant", "content": "" }), None, None)
+    }
+
+    fn chunk(&self, delta: Value, finish_reason: Option<&str>, usage: Option<Value>) -> String {
+        let mut chunk = json!({
+            "id": self.id,
+            "object": "chat.completion.chunk",
+            "created": self.created,
+            "model": self.model,
+            "choices": [{
+                "index": 0,
+                "delta": delta,
+                "finish_reason": finish_reason,
+            }],
+        });
+        if let Some(usage) = usage {
+            chunk["usage"] = usage;
+        }
+        format!("data: {chunk}\n\n")
+    }
+
+    /// `message_start` carries input usage, `message_delta` output usage.
+    /// Cache reads and writes are billed input, so they count into
+    /// `prompt_tokens` as OpenAI counts them.
+    fn read_usage(&mut self, usage: Option<&Value>) {
+        let Some(usage) = usage else {
+            return;
+        };
+        let n = |k: &str| usage.get(k).and_then(Value::as_u64);
+        if let Some(input) = n("input_tokens") {
+            let read = n("cache_read_input_tokens").unwrap_or(0);
+            let written = n("cache_creation_input_tokens").unwrap_or(0);
+            self.prompt_tokens = input + read + written;
+            self.cached_tokens = read;
+        }
+        if let Some(output) = n("output_tokens") {
+            self.completion_tokens = output;
+        }
+    }
+
+    fn usage(&self) -> Value {
+        json!({
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "total_tokens": self.prompt_tokens + self.completion_tokens,
+            "prompt_tokens_details": { "cached_tokens": self.cached_tokens },
+        })
+    }
+}
+
+/// A Messages `stop_reason` as a chat-completion `finish_reason`.
+fn finish_reason(stop_reason: &str) -> &'static str {
+    match stop_reason {
+        "max_tokens" | "model_context_window_exceeded" | "compaction" => "length",
+        "tool_use" => "tool_calls",
+        "refusal" => "content_filter",
+        // `end_turn`, `stop_sequence`, `pause_turn`, and anything newer.
+        _ => "stop",
+    }
+}
+
+fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Converts and strips the cache markers, so shape tests read
+    /// without them; `cache_breakpoints_mark_tools_system_and_last_user`
+    /// covers the markers.
+    fn convert(req: Value) -> Value {
+        let mut out = from_chat_request(&req, DEFAULT_MAX_TOKENS).expect("converts");
+        strip_cache(&mut out);
+        out
+    }
+
+    fn strip_cache(v: &mut Value) {
+        match v {
+            Value::Object(o) => {
+                o.remove("cache_control");
+                o.values_mut().for_each(strip_cache);
+            }
+            Value::Array(a) => a.iter_mut().for_each(strip_cache),
+            _ => {}
+        }
+    }
+
+    /// Parses every `data:` line of an SSE text back into JSON, with the
+    /// `[DONE]` sentinel as a string.
+    fn events(sse: &str) -> Vec<Value> {
+        sse.lines()
+            .filter_map(|l| l.strip_prefix("data: "))
+            .map(|p| serde_json::from_str(p).unwrap_or_else(|_| Value::String(p.to_string())))
+            .collect()
+    }
+
+    /// Feeds a whole Messages stream through a converter with fixed ids.
+    fn run(lines: &[&str]) -> (StreamConverter, String) {
+        let mut conv = StreamConverter::with_id("claude", "chatcmpl-fixed", 1)
+            .json_tool(Some(JSON_TOOL.to_string()));
+        let mut out = String::new();
+        for line in lines {
+            out.push_str(&conv.line(line));
+        }
+        out.push_str(&conv.finish());
+        (conv, out)
+    }
+
+    // -- request ---------------------------------------------------------------
+
+    /// System and developer turns move to `system`. The provider is
+    /// always asked to stream, and `max_tokens` is always present.
+    #[test]
+    fn system_messages_become_the_system_field() {
+        let out = convert(json!({
+            "model": "claude-sonnet-4",
+            "messages": [
+                { "role": "system", "content": "Be brief." },
+                { "role": "developer", "content": [{ "type": "text", "text": "And kind." }] },
+                { "role": "user", "content": "hi" }
+            ],
+            "stream": false
+        }));
+        assert_eq!(
+            out,
+            json!({
+                "model": "claude-sonnet-4",
+                "system": [
+                    { "type": "text", "text": "Be brief." },
+                    { "type": "text", "text": "And kind." }
+                ],
+                "messages": [{ "role": "user", "content": [{ "type": "text", "text": "hi" }] }],
+                "max_tokens": DEFAULT_MAX_TOKENS,
+                "stream": true,
+            })
+        );
+    }
+
+    /// `max_completion_tokens` wins over `max_tokens`; the catalog
+    /// ceiling is only a fallback.
+    #[test]
+    fn max_tokens_comes_from_the_caller_then_the_catalog() {
+        let user = json!([{ "role": "user", "content": "hi" }]);
+        let out = from_chat_request(
+            &json!({ "messages": user, "max_tokens": 100, "max_completion_tokens": 200 }),
+            8192,
+        )
+        .unwrap();
+        assert_eq!(out["max_tokens"], 200);
+        let out = from_chat_request(&json!({ "messages": user }), 8192).unwrap();
+        assert_eq!(out["max_tokens"], 8192);
+    }
+
+    /// One breakpoint each on the last tool, the last system block and
+    /// the last block of the last user turn; nothing else is marked, and
+    /// a request without tools gains no `tools` key.
+    #[test]
+    fn cache_breakpoints_mark_tools_system_and_last_user() {
+        let out = from_chat_request(
+            &json!({
+                "messages": [
+                    { "role": "system", "content": "a" },
+                    { "role": "system", "content": "b" },
+                    { "role": "user", "content": "q1" },
+                    { "role": "assistant", "content": "a1" },
+                    { "role": "user", "content": [{ "type": "text", "text": "q2" }, { "type": "text", "text": "q3" }] }
+                ],
+                "tools": [
+                    { "type": "function", "function": { "name": "f" } },
+                    { "type": "function", "function": { "name": "g" } }
+                ]
+            }),
+            DEFAULT_MAX_TOKENS,
+        )
+        .unwrap();
+        let marked = json!({ "type": "ephemeral" });
+        assert!(out["tools"][0].get("cache_control").is_none());
+        assert_eq!(out["tools"][1]["cache_control"], marked);
+        assert!(out["system"][0].get("cache_control").is_none());
+        assert_eq!(out["system"][1]["cache_control"], marked);
+        assert!(out["messages"][0]["content"][0]
+            .get("cache_control")
+            .is_none());
+        assert!(out["messages"][1]["content"][0]
+            .get("cache_control")
+            .is_none());
+        assert!(out["messages"][2]["content"][0]
+            .get("cache_control")
+            .is_none());
+        assert_eq!(out["messages"][2]["content"][1]["cache_control"], marked);
+
+        let bare = from_chat_request(
+            &json!({ "messages": [{ "role": "user", "content": "hi" }] }),
+            DEFAULT_MAX_TOKENS,
+        )
+        .unwrap();
+        assert!(bare.get("tools").is_none(), "{bare}");
+        assert!(bare.get("system").is_none(), "{bare}");
+        assert_eq!(bare["messages"][0]["content"][0]["cache_control"], marked);
+    }
+
+    /// Text the API rejects as empty: whitespace-only blocks go, in every
+    /// role, and a whitespace-only stop sequence goes with them.
+    #[test]
+    fn whitespace_only_text_and_stops_are_dropped() {
+        let out = convert(json!({
+            "messages": [
+                { "role": "system", "content": "  \n" },
+                { "role": "user", "content": [{ "type": "text", "text": " " }, { "type": "text", "text": "hi" }] },
+                { "role": "assistant", "content": "\t" },
+                { "role": "user", "content": "more" }
+            ],
+            "stop": ["", "  ", "END"]
+        }));
+        assert!(out.get("system").is_none());
+        assert_eq!(
+            out["messages"],
+            json!([{ "role": "user", "content": [
+                { "type": "text", "text": "hi" }, { "type": "text", "text": "more" }
+            ] }])
+        );
+        assert_eq!(out["stop_sequences"], json!(["END"]));
+        let none =
+            convert(json!({ "messages": [{ "role": "user", "content": "hi" }], "stop": "  " }));
+        assert!(none.get("stop_sequences").is_none());
+    }
+
+    /// Ids outside `[a-zA-Z0-9_-]` are rewritten the same way on the call
+    /// and its result, so they still match.
+    #[test]
+    fn tool_ids_are_sanitized_consistently() {
+        let out = convert(json!({
+            "messages": [
+                { "role": "user", "content": "go" },
+                { "role": "assistant", "tool_calls": [{ "id": "call:1.a", "type": "function", "function": { "name": "f", "arguments": "{}" } }] },
+                { "role": "tool", "tool_call_id": "call:1.a", "content": "ok" }
+            ],
+            "tools": [{ "type": "function", "function": { "name": "f" } }]
+        }));
+        let id = out["messages"][1]["content"][0]["id"].as_str().unwrap();
+        assert!(id.starts_with("call_1_a_"), "{id}");
+        assert_eq!(out["messages"][2]["content"][0]["tool_use_id"], id);
+        assert_eq!(sanitize_id("call_1"), "call_1");
+        assert_ne!(sanitize_id("call:1"), sanitize_id("call.1"));
+        assert!(!sanitize_id("").is_empty());
+    }
+
+    /// A call the client never answered gets a placeholder result, first
+    /// in the following user turn or in a new one, so the API does not
+    /// reject the conversation.
+    #[test]
+    fn orphaned_tool_calls_get_placeholder_results() {
+        let call = |id: &str| json!({ "id": id, "type": "function", "function": { "name": "f", "arguments": "{}" } });
+        let out = convert(json!({
+            "messages": [
+                { "role": "user", "content": "go" },
+                { "role": "assistant", "tool_calls": [call("a"), call("b")] },
+                { "role": "tool", "tool_call_id": "b", "content": "ok" },
+                { "role": "user", "content": "and?" },
+                { "role": "assistant", "tool_calls": [call("c")] }
+            ],
+            "tools": [{ "type": "function", "function": { "name": "f" } }]
+        }));
+        assert_eq!(
+            out["messages"][2]["content"],
+            json!([
+                { "type": "tool_result", "tool_use_id": "a", "content": MISSING_RESULT },
+                { "type": "tool_result", "tool_use_id": "b", "content": "ok" },
+                { "type": "text", "text": "and?" }
+            ])
+        );
+        assert_eq!(
+            out["messages"][4],
+            json!({ "role": "user", "content": [
+                { "type": "tool_result", "tool_use_id": "c", "content": MISSING_RESULT }
+            ] })
+        );
+    }
+
+    /// Tools the history used are defined even when the client no longer
+    /// offers them: empty, and forbidden when it offers none at all.
+    #[test]
+    fn history_tools_are_declared_when_the_request_has_none() {
+        let out = convert(json!({
+            "messages": [
+                { "role": "user", "content": "go" },
+                { "role": "assistant", "tool_calls": [
+                    { "id": "a", "type": "function", "function": { "name": "read", "arguments": "{}" } },
+                    { "id": "b", "type": "function", "function": { "name": "read", "arguments": "{}" } }
+                ] },
+                { "role": "tool", "tool_call_id": "a", "content": "x" },
+                { "role": "tool", "tool_call_id": "b", "content": "y" },
+                { "role": "user", "content": "summarize" }
+            ]
+        }));
+        assert_eq!(
+            out["tools"],
+            json!([{ "name": "read", "input_schema": { "type": "object", "properties": {} } }])
+        );
+        assert_eq!(out["tool_choice"], json!({ "type": "none" }));
+
+        // Offered alongside a live tool, the used one is added, not forced off.
+        let mixed = convert(json!({
+            "messages": [
+                { "role": "user", "content": "go" },
+                { "role": "assistant", "tool_calls": [{ "id": "a", "type": "function", "function": { "name": "old", "arguments": "{}" } }] },
+                { "role": "tool", "tool_call_id": "a", "content": "x" }
+            ],
+            "tools": [{ "type": "function", "function": { "name": "new" } }]
+        }));
+        let names: Vec<&str> = mixed["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|t| t["name"].as_str().unwrap())
+            .collect();
+        assert_eq!(names, ["new", "old"]);
+        assert_eq!(mixed["tool_choice"], json!({ "type": "auto" }));
+    }
+
+    /// A JSON schema `response_format` becomes a forced tool carrying the
+    /// schema; the forced tool wins over thinking.
+    #[test]
+    fn response_format_json_schema_becomes_a_forced_tool() {
+        let schema = json!({ "type": "object", "properties": { "ok": { "type": "boolean" } } });
+        let req = json!({
+            "messages": [{ "role": "user", "content": "hi" }],
+            "response_format": { "type": "json_schema", "json_schema": { "name": "r", "schema": schema } }
+        });
+        let out = convert(req.clone());
+        assert_eq!(out["tools"][0]["name"], JSON_TOOL);
+        assert_eq!(out["tools"][0]["input_schema"], schema);
+        assert_eq!(
+            out["tool_choice"],
+            json!({ "type": "tool", "name": JSON_TOOL, "disable_parallel_tool_use": true })
+        );
+
+        let mut thinking = req.clone();
+        thinking["reasoning_effort"] = json!("medium");
+        thinking["max_tokens"] = json!(64000);
+        let out = convert(thinking);
+        assert_eq!(out["tool_choice"]["name"], JSON_TOOL);
+        assert!(out.get("thinking").is_none(), "{out}");
+        assert_eq!(json_tool_name(&req).as_deref(), Some(JSON_TOOL));
+        assert_eq!(
+            json_tool_name(&json!({ "response_format": { "type": "json_object" } })),
+            None
+        );
+    }
+
+    /// The schema tool dodges a caller's tool of the same name, whether
+    /// offered now or used in the history.
+    #[test]
+    fn the_json_tool_name_avoids_the_callers_tools() {
+        let req = json!({
+            "messages": [
+                { "role": "user", "content": "hi" },
+                { "role": "assistant", "tool_calls": [{ "id": "a", "type": "function", "function": { "name": "json_tool_call_2", "arguments": "{}" } }] },
+                { "role": "tool", "tool_call_id": "a", "content": "x" }
+            ],
+            "tools": [{ "type": "function", "function": { "name": JSON_TOOL } }],
+            "response_format": { "type": "json_schema", "json_schema": { "schema": { "type": "object" } } }
+        });
+        assert_eq!(json_tool_name(&req).as_deref(), Some("json_tool_call_3"));
+        let out = convert(req);
+        assert_eq!(out["tool_choice"]["name"], "json_tool_call_3");
+        assert_eq!(out["tools"].as_array().unwrap().len(), 3);
+    }
+
+    /// A caller's own forced tool is a contract too: kept, thinking off.
+    #[test]
+    fn a_forced_tool_turns_thinking_off() {
+        let out = convert(json!({
+            "messages": [{ "role": "user", "content": "hi" }],
+            "tools": [{ "type": "function", "function": { "name": "f" } }],
+            "tool_choice": "required",
+            "reasoning_effort": "high", "max_tokens": 64000
+        }));
+        assert_eq!(out["tool_choice"], json!({ "type": "any" }));
+        assert!(out.get("thinking").is_none());
+    }
+
+    /// Ollama's `think`, arriving as `chat_template_kwargs`: `false` is
+    /// off, `true` is a medium budget, a level is that level.
+    #[test]
+    fn ollama_think_becomes_a_thinking_budget() {
+        let with = |kwargs: Value| {
+            convert(json!({
+                "messages": [{ "role": "user", "content": "hi" }],
+                "max_tokens": 64000,
+                "chat_template_kwargs": kwargs
+            }))
+        };
+        assert!(with(json!({ "enable_thinking": false }))
+            .get("thinking")
+            .is_none());
+        assert_eq!(
+            with(json!({ "enable_thinking": true }))["thinking"]["budget_tokens"],
+            8192
+        );
+        assert_eq!(
+            with(json!({ "enable_thinking": true, "reasoning_effort": "max" }))["thinking"]
+                ["budget_tokens"],
+            32000
+        );
+    }
+
+    /// An `/api/chat` tool result has a `name` and no id; it answers the
+    /// first still-open call of that name, or the first call at all.
+    #[test]
+    fn tool_results_without_ids_match_the_preceding_calls() {
+        let call = |id: &str, name: &str| json!({ "id": id, "type": "function", "function": { "name": name, "arguments": "{}" } });
+        let out = convert(json!({
+            "messages": [
+                { "role": "user", "content": "go" },
+                { "role": "assistant", "tool_calls": [call("a", "read"), call("b", "read"), call("c", "list")] },
+                { "role": "tool", "name": "read", "content": "1" },
+                { "role": "tool", "name": "read", "content": "2" },
+                { "role": "tool", "content": "3" }
+            ],
+            "tools": [{ "type": "function", "function": { "name": "read" } }, { "type": "function", "function": { "name": "list" } }]
+        }));
+        let ids: Vec<&str> = out["messages"][2]["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|b| b["tool_use_id"].as_str().unwrap())
+            .collect();
+        assert_eq!(ids, ["a", "b", "c"]);
+        let err = from_chat_request(
+            &json!({ "messages": [{ "role": "user", "content": "x" }, { "role": "tool", "content": "orphan" }] }),
+            DEFAULT_MAX_TOKENS,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("tool_call_id"), "{err}");
+    }
+
+    /// A whitespace-only final assistant prefill leaves no empty turn.
+    #[test]
+    fn a_blank_final_assistant_turn_is_removed() {
+        let out = convert(json!({
+            "messages": [{ "role": "user", "content": "a" }, { "role": "assistant", "content": "  \n" }]
+        }));
+        assert_eq!(out["messages"].as_array().unwrap().len(), 1);
+    }
+
+    /// A JSON tool the request did not inject is an ordinary tool call.
+    #[test]
+    fn a_users_own_json_tool_call_stays_a_tool_call() {
+        let mut conv = StreamConverter::with_id("m", "id", 0);
+        let mut out = String::new();
+        for line in [
+            r#"data: {"type":"message_start","message":{"id":"m"}}"#,
+            &format!(
+                r#"data: {{"type":"content_block_start","index":0,"content_block":{{"type":"tool_use","id":"t","name":"{JSON_TOOL}","input":{{}}}}}}"#
+            ),
+            r#"data: {"type":"content_block_stop","index":0}"#,
+            r#"data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}"#,
+        ] {
+            out.push_str(&conv.line(line));
+        }
+        assert!(out.contains("tool_calls"), "{out}");
+        assert_eq!(
+            conv.completion()["choices"][0]["finish_reason"],
+            "tool_calls"
+        );
+    }
+
+    /// The injected JSON tool with no arguments is `{}` content.
+    #[test]
+    fn an_empty_json_tool_input_is_empty_braces() {
+        let (conv, out) = run(&[
+            r#"data: {"type":"message_start","message":{"id":"m"}}"#,
+            &format!(
+                r#"data: {{"type":"content_block_start","index":0,"content_block":{{"type":"tool_use","id":"t","name":"{JSON_TOOL}","input":{{}}}}}}"#
+            ),
+            r#"data: {"type":"content_block_stop","index":0}"#,
+            r#"data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}"#,
+            r#"data: {"type":"message_stop"}"#,
+        ]);
+        assert_eq!(events(&out)[1]["choices"][0]["delta"]["content"], "{}");
+        assert_eq!(conv.completion()["choices"][0]["message"]["content"], "{}");
+    }
+
+    /// Thinking is left off when the last assistant turn is a tool call
+    /// the client cannot hand back the thinking block for.
+    #[test]
+    fn thinking_is_off_while_a_tool_call_awaits_its_result() {
+        let out = convert(json!({
+            "messages": [
+                { "role": "user", "content": "go" },
+                { "role": "assistant", "tool_calls": [{ "id": "a", "type": "function", "function": { "name": "f", "arguments": "{}" } }] },
+                { "role": "tool", "tool_call_id": "a", "content": "ok" }
+            ],
+            "tools": [{ "type": "function", "function": { "name": "f" } }],
+            "reasoning_effort": "high", "max_tokens": 64000
+        }));
+        assert!(out.get("thinking").is_none(), "{out}");
+        assert!(!thinks(&out));
+
+        let fresh = convert(json!({
+            "messages": [
+                { "role": "user", "content": "go" },
+                { "role": "assistant", "tool_calls": [{ "id": "a", "type": "function", "function": { "name": "f", "arguments": "{}" } }] },
+                { "role": "tool", "tool_call_id": "a", "content": "ok" },
+                { "role": "assistant", "content": "done" },
+                { "role": "user", "content": "next" }
+            ],
+            "tools": [{ "type": "function", "function": { "name": "f" } }],
+            "reasoning_effort": "high", "max_tokens": 64000
+        }));
+        assert!(thinks(&fresh), "{fresh}");
+    }
+
+    /// Images in a tool result are carried as image blocks.
+    #[test]
+    fn tool_results_may_carry_images() {
+        let out = convert(json!({
+            "messages": [
+                { "role": "user", "content": "go" },
+                { "role": "assistant", "tool_calls": [{ "id": "a", "type": "function", "function": { "name": "shot", "arguments": "{}" } }] },
+                { "role": "tool", "tool_call_id": "a", "content": [
+                    { "type": "text", "text": "here" },
+                    { "type": "image_url", "image_url": { "url": "data:image/png;base64,AAAA" } }
+                ] }
+            ],
+            "tools": [{ "type": "function", "function": { "name": "shot" } }]
+        }));
+        assert_eq!(
+            out["messages"][2]["content"][0]["content"],
+            json!([
+                { "type": "text", "text": "here" },
+                { "type": "image", "source": { "type": "base64", "media_type": "image/png", "data": "AAAA" } }
+            ])
+        );
+    }
+
+    /// Sampling and stop parameters, under the API's names.
+    #[test]
+    fn sampling_parameters_are_renamed() {
+        let out = convert(json!({
+            "messages": [{ "role": "user", "content": "hi" }],
+            "temperature": 0.2, "top_p": 0.9, "stop": "END", "user": "u1",
+            "frequency_penalty": 0.5
+        }));
+        assert_eq!(out["temperature"], 0.2);
+        assert_eq!(out["top_p"], 0.9);
+        assert_eq!(out["stop_sequences"], json!(["END"]));
+        assert_eq!(out["metadata"], json!({ "user_id": "u1" }));
+        // No Messages equivalent: dropped rather than sent to be 400'd.
+        assert!(out.get("frequency_penalty").is_none());
+    }
+
+    /// Calls become `tool_use` blocks with decoded arguments, and every
+    /// `tool` message that follows lands in one user turn.
+    #[test]
+    fn tool_calls_and_results_round_trip() {
+        let out = convert(json!({
+            "messages": [
+                { "role": "user", "content": "weather in two cities" },
+                { "role": "assistant", "content": null, "tool_calls": [
+                    { "id": "call_1", "type": "function", "function": { "name": "weather", "arguments": "{\"city\":\"Paris\"}" } },
+                    { "id": "call_2", "type": "function", "function": { "name": "weather", "arguments": "" } }
+                ] },
+                { "role": "tool", "tool_call_id": "call_1", "content": "sunny" },
+                { "role": "tool", "tool_call_id": "call_2", "content": [{ "type": "text", "text": "rain" }] },
+                { "role": "user", "content": "thanks" }
+            ],
+            "tools": [
+                { "type": "function", "function": { "name": "weather", "description": "Look up weather", "parameters": { "type": "object", "properties": { "city": { "type": "string" } } } } },
+                { "type": "web_search" }
+            ],
+            "tool_choice": "auto",
+            "parallel_tool_calls": false
+        }));
+        assert_eq!(
+            out["messages"],
+            json!([
+                { "role": "user", "content": [{ "type": "text", "text": "weather in two cities" }] },
+                { "role": "assistant", "content": [
+                    { "type": "tool_use", "id": "call_1", "name": "weather", "input": { "city": "Paris" } },
+                    { "type": "tool_use", "id": "call_2", "name": "weather", "input": {} }
+                ] },
+                { "role": "user", "content": [
+                    { "type": "tool_result", "tool_use_id": "call_1", "content": "sunny" },
+                    { "type": "tool_result", "tool_use_id": "call_2", "content": [{ "type": "text", "text": "rain" }] },
+                    { "type": "text", "text": "thanks" }
+                ] }
+            ])
+        );
+        assert_eq!(
+            out["tools"],
+            json!([{
+                "name": "weather",
+                "description": "Look up weather",
+                "input_schema": { "type": "object", "properties": { "city": { "type": "string" } } }
+            }])
+        );
+        assert_eq!(
+            out["tool_choice"],
+            json!({ "type": "auto", "disable_parallel_tool_use": true })
+        );
+    }
+
+    /// Each `tool_choice` spelling; none at all without tools.
+    #[test]
+    fn tool_choice_is_translated() {
+        let with = |choice: Value| {
+            convert(json!({
+                "messages": [{ "role": "user", "content": "hi" }],
+                "tools": [{ "type": "function", "function": { "name": "f" } }],
+                "tool_choice": choice
+            }))["tool_choice"]
+                .clone()
+        };
+        assert_eq!(with(json!("required")), json!({ "type": "any" }));
+        assert_eq!(with(json!("none")), json!({ "type": "none" }));
+        assert_eq!(
+            with(json!({ "type": "function", "function": { "name": "f" } })),
+            json!({ "type": "tool", "name": "f" })
+        );
+        let without = convert(json!({
+            "messages": [{ "role": "user", "content": "hi" }],
+            "tool_choice": "required"
+        }));
+        assert!(without.get("tool_choice").is_none());
+        assert!(without.get("tools").is_none());
+    }
+
+    /// A parameterless function still gets the required `input_schema`.
+    #[test]
+    fn a_tool_without_parameters_gets_an_empty_schema() {
+        let out = convert(json!({
+            "messages": [{ "role": "user", "content": "hi" }],
+            "tools": [{ "type": "function", "function": { "name": "now" } }]
+        }));
+        assert_eq!(
+            out["tools"][0]["input_schema"],
+            json!({ "type": "object", "properties": {} })
+        );
+    }
+
+    /// A data URI becomes a base64 source, an https URL a URL source, and
+    /// audio is refused rather than dropped.
+    #[test]
+    fn images_become_image_blocks_and_audio_is_refused() {
+        let out = convert(json!({
+            "messages": [{ "role": "user", "content": [
+                { "type": "text", "text": "what is this" },
+                { "type": "image_url", "image_url": { "url": "data:image/jpeg;base64,AAAA" } },
+                { "type": "image_url", "image_url": { "url": "https://example.invalid/a.png" } }
+            ] }]
+        }));
+        assert_eq!(
+            out["messages"][0]["content"],
+            json!([
+                { "type": "text", "text": "what is this" },
+                { "type": "image", "source": { "type": "base64", "media_type": "image/jpeg", "data": "AAAA" } },
+                { "type": "image", "source": { "type": "url", "url": "https://example.invalid/a.png" } }
+            ])
+        );
+        let err = from_chat_request(
+            &json!({ "messages": [{ "role": "user", "content": [
+                { "type": "input_audio", "input_audio": { "data": "AAAA", "format": "wav" } }
+            ] }] }),
+            DEFAULT_MAX_TOKENS,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("input_audio"), "{err}");
+    }
+
+    /// An empty assistant turn and trailing whitespace on the final one
+    /// are both cleaned up, as the API rejects both.
+    #[test]
+    fn empty_and_trailing_whitespace_assistant_turns_are_fixed() {
+        let out = convert(json!({
+            "messages": [
+                { "role": "user", "content": "a" },
+                { "role": "assistant", "content": "" },
+                { "role": "user", "content": "b" },
+                { "role": "assistant", "content": "Sure:  \n" }
+            ]
+        }));
+        assert_eq!(
+            out["messages"],
+            json!([
+                { "role": "user", "content": [{ "type": "text", "text": "a" }, { "type": "text", "text": "b" }] },
+                { "role": "assistant", "content": [{ "type": "text", "text": "Sure:" }] }
+            ])
+        );
+    }
+
+    /// `reasoning_effort` becomes a clamped thinking budget and drops what
+    /// thinking forbids; too small a `max_tokens` means no thinking.
+    #[test]
+    fn reasoning_effort_becomes_a_thinking_budget() {
+        let out = convert(json!({
+            "messages": [{ "role": "user", "content": "hi" }],
+            "reasoning_effort": "high", "max_tokens": 64000, "temperature": 0.1,
+            "tools": [{ "type": "function", "function": { "name": "f" } }]
+        }));
+        assert_eq!(
+            out["thinking"],
+            json!({ "type": "enabled", "budget_tokens": 16384 })
+        );
+        assert!(out.get("temperature").is_none());
+        assert_eq!(out["tool_choice"], json!({ "type": "auto" }));
+
+        let clamped = convert(json!({
+            "messages": [{ "role": "user", "content": "hi" }],
+            "reasoning_effort": "high", "max_tokens": 8000
+        }));
+        assert_eq!(clamped["thinking"]["budget_tokens"], 4000);
+
+        let none = convert(json!({
+            "messages": [{ "role": "user", "content": "hi" }],
+            "reasoning_effort": "low", "max_tokens": 1500
+        }));
+        assert!(none.get("thinking").is_none());
+        assert_eq!(none["temperature"], Value::Null);
+    }
+
+    /// A `tool` message without an id cannot be matched to its call.
+    #[test]
+    fn a_tool_result_without_an_id_is_an_error() {
+        let err = from_chat_request(
+            &json!({ "messages": [{ "role": "tool", "content": "x" }] }),
+            DEFAULT_MAX_TOKENS,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("tool_call_id"), "{err}");
+    }
+
+    // -- response --------------------------------------------------------------
+
+    const TEXT_STREAM: &[&str] = &[
+        "event: message_start",
+        r#"data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-sonnet-4","content":[],"stop_reason":null,"usage":{"input_tokens":25,"cache_read_input_tokens":10,"cache_creation_input_tokens":0,"output_tokens":1}}}"#,
+        "",
+        "event: content_block_start",
+        r#"data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#,
+        "",
+        "event: ping",
+        r#"data: {"type":"ping"}"#,
+        "",
+        "event: content_block_delta",
+        r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#,
+        "",
+        "event: content_block_delta",
+        r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":", world"}}"#,
+        "",
+        "event: content_block_stop",
+        r#"data: {"type":"content_block_stop","index":0}"#,
+        "",
+        "event: message_delta",
+        r#"data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":4}}"#,
+        "",
+        "event: message_stop",
+        r#"data: {"type":"message_stop"}"#,
+        "",
+    ];
+
+    /// Role first, one content delta per text delta, a finish chunk with
+    /// usage, then `[DONE]`. The id is the provider's, the model the
+    /// client's.
+    #[test]
+    fn a_text_stream_becomes_chat_completion_chunks() {
+        let (conv, out) = run(TEXT_STREAM);
+        let ev = events(&out);
+        assert_eq!(ev.len(), 5, "{out}");
+        assert_eq!(ev[0]["id"], "msg_01");
+        assert_eq!(ev[0]["object"], "chat.completion.chunk");
+        assert_eq!(ev[0]["model"], "claude");
+        assert_eq!(
+            ev[0]["choices"][0]["delta"],
+            json!({ "role": "assistant", "content": "" })
+        );
+        assert_eq!(ev[1]["choices"][0]["delta"]["content"], "Hello");
+        assert_eq!(ev[2]["choices"][0]["delta"]["content"], ", world");
+        assert_eq!(ev[3]["choices"][0]["finish_reason"], "stop");
+        assert_eq!(
+            ev[3]["usage"],
+            json!({
+                "prompt_tokens": 35, "completion_tokens": 4, "total_tokens": 39,
+                "prompt_tokens_details": { "cached_tokens": 10 }
+            })
+        );
+        assert_eq!(ev[4], "[DONE]");
+        assert!(conv.finished());
+        assert!(conv.error().is_none());
+
+        // And folded, for a `stream: false` caller.
+        let completion = conv.completion();
+        assert_eq!(completion["object"], "chat.completion");
+        assert_eq!(
+            completion["choices"][0]["message"]["content"],
+            "Hello, world"
+        );
+        assert_eq!(completion["choices"][0]["finish_reason"], "stop");
+        assert_eq!(completion["usage"]["total_tokens"], 39);
+        assert!(completion["choices"][0]["message"]
+            .get("tool_calls")
+            .is_none());
+    }
+
+    /// `tool_use` start announces the call, each `input_json_delta`
+    /// streams arguments under the same index, and `stop_reason:
+    /// tool_use` is `tool_calls`. Block indices are not tool indices: the
+    /// text block at 0 must not shift the first call off index 0.
+    #[test]
+    fn a_tool_use_stream_becomes_tool_call_deltas() {
+        let (conv, out) = run(&[
+            r#"data: {"type":"message_start","message":{"id":"msg_02","usage":{"input_tokens":5,"output_tokens":1}}}"#,
+            r#"data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#,
+            r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Checking."}}"#,
+            r#"data: {"type":"content_block_stop","index":0}"#,
+            r#"data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"weather","input":{}}}"#,
+            r#"data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"city\":"}}"#,
+            r#"data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"Paris\"}"}}"#,
+            r#"data: {"type":"content_block_stop","index":1}"#,
+            r#"data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":12}}"#,
+            r#"data: {"type":"message_stop"}"#,
+        ]);
+        let ev = events(&out);
+        let tool_start = &ev[2]["choices"][0]["delta"]["tool_calls"][0];
+        assert_eq!(
+            *tool_start,
+            json!({ "index": 0, "id": "toolu_1", "type": "function", "function": { "name": "weather", "arguments": "" } })
+        );
+        assert_eq!(
+            ev[3]["choices"][0]["delta"]["tool_calls"][0],
+            json!({ "index": 0, "function": { "arguments": "{\"city\":" } })
+        );
+        assert_eq!(
+            ev[4]["choices"][0]["delta"]["tool_calls"][0]["function"]["arguments"],
+            "\"Paris\"}"
+        );
+        assert_eq!(ev[5]["choices"][0]["finish_reason"], "tool_calls");
+        assert_eq!(ev[6], "[DONE]");
+
+        let message = &conv.completion()["choices"][0]["message"];
+        assert_eq!(message["content"], "Checking.");
+        assert_eq!(
+            message["tool_calls"],
+            json!([{ "id": "toolu_1", "type": "function", "function": { "name": "weather", "arguments": "{\"city\":\"Paris\"}" } }])
+        );
+        assert_eq!(
+            conv.completion()["choices"][0]["finish_reason"],
+            "tool_calls"
+        );
+    }
+
+    /// A call that streams no arguments still ends with `{}`, emitted at
+    /// its block's stop, so a client can parse it.
+    #[test]
+    fn a_tool_call_without_arguments_gets_empty_braces() {
+        let (conv, out) = run(&[
+            r#"data: {"type":"message_start","message":{"id":"m"}}"#,
+            r#"data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"t","name":"now","input":{}}}"#,
+            r#"data: {"type":"content_block_stop","index":0}"#,
+            r#"data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}"#,
+            r#"data: {"type":"message_stop"}"#,
+        ]);
+        let ev = events(&out);
+        assert_eq!(
+            ev[2]["choices"][0]["delta"]["tool_calls"][0],
+            json!({ "index": 0, "function": { "arguments": "{}" } })
+        );
+        assert_eq!(
+            conv.completion()["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"],
+            "{}"
+        );
+    }
+
+    /// The forced JSON tool's arguments are the reply: streamed as
+    /// content, folded as content, finished with `stop`, and never
+    /// reported as a tool call.
+    #[test]
+    fn the_json_tool_streams_as_content() {
+        let (conv, out) = run(&[
+            r#"data: {"type":"message_start","message":{"id":"m"}}"#,
+            &format!(
+                r#"data: {{"type":"content_block_start","index":0,"content_block":{{"type":"tool_use","id":"t","name":"{JSON_TOOL}","input":{{}}}}}}"#
+            ),
+            r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"ok\":"}}"#,
+            r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"true}"}}"#,
+            r#"data: {"type":"content_block_stop","index":0}"#,
+            r#"data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}"#,
+            r#"data: {"type":"message_stop"}"#,
+        ]);
+        let ev = events(&out);
+        assert_eq!(ev[1]["choices"][0]["delta"]["content"], "{\"ok\":");
+        assert_eq!(ev[2]["choices"][0]["delta"]["content"], "true}");
+        assert_eq!(ev[3]["choices"][0]["finish_reason"], "stop");
+        assert!(!out.contains("tool_calls"), "{out}");
+        let message = &conv.completion()["choices"][0]["message"];
+        assert_eq!(message["content"], "{\"ok\":true}");
+        assert!(message.get("tool_calls").is_none());
+    }
+
+    /// A call with no text at all folds to `content: null`, as OpenAI
+    /// returns it.
+    #[test]
+    fn a_pure_tool_call_folds_to_null_content() {
+        let (conv, _) = run(&[
+            r#"data: {"type":"message_start","message":{"id":"m"}}"#,
+            r#"data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"t","name":"f"}}"#,
+            r#"data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}"#,
+            r#"data: {"type":"message_stop"}"#,
+        ]);
+        assert_eq!(
+            conv.completion()["choices"][0]["message"]["content"],
+            Value::Null
+        );
+    }
+
+    /// Thinking streams as `reasoning_content`; the signature is dropped,
+    /// and `max_tokens` is `length`.
+    #[test]
+    fn thinking_becomes_reasoning_content() {
+        let (conv, out) = run(&[
+            r#"data: {"type":"message_start","message":{"id":"m"}}"#,
+            r#"data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}"#,
+            r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me see"}}"#,
+            r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"abc"}}"#,
+            r#"data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}"#,
+            r#"data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"42"}}"#,
+            r#"data: {"type":"message_delta","delta":{"stop_reason":"max_tokens"}}"#,
+            r#"data: {"type":"message_stop"}"#,
+        ]);
+        let ev = events(&out);
+        assert_eq!(
+            ev[1]["choices"][0]["delta"]["reasoning_content"],
+            "Let me see"
+        );
+        assert_eq!(ev[2]["choices"][0]["delta"]["content"], "42");
+        assert_eq!(ev[3]["choices"][0]["finish_reason"], "length");
+        assert!(!out.contains("abc"), "signature leaked: {out}");
+        assert_eq!(finish_reason("model_context_window_exceeded"), "length");
+        assert_eq!(finish_reason("pause_turn"), "stop");
+        let message = &conv.completion()["choices"][0]["message"];
+        assert_eq!(message["reasoning_content"], "Let me see");
+        assert_eq!(message["content"], "42");
+    }
+
+    /// A stream cut before `message_delta` ends without `[DONE]`; one
+    /// that reached a stop reason is closed.
+    #[test]
+    fn an_early_end_is_not_completed() {
+        let (conv, out) = run(&[
+            r#"data: {"type":"message_start","message":{"id":"m"}}"#,
+            r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}"#,
+        ]);
+        assert!(!out.contains("[DONE]"), "{out}");
+        assert!(!conv.finished());
+
+        let (conv, out) = run(&[
+            r#"data: {"type":"message_start","message":{"id":"m"}}"#,
+            r#"data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}"#,
+        ]);
+        assert!(out.ends_with("data: [DONE]\n\n"), "{out}");
+        assert!(conv.finished());
+    }
+
+    /// An in-band error is relayed in OpenAI's shape and ends the stream
+    /// without `[DONE]`, which consumers would take for success.
+    #[test]
+    fn an_error_event_is_relayed_in_band() {
+        let (conv, out) = run(&[
+            r#"data: {"type":"message_start","message":{"id":"m"}}"#,
+            r#"data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}"#,
+            r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"late"}}"#,
+        ]);
+        let ev = events(&out);
+        assert_eq!(ev[1]["error"]["type"], "overloaded_error");
+        assert_eq!(ev.len(), 2, "output after the error: {out}");
+        assert!(!out.contains("[DONE]"));
+        assert_eq!(conv.error().unwrap()["message"], "Overloaded");
+    }
+
+    /// Empty, `event:` and comment lines produce nothing.
+    #[test]
+    fn non_data_lines_produce_nothing() {
+        let mut conv = StreamConverter::with_id("m", "id", 0);
+        assert_eq!(conv.line("event: message_start"), "");
+        assert_eq!(conv.line(""), "");
+        assert_eq!(conv.line(": comment"), "");
+    }
+}

--- a/src/cmd/serve/responses.rs
+++ b/src/cmd/serve/responses.rs
@@ -3,8 +3,10 @@
 //! Codex speaks only `/v1/responses` (`wire_api = "responses"` is the only
 //! value it accepts). llama-server, `openai`, `groq` and `openrouter`
 //! implement it; most OpenAI-compatible providers stop at
-//! `/v1/chat/completions` — `anthropic` 404s the route, `opencode` 500s it
-//! for every non-OpenAI model — so the daemon bridges the two.
+//! `/v1/chat/completions` (`mistral` 404s the route, `opencode` 500s it
+//! for every non-OpenAI model), so the daemon bridges the two. An
+//! Anthropic-wire provider has no Responses route and is bridged without
+//! being asked (see the `anthropic` sibling module).
 //!
 //! A port of Ollama's `openai/responses.go` (`FromResponsesRequest`,
 //! `ResponsesStreamConverter`), speaking chat completions to a provider

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -10,22 +10,24 @@
 //! serves.
 //!
 //! Only a *subset* is exposed as [`Provider`]s, because `llmman serve`
-//! reaches an upstream exactly one way: an HTTPS POST of an OpenAI Chat
-//! Completions body with `Authorization: Bearer <key>` (see
-//! `Target::Remote` in `cmd::serve`). An entry is offered only if llmman
-//! can be *sure* it speaks that:
+//! reaches an upstream exactly two ways, one per [`Wire`]: an HTTPS POST
+//! of an OpenAI Chat Completions body with `Authorization: Bearer <key>`,
+//! or an HTTPS POST of an Anthropic Messages body with `x-api-key: <key>`
+//! (see `Target::Remote` in `cmd::serve`). An entry is offered only if
+//! llmman can be *sure* it speaks one of those:
 //!
-//! * its `npm` driver is one of [`OPENAI_COMPATIBLE_NPM`], as opposed to
-//!   `@ai-sdk/anthropic` (Messages wire format),
-//!   `@ai-sdk/amazon-bedrock` (SigV4 signing), `@ai-sdk/google-vertex`
-//!   (GCP credentials), and the rest;
+//! * its `npm` driver is one of [`OPENAI_COMPATIBLE_NPM`], or it is a
+//!   [`BUILTIN_ENDPOINTS`] entry vetted by hand (the one way onto the
+//!   Anthropic wire, since `@ai-sdk/anthropic` names a body format, not
+//!   an auth scheme), as opposed to `@ai-sdk/amazon-bedrock` (SigV4
+//!   signing), `@ai-sdk/google-vertex` (GCP credentials), and the rest;
 //! * it has one concrete `https` base URL. models.dev leaves `api` unset
 //!   where the SDK hardcodes the endpoint — recovered from
 //!   [`BUILTIN_ENDPOINTS`] — and templated (`${VAR}`) where it is
 //!   per-account, which llmman has nothing to interpolate from;
 //! * exactly one of its `env` entries is an API key. Multi-variable auth
 //!   (`CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_KEY`, ...) is not "one
-//!   bearer token".
+//!   API key".
 //!
 //! Everything filtered out is deliberately *absent* rather than
 //! half-supported: a provider llmman offers is one it can actually reach.
@@ -54,36 +56,58 @@ const CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 /// fetch falls back to any cached copy, however stale.
 const FETCH_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// The AI SDK driver packages that speak the OpenAI wire format — the
-/// only ones `Target::Remote`'s "POST an OpenAI body with a bearer token"
-/// can actually drive. See this module's own doc comment.
+/// The AI SDK driver packages that speak the OpenAI wire format, which
+/// [`Wire::OpenAi`] drives. See this module's own doc comment.
 const OPENAI_COMPATIBLE_NPM: &[&str] = &[
     "@ai-sdk/openai-compatible",
     "@ai-sdk/openai",
     "@openrouter/ai-sdk-provider",
 ];
 
+/// The wire format `llmman serve` speaks to a provider: the route, the
+/// credential header, and whether a request is translated on the way.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Wire {
+    /// OpenAI Chat Completions, `Authorization: Bearer <key>`.
+    OpenAi,
+    /// Anthropic Messages, `x-api-key: <key>` + `anthropic-version`.
+    Anthropic,
+}
+
+impl Wire {
+    /// The lowercase name the daemon's own API reports.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Wire::OpenAi => "openai",
+            Wire::Anthropic => "anthropic",
+        }
+    }
+}
+
 /// A provider whose endpoint models.dev leaves unset because its AI SDK
 /// package hardcodes it, plus the one `env` entry that is its API key.
 struct Builtin {
     /// models.dev provider id.
     id: &'static str,
-    /// Base URL that `/chat/completions` is appended to.
+    /// Base URL that the wire's route (`/chat/completions`, `/messages`)
+    /// is appended to.
     base_url: &'static str,
     /// The API-key variable, picked out of the provider's `env` list.
     key_env: &'static str,
+    /// What is spoken at `base_url`.
+    wire: Wire,
 }
 
 /// Endpoints for providers models.dev has no `api` for, restricted to
-/// ones with a published, stable OpenAI-compatible endpoint that was
-/// checked by hand to answer `POST /chat/completions` at the URL below.
+/// ones with a published, stable endpoint that was checked by hand to
+/// answer its wire's route at the URL below.
 ///
 /// Not a second registry: an entry here must still be present in the
 /// fetched catalog to be offered, and supplies only the one field
 /// models.dev omits. The rest (`amazon-bedrock`, `azure`,
 /// `google-vertex`, `watsonx`, ...) are left out because their auth is
-/// not a bearer token, their endpoint is per-account, or their wire
-/// format is not OpenAI's. `v0` is left out for a third reason: nothing
+/// not an API key, their endpoint is per-account, or their wire format
+/// is neither of [`Wire`]'s. `v0` is left out for a third reason: nothing
 /// answers at its documented `https://api.v0.dev/v1`, so llmman has no
 /// endpoint it can vouch for.
 const BUILTIN_ENDPOINTS: &[Builtin] = &[
@@ -91,14 +115,15 @@ const BUILTIN_ENDPOINTS: &[Builtin] = &[
         id: "openai",
         base_url: "https://api.openai.com/v1",
         key_env: "OPENAI_API_KEY",
+        wire: Wire::OpenAi,
     },
-    // Anthropic publishes an OpenAI-compatible surface on its normal API
-    // host, keyed by the same ANTHROPIC_API_KEY as a bearer token, so it
-    // is reachable without llmman speaking the Messages wire format.
+    // Its own Messages API, never the OpenAI-compatibility shim, which
+    // has no thinking, cache control or beta headers.
     Builtin {
         id: "anthropic",
         base_url: "https://api.anthropic.com/v1",
         key_env: "ANTHROPIC_API_KEY",
+        wire: Wire::Anthropic,
     },
     // Gemini's OpenAI-compatibility endpoint, not the native
     // generateContent one. GEMINI_API_KEY of the three variables
@@ -107,57 +132,68 @@ const BUILTIN_ENDPOINTS: &[Builtin] = &[
         id: "google",
         base_url: "https://generativelanguage.googleapis.com/v1beta/openai",
         key_env: "GEMINI_API_KEY",
+        wire: Wire::OpenAi,
     },
     Builtin {
         id: "groq",
         base_url: "https://api.groq.com/openai/v1",
         key_env: "GROQ_API_KEY",
+        wire: Wire::OpenAi,
     },
     Builtin {
         id: "mistral",
         base_url: "https://api.mistral.ai/v1",
         key_env: "MISTRAL_API_KEY",
+        wire: Wire::OpenAi,
     },
     Builtin {
         id: "xai",
         base_url: "https://api.x.ai/v1",
         key_env: "XAI_API_KEY",
+        wire: Wire::OpenAi,
     },
     Builtin {
         id: "cerebras",
         base_url: "https://api.cerebras.ai/v1",
         key_env: "CEREBRAS_API_KEY",
+        wire: Wire::OpenAi,
     },
     Builtin {
         id: "togetherai",
         base_url: "https://api.together.xyz/v1",
         key_env: "TOGETHER_API_KEY",
+        wire: Wire::OpenAi,
     },
     Builtin {
         id: "deepinfra",
         base_url: "https://api.deepinfra.com/v1/openai",
         key_env: "DEEPINFRA_API_KEY",
+        wire: Wire::OpenAi,
     },
     // No `/v1`: Perplexity serves /chat/completions off the bare host.
     Builtin {
         id: "perplexity",
         base_url: "https://api.perplexity.ai",
         key_env: "PERPLEXITY_API_KEY",
+        wire: Wire::OpenAi,
     },
     Builtin {
         id: "cohere",
         base_url: "https://api.cohere.ai/compatibility/v1",
         key_env: "COHERE_API_KEY",
+        wire: Wire::OpenAi,
     },
     Builtin {
         id: "venice",
         base_url: "https://api.venice.ai/api/v1",
         key_env: "VENICE_API_KEY",
+        wire: Wire::OpenAi,
     },
     Builtin {
         id: "vercel",
         base_url: "https://ai-gateway.vercel.sh/v1",
         key_env: "AI_GATEWAY_API_KEY",
+        wire: Wire::OpenAi,
     },
 ];
 
@@ -226,11 +262,13 @@ pub struct Provider {
     pub id: String,
     /// Human-readable name, for listings and error messages.
     pub name: String,
-    /// OpenAI-compatible base URL that a route (`/chat/completions`, ...)
-    /// is appended to. Never has a trailing slash.
+    /// Base URL that the wire's route (`/chat/completions`, `/messages`,
+    /// ...) is appended to. Never has a trailing slash.
     pub base_url: String,
     /// Environment variable holding this provider's API key.
     pub key_env: String,
+    /// What is spoken at `base_url`.
+    pub wire: Wire,
     /// Models this provider serves, sorted by id. Used to validate
     /// `--model`, to suggest values, and to answer `llmman list
     /// --provider`; the id is never sent upstream verbatim.
@@ -245,6 +283,9 @@ pub struct Model {
     /// `None` where models.dev publishes no price, which is not the same
     /// as free and must not be rendered as one.
     pub cost: Option<Cost>,
+    /// models.dev's `limit.output`, the default `max_tokens` for a wire
+    /// that requires one. `None` where the catalog has none.
+    pub max_output: Option<u32>,
 }
 
 /// US dollars per million tokens — models.dev's own unit, unconverted so
@@ -534,7 +575,7 @@ struct RawProvider {
 }
 
 /// A models.dev model entry — the id is the map key, so only the price
-/// is read out of the value.
+/// and the output ceiling are read out of the value.
 #[derive(Debug, Deserialize)]
 struct RawModel {
     /// Untyped on purpose: a typed `{input, output}` would let an
@@ -542,6 +583,16 @@ struct RawModel {
     /// and a listing column is not worth `--provider x` breaking over.
     #[serde(default)]
     cost: Option<serde_json::Value>,
+    /// Untyped for the same reason; only `output` is read.
+    #[serde(default)]
+    limit: Option<serde_json::Value>,
+}
+
+/// A models.dev `limit.output` as a token count, or `None` unless it is
+/// a positive whole number that fits.
+fn max_output_of(raw: &serde_json::Value) -> Option<u32> {
+    let n = raw.get("output")?.as_u64()?;
+    u32::try_from(n).ok().filter(|&n| n > 0)
 }
 
 /// A models.dev `cost` object as a [`Cost`], or `None` unless *both*
@@ -596,18 +647,16 @@ fn routable(id: &str, raw: RawProvider) -> Option<Provider> {
     };
 
     // `npm` is the wire-format signal. A builtin has already been vetted
-    // by hand, so it stands in for a driver package this doesn't know:
-    // `anthropic`'s entry names `@ai-sdk/anthropic` even though the
-    // endpoint used here is its OpenAI-compatible one.
-    let openai_compatible = raw
-        .npm
-        .as_deref()
-        .is_some_and(|npm| OPENAI_COMPATIBLE_NPM.contains(&npm));
-    if !openai_compatible && builtin.is_none() {
-        return None;
-    }
+    // by hand, so its own `wire` stands in for a driver package this
+    // doesn't know (`google`'s entry names `@ai-sdk/google` even though
+    // the endpoint used here is its OpenAI-compatible one).
+    let wire = match (builtin, raw.npm.as_deref()) {
+        (Some(b), _) => b.wire,
+        (None, Some(npm)) if OPENAI_COMPATIBLE_NPM.contains(&npm) => Wire::OpenAi,
+        _ => return None,
+    };
 
-    // One bearer token, and llmman must know which variable holds it. A
+    // One API key, and llmman must know which variable holds it. A
     // builtin names it explicitly (`google` lists three aliases); for
     // everything else a single-entry `env` is the only unambiguous case.
     let key_env = match builtin {
@@ -623,6 +672,7 @@ fn routable(id: &str, raw: RawProvider) -> Option<Provider> {
         name: raw.name,
         base_url: base_url_of(base_url),
         key_env,
+        wire,
         // Sorted by id, since `models` came out of a BTreeMap.
         models: raw
             .models
@@ -630,6 +680,7 @@ fn routable(id: &str, raw: RawProvider) -> Option<Provider> {
             .map(|(id, model)| Model {
                 id,
                 cost: model.cost.as_ref().and_then(cost_of),
+                max_output: model.limit.as_ref().and_then(max_output_of),
             })
             .collect(),
     })
@@ -638,14 +689,15 @@ fn routable(id: &str, raw: RawProvider) -> Option<Provider> {
 /// Normalizes a models.dev `api` into a base URL that a route can be
 /// appended to.
 ///
-/// Some entries give the full chat route rather than the base it hangs
-/// off (`bailing` is `.../v1/chat/completions` today). Appending to that
+/// Some entries give the full route rather than the base it hangs off
+/// (`bailing` is `.../v1/chat/completions` today). Appending to that
 /// yields `.../chat/completions/chat/completions`, which fails as a
 /// confusing 404 from the provider rather than anything llmman reports.
 /// Trailing slashes go for the same reason — `url` adds its own.
 fn base_url_of(api: &str) -> String {
     let api = api.trim_end_matches('/');
     api.strip_suffix("/chat/completions")
+        .or_else(|| api.strip_suffix("/messages"))
         .unwrap_or(api)
         .trim_end_matches('/')
         .to_string()
@@ -909,7 +961,7 @@ mod tests {
                     "npm": "@openrouter/ai-sdk-provider",
                     "env": ["OPENROUTER_API_KEY"],
                     "models": {
-                        "z-model": { "cost": { "input": 2.5, "output": 10 } },
+                        "z-model": { "cost": { "input": 2.5, "output": 10 }, "limit": { "context": 200000, "output": 32000 } },
                         "a-model": {}
                     }
                 }
@@ -919,29 +971,31 @@ mod tests {
         assert_eq!(p.name, "OpenRouter");
         assert_eq!(p.base_url, "https://openrouter.ai/api/v1");
         assert_eq!(p.key_env, "OPENROUTER_API_KEY");
+        assert_eq!(p.wire, Wire::OpenAi);
         // Sorted by id; an unpriced model keeps `None`, not a zero.
         assert_eq!(
             p.models,
             vec![
                 Model {
                     id: "a-model".into(),
-                    cost: None
+                    cost: None,
+                    max_output: None,
                 },
                 Model {
                     id: "z-model".into(),
                     cost: Some(Cost {
                         input: 2.5,
                         output: 10.0
-                    })
+                    }),
+                    max_output: Some(32000),
                 },
             ]
         );
     }
 
     /// models.dev leaves `api` unset for providers whose SDK hardcodes
-    /// the endpoint; those are recovered from `BUILTIN_ENDPOINTS`,
-    /// including `anthropic`, whose `npm` is not OpenAI-compatible but
-    /// whose builtin endpoint is.
+    /// the endpoint; those are recovered from `BUILTIN_ENDPOINTS`, each
+    /// with the wire format its builtin was vetted for.
     #[test]
     fn builtins_supply_endpoints_the_catalog_omits() {
         let catalog = catalog_from(
@@ -962,11 +1016,24 @@ mod tests {
         let anthropic = catalog.get("anthropic").expect("anthropic is routable");
         assert_eq!(anthropic.base_url, "https://api.anthropic.com/v1");
         assert_eq!(anthropic.key_env, "ANTHROPIC_API_KEY");
+        // Its own Messages API, never the OpenAI-compatibility shim.
+        assert_eq!(anthropic.wire, Wire::Anthropic);
 
         // Three candidate variables in the catalog, one unambiguous
         // choice from the builtin.
         let google = catalog.get("google").expect("google is routable");
         assert_eq!(google.key_env, "GEMINI_API_KEY");
+        assert_eq!(google.wire, Wire::OpenAi);
+    }
+
+    /// A full `/messages` route is trimmed to its base like
+    /// `/chat/completions` is.
+    #[test]
+    fn a_messages_route_is_trimmed_to_its_base() {
+        assert_eq!(
+            base_url_of("https://api.anthropic.com/v1/messages/"),
+            "https://api.anthropic.com/v1"
+        );
     }
 
     /// A concrete `api` tracks a provider moving hosts, so it wins over
@@ -988,8 +1055,8 @@ mod tests {
         assert_eq!(p.base_url, "https://api.openai.example/v2");
     }
 
-    /// Everything llmman cannot reach with a bearer-token OpenAI POST
-    /// must be absent rather than half-supported.
+    /// Everything llmman cannot reach with an API-key POST in one of its
+    /// two wire formats must be absent rather than half-supported.
     #[test]
     fn unreachable_providers_are_dropped() {
         let catalog = catalog_from(
@@ -1034,7 +1101,8 @@ mod tests {
                 }
             }"#,
         );
-        // Anthropic wire format, not OpenAI's.
+        // The Messages body format, but no vetted auth scheme: only the
+        // `anthropic` builtin rides that wire.
         assert!(catalog.get("minimax").is_none());
         // SigV4 signing, and no endpoint at all.
         assert!(catalog.get("amazon-bedrock").is_none());
@@ -1304,6 +1372,7 @@ mod tests {
             name: "Groq".into(),
             base_url: "https://api.groq.com/openai/v1".into(),
             key_env: "GROQ_API_KEY".into(),
+            wire: Wire::OpenAi,
             models: vec![],
         };
         assert_eq!(
@@ -1342,6 +1411,7 @@ mod tests {
             name: "Test".into(),
             base_url: "https://example.invalid/v1".into(),
             key_env: "LLMMAN_TEST_PROVIDER_KEY_UNSET".into(),
+            wire: Wire::OpenAi,
             models: vec![],
         };
         assert_eq!(p.api_key(), None);


### PR DESCRIPTION
Anthropic was reached through its OpenAI-compatibility shim, which has no thinking, cache control or beta headers. A Claude Code request on `/v1/messages` was translated to OpenAI and back, losing its tools and cache breakpoints, and Codex paid a 404 probing `/v1/responses` first.

Providers now carry a wire format (`openai` | `anthropic`). `anthropic` is spoken to in the Messages API with `x-api-key`:

| Arrived on | Sent as |
|---|---|
| `/v1/messages` (claude) | relayed intact; `model` rewritten, client `anthropic-beta`/`anthropic-version` kept |
| `/v1/chat/completions` (opencode, aider, qwen, hermes), `/api/chat`, `/api/generate` | translated to Messages and back by `serve::anthropic` |
| `/v1/responses` (codex) | the existing bridge, then the same translation |
| `/v1/completions`, `/v1/embeddings`, `/api/embed`, `/v1/responses/input_tokens` | 501 up front |

Checked against litellm's and opencode's adapters, the translation adds what the API needs and an OpenAI client cannot say: cache breakpoints on the last tool, system block and user block; a `response_format` schema as a forced tool whose arguments come back as content; tools declared back from history; placeholder results for unanswered calls; Ollama tool results matched by name and `think` as a budget; thinking off while a tool call awaits its result or a tool is forced; whitespace-only text and stops dropped; ids sanitized collision-free; `{}` for empty arguments. `max_tokens` defaults to the model's `limit.output`, else 4096.

Only the `anthropic` builtin rides this wire: `@ai-sdk/anthropic` names a body format, not an auth scheme, and MiniMax/Kimi endpoints commonly take Bearer.

`cargo test --lib`: 722 pass, clippy clean. The two `launch_e2e` failures are pre-existing on `main`.
