### PR TITLE
feat: add `llmman log`, a `git log` for the prompts serve has seen

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ at once, picked per request? See [Hybrid model pairs](#hybrid-model-pairs).
 | `pull`    | Pull a model from a registry or HuggingFace |
 | `list` (`ls`) | List locally stored models, or a hosted provider's (`--provider`) models |
 | `ps`      | List models currently loaded |
+| `log`     | Show the prompts `serve` has seen, newest first, like `git log` |
 | `providers` | List the hosted providers `--provider` can route to |
 | `stop`    | Stop (unload) a running model |
 | `build`   | Package model files into a local OCI image |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ Default locations:
 
 Set `LLMMAN_MODELS` to change this (matching Ollama's `OLLAMA_MODELS`).
 Commands that read or write the local store directly (`list`, `rm`, `cp`,
-`show`, `build`, `serve`) all honor it. Commands that go through the
+`show`, `build`, `serve`, `log`) all honor it. Commands that go through the
 background daemon instead (`pull`, `push`, `run`, `launch`, `ps`, `stop`)
 always use whichever store the daemon was started with; set `LLMMAN_MODELS`
 before `llmman serve` to change it for all of them. `transfer`, `login`, and
@@ -201,6 +201,7 @@ setting may not behave identically.
 | `LLMMAN_TMPDIR` | Staging directory for `llama-server` release downloads, overriding the default `tmp` subdirectory of the install root. |
 | `LLMMAN_VERIFY` | Overrides the signature-verification mode (`off`, `warn`, or `enforce`) for every reference, ignoring what `[verify]` selected. Does *not* supply trusted keys — those still come from `llmman.conf`, so `enforce` with no configured keys fails every check rather than passing them. Intended for CI, which can demand `enforce` without editing config files. See [verification.md](verification.md). |
 | `LLMMAN_SIGN_PASSWORD` | Passphrase for the `--sign-key` private key used by `push`/`transfer`, when it is an encrypted PEM. Falls back to `COSIGN_PASSWORD`. Read by the CLI process, which does the signing itself; neither key nor passphrase reaches the daemon. |
+| `LLMMAN_NOHISTORY` | When set (to anything other than `0`/`false`/`no`/`off`), `llmman serve` stops recording prompts for `llmman log`. Otherwise each request to a generation route (`/api/chat`, `/api/generate`, `/v1/chat/completions`, `/v1/completions`, `/v1/responses`, `/v1/messages`) appends its time, route, model, `User-Agent` and the last user message's text — not the transcript or the reply — to `prompts.jsonl` beside the store (`~/.local/share/llmman/prompts.jsonl` by default), readable only by its owner. Delete the file to clear the history. |
 | `LLMMAN_NOPRUNE` | When set (to anything other than `0`/`false`/`no`/`off`), skips the garbage-collection sweep that `llmman rm` and `llmman serve` startup otherwise run to delete blobs and extracted-cache entries no longer referenced by any local model. Note this is broader than skipping the daemon-startup catch-all: it also stops `llmman rm` itself from ever freeing disk space, so a removed model's (possibly multi-GB) weights stay on disk until a later sweep runs without this set. Useful for a shared/read-mostly store, or scripts that `rm` in a loop and prune once at the end. |
 | `LLAMA_ARG_FIT` / `LLAMA_ARG_FIT_TARGET` / `LLAMA_ARG_THREADS` | llama.cpp's own env-configurable `--fit`/`--fit-target`/`--threads` options. Not something llmman parses itself, just forwarded through to every `llama-server` (local or `--ociman` container) it spawns, same as `CUDA_VISIBLE_DEVICES`/etc. below. |
 

--- a/src/cmd/log.rs
+++ b/src/cmd/log.rs
@@ -1,0 +1,469 @@
+//! `llmman log` — `git log` for the prompts `llmman serve` has seen. Reads
+//! `crate::promptlog`'s file directly (no daemon, as `git log` needs no
+//! server), newest first, through a pager on a terminal.
+
+use std::io::{self, IsTerminal, Write};
+use std::process::{Command, Stdio};
+
+use anyhow::{bail, Context};
+use chrono::{DateTime, Local, Utc};
+use clap::Args;
+
+use crate::promptlog::Entry;
+
+#[derive(Args, Debug)]
+pub struct LogArgs {
+    /// Limit the number of prompts to output
+    #[arg(short = 'n', long = "max-count", value_name = "NUMBER")]
+    pub max_count: Option<usize>,
+    /// Skip NUMBER prompts before starting to show the output
+    #[arg(long, value_name = "NUMBER", default_value_t = 0)]
+    pub skip: usize,
+    /// Show prompts more recent than a specific date (RFC 3339, YYYY-MM-DD,
+    /// "yesterday", or "2 hours ago")
+    #[arg(long, visible_alias = "after", value_name = "DATE")]
+    pub since: Option<String>,
+    /// Show prompts older than a specific date
+    #[arg(long, visible_alias = "before", value_name = "DATE")]
+    pub until: Option<String>,
+    /// Limit to prompts sent to a model matching the pattern (regular
+    /// expression). Repeat to match any of several
+    #[arg(long, value_name = "PATTERN")]
+    pub model: Vec<String>,
+    /// Limit to prompts whose text matches the pattern (regular
+    /// expression). Repeat to match any of several
+    #[arg(long, value_name = "PATTERN")]
+    pub grep: Vec<String>,
+    /// Match the limiting patterns without regard to letter case
+    #[arg(short = 'i', long = "regexp-ignore-case")]
+    pub ignore_case: bool,
+    /// One line per prompt: its abbreviated id and first line
+    #[arg(long)]
+    pub oneline: bool,
+    /// Oldest first
+    #[arg(long)]
+    pub reverse: bool,
+    /// Do not pipe the output into a pager
+    #[arg(long)]
+    pub no_pager: bool,
+}
+
+/// git's `log -3` shorthand for `-n 3`, which clap has no spelling for:
+/// a bare `-<digits>` after `log` is rewritten before parsing.
+pub fn expand_count_shorthand<I: IntoIterator<Item = std::ffi::OsString>>(
+    args: I,
+) -> Vec<std::ffi::OsString> {
+    let mut args: Vec<std::ffi::OsString> = args.into_iter().collect();
+    if args.get(1).is_some_and(|a| a == "log") {
+        for arg in &mut args[2..] {
+            if let Some(n) = arg.to_str().and_then(|a| a.strip_prefix('-')) {
+                if !n.is_empty() && n.bytes().all(|b| b.is_ascii_digit()) {
+                    *arg = format!("-n{n}").into();
+                }
+            }
+        }
+    }
+    args
+}
+
+pub fn run(args: &LogArgs) -> anyhow::Result<()> {
+    let path = crate::promptlog::path()?;
+    let mut entries = crate::promptlog::read(&path)
+        .with_context(|| format!("read prompt log {}", path.display()))?;
+
+    let now = Utc::now();
+    let since = args
+        .since
+        .as_deref()
+        .map(|s| parse_date(s, now))
+        .transpose()?;
+    let until = args
+        .until
+        .as_deref()
+        .map(|s| parse_date(s, now))
+        .transpose()?;
+    let model = patterns(&args.model, args.ignore_case)?;
+    let grep = patterns(&args.grep, args.ignore_case)?;
+    entries.retain(|e| {
+        let time = DateTime::parse_from_rfc3339(&e.time).ok();
+        since.is_none_or(|s| time.is_some_and(|t| t >= s))
+            && until.is_none_or(|u| time.is_some_and(|t| t <= u))
+            && model.as_ref().is_none_or(|m| m.is_match(&e.model))
+            && grep.as_ref().is_none_or(|g| g.is_match(&e.prompt))
+    });
+
+    let color = io::stdout().is_terminal();
+    let mut out = String::new();
+    for entry in select(&entries, args.skip, args.max_count, args.reverse) {
+        if args.oneline {
+            oneline(entry, color, &mut out);
+        } else {
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            full(entry, color, &mut out);
+        }
+    }
+    emit(&out, !args.no_pager)
+}
+
+/// As git: `--skip`/`-n` select newest-first, `--reverse` then flips
+/// only what's shown (`log --reverse -3` is the newest three, oldest
+/// first).
+fn select(entries: &[Entry], skip: usize, max: Option<usize>, reverse: bool) -> Vec<&Entry> {
+    let mut shown: Vec<&Entry> = entries
+        .iter()
+        .rev()
+        .skip(skip)
+        .take(max.unwrap_or(usize::MAX))
+        .collect();
+    if reverse {
+        shown.reverse();
+    }
+    shown
+}
+
+/// Several patterns match when any does, as in git; none is no filter.
+fn patterns(patterns: &[String], ignore_case: bool) -> anyhow::Result<Option<regex::RegexSet>> {
+    if patterns.is_empty() {
+        return Ok(None);
+    }
+    regex::RegexSetBuilder::new(patterns)
+        .case_insensitive(ignore_case)
+        .build()
+        .map(Some)
+        .context("invalid pattern")
+}
+
+/// RFC 3339; local `YYYY-MM-DD` (midnight) or `YYYY-MM-DD HH:MM[:SS]`;
+/// `yesterday`; git's `N <unit>[s] ago` (also `N.<unit>.ago`).
+fn parse_date(s: &str, now: DateTime<Utc>) -> anyhow::Result<DateTime<Utc>> {
+    let s = s.trim();
+    if let Ok(t) = DateTime::parse_from_rfc3339(s) {
+        return Ok(t.with_timezone(&Utc));
+    }
+    for fmt in ["%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M"] {
+        if let Ok(t) = chrono::NaiveDateTime::parse_from_str(s, fmt) {
+            return local_to_utc(t);
+        }
+    }
+    if let Ok(d) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+        return local_to_utc(d.and_hms_opt(0, 0, 0).unwrap());
+    }
+    let words: Vec<&str> = s.split(['.', ' ']).filter(|w| !w.is_empty()).collect();
+    let (n, unit): (i64, &str) = match words[..] {
+        ["yesterday"] => (1, "day"),
+        [n, unit, "ago"] => (n.parse().ok().unwrap_or(-1), unit.trim_end_matches('s')),
+        _ => bail!("invalid date: {s:?}"),
+    };
+    let seconds: i64 = match unit {
+        "second" | "sec" => 1,
+        "minute" | "min" => 60,
+        "hour" => 3600,
+        "day" => 86400,
+        "week" => 86400 * 7,
+        "month" => 86400 * 30,
+        "year" => 86400 * 365,
+        _ => bail!("invalid date: {s:?}"),
+    };
+    n.checked_mul(seconds)
+        .filter(|_| n >= 0)
+        .and_then(chrono::Duration::try_seconds)
+        .and_then(|d| now.checked_sub_signed(d))
+        .with_context(|| format!("invalid date: {s:?}"))
+}
+
+fn local_to_utc(t: chrono::NaiveDateTime) -> anyhow::Result<DateTime<Utc>> {
+    t.and_local_timezone(Local)
+        .single()
+        .map(|t| t.with_timezone(&Utc))
+        .ok_or_else(|| anyhow::anyhow!("not a valid local time: {t}"))
+}
+
+const YELLOW: &str = "\x1b[33m";
+const RESET: &str = "\x1b[0m";
+
+fn paint(text: &str, color: bool) -> String {
+    if color {
+        format!("{YELLOW}{text}{RESET}")
+    } else {
+        text.to_string()
+    }
+}
+
+/// Request-supplied text with control characters (tab aside) dropped:
+/// no driving the terminal — `less -R` passes escapes through — and no
+/// forged header lines from a newline in a model name.
+fn clean(s: &str) -> String {
+    s.chars()
+        .filter(|c| !c.is_control() || *c == '\t')
+        .collect()
+}
+
+/// `git log`'s layout: header, blank line, message indented four.
+fn full(e: &Entry, color: bool, out: &mut String) {
+    out.push_str(&paint(&format!("prompt {}", e.id), color));
+    out.push('\n');
+    out.push_str(&format!("Model:  {}\n", clean(&e.model)));
+    if let Some(client) = &e.client {
+        out.push_str(&format!("Client: {}\n", clean(client)));
+    }
+    out.push_str(&format!("Route:  {}\n", e.route));
+    out.push_str(&format!("Date:   {}\n\n", git_date(&e.time)));
+    for line in e.prompt.lines() {
+        out.push_str("    ");
+        out.push_str(&clean(line));
+        out.push('\n');
+    }
+}
+
+fn oneline(e: &Entry, color: bool, out: &mut String) {
+    out.push_str(&paint(&crate::fmt::short_id(&e.id), color));
+    out.push(' ');
+    out.push_str(&clean(e.prompt.lines().next().unwrap_or_default()));
+    out.push('\n');
+}
+
+/// git's date format, local time: `Sun Sep 6 12:34:56 2026 +0100`.
+fn git_date(rfc3339: &str) -> String {
+    match DateTime::parse_from_rfc3339(rfc3339) {
+        Ok(t) => t
+            .with_timezone(&Local)
+            .format("%a %b %-d %H:%M:%S %Y %z")
+            .to_string(),
+        Err(_) => rfc3339.to_string(),
+    }
+}
+
+/// Through the pager when stdout is a terminal, as git: `$LLMMAN_PAGER`,
+/// else `$PAGER`, else `less`, via the shell; empty or `cat` means none.
+/// `LESS=FRX` is git's default too.
+fn emit(text: &str, pager: bool) -> anyhow::Result<()> {
+    if pager && io::stdout().is_terminal() {
+        if let Some(mut child) = pager_command().and_then(|cmd| spawn_pager(&cmd).ok()) {
+            if let Some(mut stdin) = child.stdin.take() {
+                // Quitting the pager early closes the pipe; not an error.
+                let _ = stdin.write_all(text.as_bytes());
+            }
+            // 127 (sh) / 9009 (cmd): no such pager, nothing was shown.
+            if !matches!(child.wait()?.code(), Some(127 | 9009)) {
+                return Ok(());
+            }
+        }
+    }
+    match io::stdout().write_all(text.as_bytes()) {
+        Err(e) if e.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+        other => Ok(other?),
+    }
+}
+
+fn pager_command() -> Option<String> {
+    let cmd = ["LLMMAN_PAGER", "PAGER"]
+        .iter()
+        .find_map(|var| std::env::var(var).ok())
+        .unwrap_or_else(|| "less".to_string());
+    let cmd = cmd.trim().to_string();
+    (!cmd.is_empty() && cmd != "cat").then_some(cmd)
+}
+
+fn spawn_pager(cmd: &str) -> io::Result<std::process::Child> {
+    let mut command = if cfg!(windows) {
+        let mut c = Command::new("cmd");
+        c.args(["/C", cmd]);
+        c
+    } else {
+        let mut c = Command::new("sh");
+        c.args(["-c", cmd]);
+        c
+    };
+    for (var, default) in [("LESS", "FRX"), ("LV", "-c")] {
+        if std::env::var_os(var).is_none() {
+            command.env(var, default);
+        }
+    }
+    command.stdin(Stdio::piped()).spawn()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry() -> Entry {
+        Entry {
+            id: "0123456789abcdef0123456789abcdef01234567".into(),
+            time: "2026-09-06T11:34:56Z".into(),
+            route: "/v1/chat/completions".into(),
+            model: "qwen3:8b".into(),
+            client: Some("claude-cli/1.2.3".into()),
+            prompt: "fix the failing test\nthen commit".into(),
+        }
+    }
+
+    #[test]
+    fn full_format_mirrors_git_log() {
+        let mut out = String::new();
+        full(&entry(), false, &mut out);
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines[0], "prompt 0123456789abcdef0123456789abcdef01234567");
+        assert_eq!(lines[1], "Model:  qwen3:8b");
+        assert_eq!(lines[2], "Client: claude-cli/1.2.3");
+        assert_eq!(lines[3], "Route:  /v1/chat/completions");
+        assert!(lines[4].starts_with("Date:   "), "{}", lines[4]);
+        assert_eq!(lines[5], "");
+        assert_eq!(lines[6], "    fix the failing test");
+        assert_eq!(lines[7], "    then commit");
+        assert_eq!(lines.len(), 8);
+    }
+
+    #[test]
+    fn the_client_line_is_left_out_when_unknown() {
+        let mut out = String::new();
+        full(
+            &Entry {
+                client: None,
+                ..entry()
+            },
+            false,
+            &mut out,
+        );
+        assert!(!out.contains("Client:"));
+    }
+
+    #[test]
+    fn oneline_is_the_short_id_and_first_line() {
+        let mut out = String::new();
+        oneline(&entry(), false, &mut out);
+        assert_eq!(out, "0123456789ab fix the failing test\n");
+    }
+
+    #[test]
+    fn color_wraps_only_the_header_in_yellow() {
+        let mut out = String::new();
+        full(&entry(), true, &mut out);
+        assert!(out.starts_with("\x1b[33mprompt 0123456789abcdef0123456789abcdef01234567\x1b[0m\n"));
+        assert_eq!(out.matches("\x1b[").count(), 2);
+    }
+
+    #[test]
+    fn request_supplied_text_cannot_drive_the_terminal() {
+        let hostile = Entry {
+            model: "m\x1b[2J\nDate:   forged".into(),
+            client: Some("c\u{9b}0m\r".into()),
+            prompt: "\x1b]0;title\x07line one\n\tindented\x08".into(),
+            ..entry()
+        };
+        let mut out = String::new();
+        full(&hostile, false, &mut out);
+        assert!(!out.contains('\x1b') && !out.contains('\u{9b}') && !out.contains('\x07'));
+        assert!(out.contains("Model:  m[2JDate:   forged\n"));
+        assert!(out.contains("Client: c0m\n"));
+        assert!(out.contains("    ]0;titleline one\n    \tindented\n"));
+        let mut one = String::new();
+        oneline(&hostile, false, &mut one);
+        assert_eq!(one, "0123456789ab ]0;titleline one\n");
+    }
+
+    #[test]
+    fn git_date_uses_gits_layout() {
+        // Local zone, so check the shape rather than the hour.
+        let d = git_date("2026-09-06T11:34:56Z");
+        let parts: Vec<&str> = d.split(' ').collect();
+        assert_eq!(parts.len(), 6, "{d}");
+        assert_eq!(parts[1], "Sep");
+        assert_eq!(parts[3].len(), 8);
+        assert_eq!(parts[4], "2026");
+        assert!(parts[5].starts_with('+') || parts[5].starts_with('-'));
+        assert_eq!(git_date("garbage"), "garbage");
+    }
+
+    #[test]
+    fn relative_dates_count_back_from_now() {
+        let now = DateTime::parse_from_rfc3339("2026-09-06T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let at = |s: &str| parse_date(s, now).unwrap().to_rfc3339();
+        assert_eq!(at("2 hours ago"), "2026-09-06T10:00:00+00:00");
+        assert_eq!(at("1.week.ago"), "2026-08-30T12:00:00+00:00");
+        assert_eq!(at("yesterday"), "2026-09-05T12:00:00+00:00");
+        assert_eq!(at("30 minutes ago"), "2026-09-06T11:30:00+00:00");
+        assert_eq!(at("2026-09-01T00:00:00Z"), "2026-09-01T00:00:00+00:00");
+        for bad in [
+            "fortnight",
+            "3 fortnights ago",
+            "-2 days ago",
+            "99999999999999 years ago",
+        ] {
+            assert!(parse_date(bad, now).is_err(), "{bad}");
+        }
+    }
+
+    #[test]
+    fn a_plain_date_is_local_midnight() {
+        let now = Utc::now();
+        let t = parse_date("2026-09-06", now).unwrap().with_timezone(&Local);
+        assert_eq!(
+            t.format("%Y-%m-%d %H:%M:%S").to_string(),
+            "2026-09-06 00:00:00"
+        );
+    }
+
+    #[test]
+    fn reverse_flips_the_selection_not_the_whole_log() {
+        let entries: Vec<Entry> = (1..=5)
+            .map(|i| Entry {
+                prompt: format!("p{i}"),
+                ..entry()
+            })
+            .collect();
+        fn prompts(shown: Vec<&Entry>) -> Vec<&str> {
+            shown.iter().map(|e| e.prompt.as_str()).collect()
+        }
+        assert_eq!(
+            prompts(select(&entries, 0, None, false)),
+            ["p5", "p4", "p3", "p2", "p1"]
+        );
+        assert_eq!(
+            prompts(select(&entries, 0, Some(3), false)),
+            ["p5", "p4", "p3"]
+        );
+        assert_eq!(
+            prompts(select(&entries, 0, Some(3), true)),
+            ["p3", "p4", "p5"]
+        );
+        assert_eq!(prompts(select(&entries, 1, Some(2), true)), ["p3", "p4"]);
+    }
+
+    #[test]
+    fn a_bare_dash_number_after_log_becomes_max_count() {
+        let expand = |args: &[&str]| -> Vec<String> {
+            expand_count_shorthand(args.iter().map(std::ffi::OsString::from))
+                .into_iter()
+                .map(|a| a.into_string().unwrap())
+                .collect()
+        };
+        assert_eq!(
+            expand(&["llmman", "log", "-3", "--oneline"]),
+            ["llmman", "log", "-n3", "--oneline"]
+        );
+        assert_eq!(
+            expand(&["llmman", "log", "-n", "3"]),
+            ["llmman", "log", "-n", "3"]
+        );
+        assert_eq!(expand(&["llmman", "log", "-"]), ["llmman", "log", "-"]);
+        assert_eq!(expand(&["llmman", "ps", "-3"]), ["llmman", "ps", "-3"]);
+    }
+
+    #[test]
+    fn several_patterns_match_any_and_ignore_case_applies_to_all() {
+        let re = patterns(&["foo".into(), "bar".into()], true)
+            .unwrap()
+            .unwrap();
+        assert!(re.is_match("FOO"));
+        assert!(re.is_match("a Bar"));
+        assert!(!re.is_match("baz"));
+        // Independent patterns: a capture name may repeat across them.
+        assert!(patterns(&["(?P<x>a)".into(), "(?P<x>b)".into()], false).is_ok());
+        assert!(patterns(&[], false).unwrap().is_none());
+        assert!(patterns(&["(".into()], false).is_err());
+    }
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -4,6 +4,7 @@ pub mod cp;
 pub mod gpu_discover;
 pub mod launch;
 pub mod list;
+pub mod log;
 pub mod login;
 pub mod logout;
 pub mod providers;

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -11,7 +11,7 @@ use anyhow::{anyhow, Context};
 // `HttpBody` is axum's re-export of the `http_body::Body` trait, in
 // scope only for `size_hint` in `track_metrics`.
 use axum::body::{Body, Bytes, HttpBody as _};
-use axum::extract::{DefaultBodyLimit, MatchedPath, Path as UrlPath, Request, State};
+use axum::extract::{DefaultBodyLimit, FromRequest, MatchedPath, Path as UrlPath, Request, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
@@ -57,6 +57,7 @@ Environment Variables:
       LLMMAN_METRICS                 Serve a Prometheus scrape endpoint at /metrics (default: off)
       LLMMAN_MODELS                  The path to the models directory
       LLMMAN_NUM_PARALLEL            Maximum number of parallel requests per model (GGUF only)
+      LLMMAN_NOHISTORY               Do not record prompts for `llmman log`
       LLMMAN_NOPRUNE                 Do not prune model blobs on startup
       LLMMAN_ORIGINS                 A comma separated list of allowed CORS origins
       LLMMAN_PEERS                   A comma separated list of peer daemons ([scheme://]host[:port]) to pool hardware with (overrides [aggregation] in llmman.conf)
@@ -582,6 +583,8 @@ struct Inner {
     memory: u64,
     store_path: PathBuf,
     cache_path: PathBuf,
+    // `record_prompt`'s file; None under LLMMAN_NOHISTORY (and in tests).
+    prompt_log: Option<PathBuf>,
     client: Client,
 }
 
@@ -8572,6 +8575,45 @@ async fn track_metrics(req: Request, next: Next) -> Response {
     Response::from_parts(parts, body)
 }
 
+/// Appends each generation request's prompt to the log `llmman log`
+/// reads (`crate::promptlog`). The body goes through the same `Bytes`
+/// extractor the handlers use, so the size limit and its 413 are
+/// unchanged; the handler then reads it back from memory.
+async fn record_prompt(State(state): State<AppState>, req: Request, next: Next) -> Response {
+    let Some(log) = state.0.prompt_log.as_deref() else {
+        return next.run(req).await;
+    };
+    let route = req
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|p| p.as_str().to_string())
+        .filter(|r| crate::promptlog::is_generation_route(r));
+    // Not a prompt: another method (a 405 ahead), or on the Ollama routes
+    // the forged cross-site request that `accept_any_content_type`, which
+    // runs after this layer, refuses.
+    let Some(route) = route.filter(|r| {
+        req.method() == axum::http::Method::POST
+            && !(r.starts_with("/api/") && forged_cross_site(req.headers()))
+    }) else {
+        return next.run(req).await;
+    };
+    let (parts, body) = req.into_parts();
+    let body = match Bytes::from_request(Request::from_parts(parts.clone(), body), &()).await {
+        Ok(body) => body,
+        Err(rejection) => return rejection.into_response(),
+    };
+    let client = parts
+        .headers
+        .get(axum::http::header::USER_AGENT)
+        .and_then(|v| v.to_str().ok());
+    if let Some(entry) = crate::promptlog::entry(&route, &body, client, now_rfc3339()) {
+        if let Err(e) = crate::promptlog::append(log, &entry) {
+            eprintln!("[llmman] warning: prompt log {}: {e}", log.display());
+        }
+    }
+    next.run(Request::from_parts(parts, Body::from(body))).await
+}
+
 /// Lets the Ollama routes take a JSON body under any `Content-Type`, as
 /// ollama does (gin's `ShouldBindJSON` ignores the header): `curl -d`
 /// sends a form type, a browser `fetch` sends `text/plain`, some SDKs
@@ -8583,12 +8625,7 @@ async fn track_metrics(req: Request, next: Next) -> Response {
 /// outright, since `/api/blobs` reads a raw body and `/api/pull` or
 /// `/api/create` would otherwise be drivable from any page.
 async fn accept_any_content_type(mut req: Request, next: Next) -> Response {
-    let is_json = req
-        .headers()
-        .get(axum::http::header::CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-        .is_some_and(is_json_content_type);
-    if !is_json {
+    if !has_json_content_type(req.headers()) {
         if foreign_origin(req.headers()) {
             let body = serde_json::json!({ "error": "cross-site request refused" });
             return (StatusCode::FORBIDDEN, Json(body)).into_response();
@@ -8599,6 +8636,19 @@ async fn accept_any_content_type(mut req: Request, next: Next) -> Response {
         );
     }
     next.run(req).await
+}
+
+fn has_json_content_type(headers: &HeaderMap) -> bool {
+    headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(is_json_content_type)
+}
+
+/// A browser "simple" request from a page `cors_layer` wouldn't allow —
+/// what `accept_any_content_type` refuses.
+fn forged_cross_site(headers: &HeaderMap) -> bool {
+    !has_json_content_type(headers) && foreign_origin(headers)
 }
 
 /// Whether the request carries an `Origin` that `cors_layer` wouldn't
@@ -8738,6 +8788,13 @@ fn build_router(app_state: AppState, metrics_enabled: bool) -> Router {
     // preflight OPTIONS before this layer runs, so preflights are not
     // counted — they are the browser's negotiation, not a request the
     // daemon did any work for.
+    // Innermost, so `track_metrics` times its body read as the handler's
+    // and CORS answers preflights before it.
+    let app = app.layer(middleware::from_fn_with_state(
+        app_state.clone(),
+        record_prompt,
+    ));
+
     let app = if metrics_enabled {
         app.layer(middleware::from_fn(track_metrics))
     } else {
@@ -8946,6 +9003,9 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         memory,
         store_path,
         cache_path,
+        prompt_log: crate::promptlog::enabled_from_env()
+            .then(crate::promptlog::path)
+            .transpose()?,
         client: Client::new(),
     }));
 
@@ -11287,6 +11347,7 @@ mod tests {
             memory: 0,
             store_path,
             cache_path: std::env::temp_dir(),
+            prompt_log: None,
             client: Client::new(),
         }
     }
@@ -14803,5 +14864,133 @@ mod tests {
             ),
             "the body ended, so it was recorded exactly once:\n{rendered}"
         );
+    }
+
+    /// Only generation routes are logged, and the handler still gets the
+    /// whole body — an echo handler proves it without a model to load.
+    #[tokio::test]
+    async fn record_prompt_logs_generation_requests_and_hands_the_body_on() {
+        let log =
+            std::env::temp_dir().join(format!("llmman-record-prompt-{}.jsonl", std::process::id()));
+        let _ = std::fs::remove_file(&log);
+        let mut inner = test_inner(std::env::temp_dir());
+        inner.prompt_log = Some(log.clone());
+        let state = AppState(Arc::new(inner));
+
+        let echo = || post(|body: Bytes| async move { body });
+        let app = Router::new()
+            .route("/api/chat", echo())
+            .route("/api/embed", echo())
+            .route("/v1/chat/completions", echo())
+            .layer(middleware::from_fn_with_state(state.clone(), record_prompt))
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let send = |route: &str, body: &'static str, headers: &'static [(&str, &str)]| {
+            let url = format!("http://127.0.0.1:{}{route}", addr.port());
+            async move {
+                let mut map = reqwest::header::HeaderMap::new();
+                for (k, v) in [
+                    ("user-agent", "test-agent/1"),
+                    ("content-type", "application/json"),
+                ]
+                .iter()
+                .chain(headers)
+                {
+                    map.insert(*k, v.parse().unwrap());
+                }
+                Client::new()
+                    .post(url)
+                    .headers(map)
+                    .body(body)
+                    .send()
+                    .await
+                    .expect("request reaches the test router")
+                    .text()
+                    .await
+                    .unwrap()
+            }
+        };
+
+        let chat = r#"{"model":"m","messages":[{"role":"user","content":"hello there"}]}"#;
+        assert_eq!(
+            send("/api/chat", chat, &[]).await,
+            chat,
+            "the handler got the body"
+        );
+        // Not prompts: another route, a load/unload request, a browser's
+        // forged cross-site request, a method the route doesn't take.
+        send("/api/embed", r#"{"model":"m","input":"vector me"}"#, &[]).await;
+        send("/api/chat", r#"{"model":"m","messages":[]}"#, &[]).await;
+        send(
+            "/api/chat",
+            chat,
+            &[
+                ("content-type", "text/plain"),
+                ("origin", "https://evil.example"),
+            ],
+        )
+        .await;
+        Client::new()
+            .get(format!("http://127.0.0.1:{}/api/chat", addr.port()))
+            .body(chat)
+            .send()
+            .await
+            .expect("request reaches the test router");
+        // But the OpenAI routes serve that same request, so it is a prompt.
+        send(
+            "/v1/chat/completions",
+            chat,
+            &[
+                ("content-type", "text/plain"),
+                ("origin", "https://evil.example"),
+            ],
+        )
+        .await;
+
+        let entries = crate::promptlog::read(&log).unwrap();
+        let _ = std::fs::remove_file(&log);
+        let routes: Vec<&str> = entries.iter().map(|e| e.route.as_str()).collect();
+        assert_eq!(routes, ["/api/chat", "/v1/chat/completions"], "{entries:?}");
+        assert_eq!(entries[0].model, "m");
+        assert_eq!(entries[0].prompt, "hello there");
+        assert_eq!(entries[0].client.as_deref(), Some("test-agent/1"));
+    }
+
+    /// An over-limit body is refused as the extractor would refuse it.
+    /// The limit is lowered to 64 bytes rather than exceeding the 2 MB
+    /// default: a 413 sent while the client still has megabytes to send
+    /// is a client-side ConnectionAborted on Windows.
+    #[tokio::test]
+    async fn record_prompt_keeps_the_body_limit() {
+        let mut inner = test_inner(std::env::temp_dir());
+        inner.prompt_log = Some(std::env::temp_dir().join("llmman-unwritten.jsonl"));
+        let state = AppState(Arc::new(inner));
+        let app = Router::new()
+            .route("/api/chat", post(|body: Bytes| async move { body }))
+            .layer(middleware::from_fn_with_state(state.clone(), record_prompt))
+            .layer(DefaultBodyLimit::max(64))
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let send = |len: usize| {
+            let url = format!("http://127.0.0.1:{}/api/chat", addr.port());
+            async move {
+                Client::new()
+                    .post(url)
+                    .body(vec![b' '; len])
+                    .send()
+                    .await
+                    .expect("request reaches the test router")
+                    .status()
+            }
+        };
+        assert_eq!(send(256).await, StatusCode::PAYLOAD_TOO_LARGE);
+        // The control: under the limit, the body reaches the handler.
+        assert_eq!(send(32).await, StatusCode::OK);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod llama_release;
 pub mod metrics;
 pub mod modelpack;
 pub mod oauth;
+pub mod promptlog;
 pub mod providers;
 pub mod shortnames;
 pub mod sources;
@@ -100,6 +101,24 @@ fn parse_env_path(value: Option<&str>) -> Option<PathBuf> {
     (!trimmed.is_empty()).then(|| PathBuf::from(trimmed))
 }
 
+/// Whether an opt-out variable (`LLMMAN_NOPRUNE`, `LLMMAN_NOHISTORY`) is
+/// set: anything but unset, blank, or `0`/`false`/`no`/`off`.
+pub fn env_flag_set(name: &str) -> bool {
+    parse_env_flag(std::env::var(name).ok().as_deref())
+}
+
+fn parse_env_flag(value: Option<&str>) -> bool {
+    let Some(v) = value else { return false };
+    let v = v.trim();
+    if v.is_empty() {
+        return false;
+    }
+    !matches!(
+        v.to_ascii_lowercase().as_str(),
+        "0" | "false" | "no" | "off"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -138,5 +157,22 @@ mod tests {
         assert!(parse_debug_enabled(Some("2")));
         assert!(parse_debug_enabled(Some("-1")));
         assert!(!parse_debug_enabled(Some("not-a-number")));
+    }
+
+    #[test]
+    fn parse_env_flag_is_false_when_unset_blank_or_explicitly_falsy() {
+        assert!(!parse_env_flag(None));
+        assert!(!parse_env_flag(Some("")));
+        assert!(!parse_env_flag(Some("   ")));
+        for falsy in ["0", "false", "no", "off", "FALSE", "Off", "  no  "] {
+            assert!(!parse_env_flag(Some(falsy)), "{falsy:?} should be falsy");
+        }
+    }
+
+    #[test]
+    fn parse_env_flag_is_true_for_any_other_value() {
+        for truthy in ["1", "true", "yes", "on", "anything"] {
+            assert!(parse_env_flag(Some(truthy)), "{truthy:?} should be truthy");
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,8 @@ enum Commands {
     List(cmd::list::ListArgs),
     /// List models currently loaded by a running `llmman serve`
     Ps(cmd::ps::PsArgs),
+    /// Show the prompts `llmman serve` has seen, newest first (like `git log`)
+    Log(cmd::log::LogArgs),
     /// List the hosted providers `--provider` can route to
     Providers(cmd::providers::ProvidersArgs),
     /// Read and write llmman.conf settings
@@ -101,7 +103,7 @@ fn main() {
     // real E2E hang this fixes.
     daemon::disable_std_handle_inheritance();
 
-    let cli = Cli::parse();
+    let cli = Cli::parse_from(cmd::log::expand_count_shorthand(std::env::args_os()));
     let result = match &cli.command {
         Commands::Launch(a) => cmd::launch::run(a),
         Commands::Run(a) => cmd::run::run(a),
@@ -115,6 +117,7 @@ fn main() {
         Commands::Verify(a) => cmd::verify::run(a),
         Commands::List(a) => cmd::list::run(a),
         Commands::Ps(a) => cmd::ps::run(a),
+        Commands::Log(a) => cmd::log::run(a),
         Commands::Providers(a) => cmd::providers::run(a),
         Commands::Config(a) => cmd::config::run(a),
         Commands::Cp(a) => cmd::cp::run(a),

--- a/src/promptlog.rs
+++ b/src/promptlog.rs
@@ -1,0 +1,310 @@
+//! The prompt log: `llmman serve` appends one JSON line per generation
+//! request to `prompts.jsonl` beside the store; `llmman log` reads it.
+//!
+//! An entry is the prompt — the last user message's text — not the whole
+//! transcript an agent re-sends every turn, so the file grows with what
+//! was typed.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const FILE: &str = "prompts.jsonl";
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Entry {
+    /// 40 hex chars, git-commit width.
+    pub id: String,
+    /// RFC 3339, UTC.
+    pub time: String,
+    pub route: String,
+    pub model: String,
+    /// The request's `User-Agent`, when it sent one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client: Option<String>,
+    pub prompt: String,
+}
+
+/// `<store>/../prompts.jsonl`, honoring `LLMMAN_MODELS` like `serve.log`.
+pub fn path() -> anyhow::Result<PathBuf> {
+    let store = crate::default_store()?;
+    Ok(store.parent().unwrap_or(&store).join(FILE))
+}
+
+/// Off under `LLMMAN_NOHISTORY` (as ollama's `OLLAMA_NOHISTORY`).
+pub fn enabled_from_env() -> bool {
+    !crate::env_flag_set("LLMMAN_NOHISTORY")
+}
+
+pub fn is_generation_route(route: &str) -> bool {
+    matches!(
+        route,
+        "/api/chat"
+            | "/api/generate"
+            | "/v1/chat/completions"
+            | "/v1/completions"
+            | "/v1/responses"
+            | "/v1/messages"
+    )
+}
+
+/// `None` for a body with no prompt text: ollama's empty-`messages`
+/// load/unload requests, or non-JSON the handler will reject anyway.
+pub fn entry(route: &str, body: &[u8], client: Option<&str>, time: String) -> Option<Entry> {
+    let req: serde_json::Value = serde_json::from_slice(body).ok()?;
+    let prompt = prompt_of(&req);
+    if prompt.is_empty() {
+        return None;
+    }
+    // Nanoseconds too, so identical requests within the same displayed
+    // second still get distinct ids.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    let mut hasher = Sha256::new();
+    hasher.update(time.as_bytes());
+    hasher.update(nanos.to_le_bytes());
+    hasher.update(route.as_bytes());
+    hasher.update(body);
+    let id = hex::encode(hasher.finalize())[..40].to_string();
+    Some(Entry {
+        id,
+        time,
+        route: route.to_string(),
+        model: req["model"].as_str().unwrap_or("").to_string(),
+        client: client.map(str::to_string),
+        prompt,
+    })
+}
+
+/// The last user turn's text from `messages` (Ollama, OpenAI, Anthropic)
+/// or the Responses API's `input` list — never another role's, nor an
+/// older turn's when the last has no text; otherwise the bare
+/// `prompt`/`input`.
+fn prompt_of(req: &serde_json::Value) -> String {
+    if let Some(messages) = req["messages"]
+        .as_array()
+        .or_else(|| req["input"].as_array())
+    {
+        return messages
+            .iter()
+            .rev()
+            .find(|m| m["role"] == "user")
+            .map(|m| text_of(&m["content"]))
+            .unwrap_or_default();
+    }
+    let prompt = if req["prompt"].is_null() {
+        &req["input"]
+    } else {
+        &req["prompt"]
+    };
+    text_of(prompt)
+}
+
+/// A string as is; a content-part list as its parts' `text` (OpenAI,
+/// Anthropic, Responses all use that key) joined by newlines.
+fn text_of(content: &serde_json::Value) -> String {
+    match content {
+        serde_json::Value::String(s) => s.trim().to_string(),
+        serde_json::Value::Array(parts) => parts
+            .iter()
+            .filter_map(|p| p.as_str().or_else(|| p["text"].as_str()))
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => String::new(),
+    }
+}
+
+/// Appends one entry as one line, to a file only its owner can read. A
+/// tail left unterminated by a crash mid-write gets its newline first,
+/// so it costs only itself.
+pub fn append(path: &Path, entry: &Entry) -> std::io::Result<()> {
+    use std::io::{Read, Seek, SeekFrom};
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).append(true).read(true);
+    #[cfg(unix)]
+    std::os::unix::fs::OpenOptionsExt::mode(&mut options, 0o600);
+    let mut file = options.open(path)?;
+    let mut line = Vec::new();
+    if file.seek(SeekFrom::End(-1)).is_ok() {
+        let mut last = [0u8];
+        file.read_exact(&mut last)?;
+        if last != *b"\n" {
+            line.push(b'\n');
+        }
+    }
+    serde_json::to_writer(&mut line, entry)?;
+    line.push(b'\n');
+    file.write_all(&line)
+}
+
+/// Every entry, oldest first. A missing file is an empty log; a line
+/// that doesn't parse (a torn write, a hand edit) is skipped.
+pub fn read(path: &Path) -> std::io::Result<Vec<Entry>> {
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
+    };
+    Ok(bytes
+        .split(|b| *b == b'\n')
+        .filter_map(|line| serde_json::from_slice(line).ok())
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn prompt(body: &str) -> String {
+        prompt_of(&serde_json::from_str(body).unwrap())
+    }
+
+    #[test]
+    fn the_last_user_message_is_the_prompt() {
+        let body = r#"{"messages":[
+            {"role":"system","content":"be terse"},
+            {"role":"user","content":"first"},
+            {"role":"assistant","content":"ok"},
+            {"role":"user","content":"  second  "}]}"#;
+        assert_eq!(prompt(body), "second");
+    }
+
+    #[test]
+    fn a_trailing_tool_turn_does_not_hide_the_user_prompt() {
+        let body = r#"{"messages":[
+            {"role":"user","content":"list files"},
+            {"role":"assistant","content":"","tool_calls":[{}]},
+            {"role":"tool","content":"a.txt"}]}"#;
+        assert_eq!(prompt(body), "list files");
+    }
+
+    #[test]
+    fn without_text_in_the_last_user_turn_nothing_is_recorded() {
+        let body = r#"{"messages":[{"role":"system","content":"sys"},{"role":"assistant","content":"hi"}]}"#;
+        assert_eq!(prompt(body), "");
+        // An image-only turn must not re-record the previous prompt.
+        let body = r#"{"messages":[
+            {"role":"user","content":"older"},
+            {"role":"assistant","content":"hi"},
+            {"role":"user","content":[{"type":"image_url","image_url":{"url":"data:..."}}]}]}"#;
+        assert_eq!(prompt(body), "");
+    }
+
+    #[test]
+    fn content_parts_are_joined_and_images_skipped() {
+        let body = r#"{"messages":[{"role":"user","content":[
+            {"type":"text","text":"what is this"},
+            {"type":"image_url","image_url":{"url":"data:..."}},
+            {"type":"input_text","text":"in detail"}]}]}"#;
+        assert_eq!(prompt(body), "what is this\nin detail");
+    }
+
+    #[test]
+    fn generate_completions_and_responses_shapes_are_read() {
+        assert_eq!(prompt(r#"{"prompt":"why"}"#), "why");
+        assert_eq!(prompt(r#"{"prompt":["a","b"]}"#), "a\nb");
+        assert_eq!(prompt(r#"{"input":"resp"}"#), "resp");
+        assert_eq!(
+            prompt(
+                r#"{"input":[{"role":"user","content":[{"type":"input_text","text":"codex"}]}]}"#
+            ),
+            "codex"
+        );
+    }
+
+    #[test]
+    fn empty_and_non_json_bodies_make_no_entry() {
+        let t = || "2026-01-01T00:00:00Z".to_string();
+        assert!(entry("/api/chat", br#"{"model":"m","messages":[]}"#, None, t()).is_none());
+        assert!(entry("/api/generate", br#"{"model":"m","prompt":""}"#, None, t()).is_none());
+        assert!(entry("/api/chat", b"not json", None, t()).is_none());
+    }
+
+    #[test]
+    fn an_entry_carries_model_client_and_a_git_width_id() {
+        let body = br#"{"model":"qwen3:8b","messages":[{"role":"user","content":"hi"}]}"#;
+        let make = || {
+            entry(
+                "/v1/chat/completions",
+                body,
+                Some("claude-cli/1.0"),
+                "2026-01-01T00:00:00Z".to_string(),
+            )
+            .unwrap()
+        };
+        let e = make();
+        assert_eq!(e.model, "qwen3:8b");
+        assert_eq!(e.client.as_deref(), Some("claude-cli/1.0"));
+        assert_eq!(e.prompt, "hi");
+        assert_eq!(e.id.len(), 40);
+        assert!(e.id.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(e.id, make().id, "the same request twice is two entries");
+    }
+
+    #[test]
+    fn append_then_read_round_trips_and_skips_a_bad_line() {
+        let dir = std::env::temp_dir().join(format!("llmman-promptlog-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let path = dir.join("sub").join(FILE);
+        assert_eq!(read(&path).unwrap(), Vec::<Entry>::new());
+
+        let e = |i: u8| Entry {
+            id: format!("{i:040}"),
+            time: "2026-01-01T00:00:00Z".into(),
+            route: "/api/chat".into(),
+            model: "m".into(),
+            client: None,
+            prompt: format!("p{i}"),
+        };
+        append(&path, &e(1)).unwrap();
+        append(&path, &e(2)).unwrap();
+        // A write torn inside a multibyte character, with no newline.
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(b"{\"prompt\":\"\xC3")
+            .unwrap();
+        append(&path, &e(3)).unwrap();
+
+        assert_eq!(read(&path).unwrap(), vec![e(1), e(2), e(3)]);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "prompts are private to their owner");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn only_the_generation_routes_are_recorded() {
+        for r in [
+            "/api/chat",
+            "/api/generate",
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/responses",
+            "/v1/messages",
+        ] {
+            assert!(is_generation_route(r), "{r}");
+        }
+        for r in [
+            "/api/embed",
+            "/v1/embeddings",
+            "/api/pull",
+            "/v1/responses/input_tokens",
+        ] {
+            assert!(!is_generation_route(r), "{r}");
+        }
+    }
+}

--- a/src/storage/gc.rs
+++ b/src/storage/gc.rs
@@ -193,44 +193,12 @@ fn dir_size(dir: &Path) -> u64 {
 /// rather prune once at the end themselves. Read fresh at each call site,
 /// like every other `LLMMAN_*` var.
 pub fn noprune_from_env() -> bool {
-    parse_noprune(std::env::var("LLMMAN_NOPRUNE").ok().as_deref())
-}
-
-/// Split out from [`noprune_from_env`] for testing without touching the
-/// real environment. Unset, blank, or an explicit falsy value
-/// (`0`/`false`/`no`/`off`, case-insensitive) all mean "don't skip".
-fn parse_noprune(value: Option<&str>) -> bool {
-    let Some(v) = value else { return false };
-    let v = v.trim();
-    if v.is_empty() {
-        return false;
-    }
-    !matches!(
-        v.to_ascii_lowercase().as_str(),
-        "0" | "false" | "no" | "off"
-    )
+    crate::env_flag_set("LLMMAN_NOPRUNE")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn parse_noprune_is_false_when_unset_blank_or_explicitly_falsy() {
-        assert!(!parse_noprune(None));
-        assert!(!parse_noprune(Some("")));
-        assert!(!parse_noprune(Some("   ")));
-        for falsy in ["0", "false", "no", "off", "FALSE", "Off", "  no  "] {
-            assert!(!parse_noprune(Some(falsy)), "{falsy:?} should be falsy");
-        }
-    }
-
-    #[test]
-    fn parse_noprune_is_true_for_any_other_value() {
-        for truthy in ["1", "true", "yes", "on", "anything"] {
-            assert!(parse_noprune(Some(truthy)), "{truthy:?} should be truthy");
-        }
-    }
 
     fn temp_dir(name: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!(


### PR DESCRIPTION
`llmman log` — `git log` for the prompts `llmman serve` has been sent.

```
$ llmman log
prompt 1873766d2cf5fb89ddd6a2a22242ab47a52547a3
Model:  qwen3:8b
Client: claude-cli/1.2.3
Route:  /v1/chat/completions
Date:   Sun Sep 6 19:22:16 2026 +0100

    fix the failing test
    then commit

$ llmman log --oneline -3
1873766d2cf5 fix the failing test
4b55493c0b7b why is the sky blue
450036622897 first question
```

**Recording.** One router layer over the six generation routes appends a JSON line to `prompts.jsonl` beside the store: time, route, model, `User-Agent`, and the last user turn's text — never the transcript or a reply. Same `Bytes` extractor as the handlers, so the body limit is unchanged; `0600`; `LLMMAN_NOHISTORY` turns it off.

**Reading.** No daemon needed. `git log` layout and flags (`-n`/`-<N>`, `--skip`, `--since`/`--until`, `--grep`, `--model`, `-i`, `--oneline`, `--reverse`, `--no-pager`), paged via `$PAGER`/`less` with `LESS=FRX`. Control characters are stripped on output.

**Tests.** Extraction across the API shapes, torn-tail recovery, date parsing, `--reverse` selection, escape stripping; router tests that only POSTs to generation routes are logged (not 405s or forged cross-site requests), the body is forwarded intact, and the limit holds.
