### PR TITLE
Transfer diffusion models with their sidecars and text encoder

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -8558,8 +8558,15 @@ async fn mediagen_backend(model_ref: &str, port: u16, args: &ServeArgs) -> anyho
             .unwrap_or_else(|| std::thread::available_parallelism().map_or(4, |n| n.get() as i32)),
         flash_attn: flash_attention_from_env().as_deref() != Some("off"),
     };
-    let ctx =
-        tokio::task::spawn_blocking(move || crate::mediagen::Context::init(api, &params)).await??;
+    let ctx = tokio::task::spawn_blocking(move || crate::mediagen::Context::init(api, &params))
+        .await?
+        .with_context(|| {
+            format!(
+                "loading the model with the llama.cpp libraries in {} (an old build? \
+                 remove it from PATH or pass --llama-cpp-version to use a release)",
+                lib_dir.display()
+            )
+        })?;
     let router = crate::mediagen::server::router(
         ctx,
         model_ref.to_string(),

--- a/src/hf/api.rs
+++ b/src/hf/api.rs
@@ -317,6 +317,61 @@ fn is_diffusion_sidecar(name: &str) -> bool {
         .any(|k| name.contains(k))
 }
 
+/// Everything a diffusion transformer needs next to it.
+pub struct DiffusionPlan {
+    /// `(role, file)` from the same repo: `vae`, `audio_vae`, `text_proj`.
+    pub sidecars: Vec<(&'static str, HfFile)>,
+    /// The `image` / `video` / `audio` capabilities the sidecars enable.
+    pub outputs: Vec<&'static str>,
+    /// `owner/repo:quant` of the text encoder the family was trained with.
+    pub text_encoder: Option<&'static str>,
+}
+
+/// See llama.cpp's `common_download_get_hf_plan` for the same resolution.
+pub fn diffusion_plan(files: &[HfFile], model_path: &str) -> DiffusionPlan {
+    let pick = |k| select_diffusion_sidecar(files, model_path, k);
+    let candidates = [
+        (
+            "vae",
+            pick("video_vae")
+                .or_else(|| pick("_vae.").filter(|f| !f.path.to_lowercase().contains("audio_vae"))),
+        ),
+        ("audio_vae", pick("audio_vae")),
+        ("text_proj", pick("embeddings_connectors")),
+    ];
+    let mut plan = DiffusionPlan {
+        sidecars: Vec::new(),
+        outputs: Vec::new(),
+        text_encoder: diffusion_default_text_encoder(model_path),
+    };
+    for (role, file) in candidates {
+        let Some(file) = file else { continue };
+        match role {
+            "vae" => plan.outputs.extend(["image", "video"]),
+            "audio_vae" => plan.outputs.push("audio"),
+            _ => {}
+        }
+        plan.sidecars.push((role, file));
+    }
+    plan
+}
+
+/// Media type and annotations of a sidecar layer.
+pub fn sidecar_layer(mut d: oci::Descriptor, file: &HfFile, role: &str) -> oci::Descriptor {
+    d.media_type = safetensors_media_type(&file.path).to_string();
+    let name = file
+        .path
+        .rsplit('/')
+        .next()
+        .unwrap_or(&file.path)
+        .to_string();
+    d.annotations = Some(BTreeMap::from([
+        (oci::ANNOTATION_FILEPATH.to_string(), name),
+        (oci::ANNOTATION_ROLE.to_string(), role.to_string()),
+    ]));
+    d
+}
+
 /// The sidecar whose file name contains `keyword` and shares the longest
 /// prefix with the chosen transformer's file name — so the `distilled`
 /// VAE goes with the `distilled` transformer.

--- a/src/hf/pull.rs
+++ b/src/hf/pull.rs
@@ -94,57 +94,25 @@ pub async fn pull(reference: &str, layout_dir: &Path, progress_key: &str) -> Res
                 );
             }
             if diffusion {
-                // The transformer needs its VAE(s), text projection and
-                // the text encoder it was trained with — see llama.cpp's
-                // common_download_get_hf_plan for the same resolution.
-                let model_path = &shards[0].path;
-                let sidecars = [
-                    (
-                        "vae",
-                        api::select_diffusion_sidecar(&files, model_path, "video_vae").or_else(
-                            || {
-                                api::select_diffusion_sidecar(&files, model_path, "_vae.")
-                                    .filter(|f| !f.path.to_lowercase().contains("audio_vae"))
-                            },
-                        ),
-                    ),
-                    (
-                        "audio_vae",
-                        api::select_diffusion_sidecar(&files, model_path, "audio_vae"),
-                    ),
-                    (
-                        "text_proj",
-                        api::select_diffusion_sidecar(&files, model_path, "embeddings_connectors"),
-                    ),
-                ];
-                for (role, file) in sidecars {
-                    let Some(file) = file else { continue };
-                    let mut d = download_layer(
+                let plan = api::diffusion_plan(&files, &shards[0].path);
+                meta.diffusion_outputs = plan.outputs;
+                for (role, file) in &plan.sidecars {
+                    let d = download_layer(
                         &dl_client,
                         &head_client,
                         &endpoint,
                         &owner,
                         &repo,
                         &commit,
-                        &file,
+                        file,
                         token.as_deref(),
                         layout_dir,
                         progress_key,
                     )
                     .await?;
-                    d.media_type = api::safetensors_media_type(&file.path).to_string();
-                    d.annotations = Some(BTreeMap::from([
-                        (oci::ANNOTATION_FILEPATH.to_string(), basename(&file.path)),
-                        (oci::ANNOTATION_ROLE.to_string(), role.to_string()),
-                    ]));
-                    layers.push(d);
-                    match role {
-                        "vae" => meta.diffusion_outputs.extend(["image", "video"]),
-                        "audio_vae" => meta.diffusion_outputs.push("audio"),
-                        _ => {}
-                    }
+                    layers.push(api::sidecar_layer(d, file, role));
                 }
-                if let Some(te_ref) = api::diffusion_default_text_encoder(model_path) {
+                if let Some(te_ref) = plan.text_encoder {
                     let mut d = pull_text_encoder(
                         &api_client,
                         &dl_client,

--- a/src/hf/transfer.rs
+++ b/src/hf/transfer.rs
@@ -124,7 +124,16 @@ mod docker {
         .context("HF file list")?;
 
         let mut changed = false;
-        let (layers, filepath_annotation) = match api::select_gguf(&files, &tag) {
+        let diffusion = api::is_diffusion_repo(&files);
+        let selected = if diffusion {
+            api::select_diffusion_gguf(&files, &tag)
+        } else {
+            api::select_gguf(&files, &tag)
+        };
+        let (layers, filepath_annotation) = match selected {
+            Ok(shards) if diffusion && shards.len() != 1 => {
+                anyhow::bail!("{owner}/{repo}: split diffusion transformers are not supported");
+            }
             Ok(shards) => {
                 meta.format = "gguf".to_string();
                 let filepath_annotation = if shards.len() == 1 {
@@ -150,7 +159,40 @@ mod docker {
                         .await?,
                     );
                 }
-                if let Some(mmproj) = api::select_mmproj(&files) {
+                if diffusion {
+                    let plan = api::diffusion_plan(&files, &shards[0].path);
+                    meta.diffusion_outputs = plan.outputs;
+                    for (role, file) in &plan.sidecars {
+                        let d = transfer_layer(
+                            &dl_client,
+                            &head_client,
+                            &endpoint,
+                            &owner,
+                            &repo,
+                            &commit,
+                            file,
+                            token.as_deref(),
+                            &session,
+                            &mut changed,
+                        )
+                        .await?;
+                        layers.push(api::sidecar_layer(d, file, role));
+                    }
+                    if let Some(te_ref) = plan.text_encoder {
+                        let d = transfer_text_encoder(
+                            &api_client,
+                            &dl_client,
+                            &head_client,
+                            &host,
+                            te_ref,
+                            token.as_deref(),
+                            &session,
+                            &mut changed,
+                        )
+                        .await?;
+                        layers.push(d);
+                    }
+                } else if let Some(mmproj) = api::select_mmproj(&files) {
                     layers.push(
                         transfer_layer(
                             &dl_client,
@@ -237,6 +279,54 @@ mod docker {
 
     fn basename(path: &str) -> String {
         path.rsplit('/').next().unwrap_or(path).to_string()
+    }
+
+    /// The text encoder GGUF from its own repository, as a `text_encoder` layer.
+    #[allow(clippy::too_many_arguments)]
+    async fn transfer_text_encoder(
+        api_client: &reqwest::Client,
+        dl_client: &reqwest::Client,
+        head_client: &reqwest::Client,
+        host: &str,
+        reference: &str,
+        token: Option<&str>,
+        session: &crate::ffi::PushSession,
+        changed: &mut bool,
+    ) -> Result<Descriptor> {
+        let (_, owner, repo, tag) = api::parse_hf_ref(&format!("{host}/{reference}"))?;
+        let endpoint = super::super::hf_endpoint(host);
+        let info = api::fetch_model_info(api_client, &endpoint, &owner, &repo, token)
+            .await
+            .with_context(|| format!("HF model info for text encoder {reference}"))?;
+        let commit = info.commit().to_string();
+        let files = api::fetch_files(api_client, &endpoint, &owner, &repo, &commit, token)
+            .await
+            .with_context(|| format!("HF file list for text encoder {reference}"))?;
+        let shards = api::select_gguf(&files, &tag)?;
+        if shards.len() != 1 {
+            anyhow::bail!("text encoder {reference}: split GGUFs are not supported");
+        }
+        let mut d = transfer_layer(
+            dl_client,
+            head_client,
+            &endpoint,
+            &owner,
+            &repo,
+            &commit,
+            &shards[0],
+            token,
+            session,
+            changed,
+        )
+        .await?;
+        d.annotations = Some(std::collections::BTreeMap::from([
+            (
+                oci::ANNOTATION_FILEPATH.to_string(),
+                basename(&shards[0].path),
+            ),
+            (oci::ANNOTATION_ROLE.to_string(), "text_encoder".to_string()),
+        ]));
+        Ok(d)
     }
 
     /// Fetches one file and streams it directly into a registry push,


### PR DESCRIPTION
`llmman transfer unsloth/LTX-2.3-GGUF docker.io/ai/ltx-2.3:latest` used to push the transformer GGUF alone: no VAEs, no text encoder, no `image`/`video`/`audio` capabilities, so the published model could not run. The resolution `pull` already does is factored into `api::diffusion_plan` and the streaming transfer pushes the same layers, fetching the text encoder from its own repository.

Verified on a DGX Spark against a local registry: the pushed manifest carries all six layers with their roles; `llmman pull localhost:5000/ai/ltx-2.3` into a fresh store and `llmman run … "Draw a cat"` produce an image (CUDA).

Also: when the llama.cpp libraries found on `PATH` are too old for the media backend (the ABI self-check fails), the error now names the directory and the fix.

Needed before `llmman-publisher` can publish `ai/ltx-2.3`.
