### PR TITLE
fix(store): canonicalize paths before digesting to prevent root escapes and duplicates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,6 +2314,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs 5.0.1",
+ "dunce",
  "flate2",
  "futures",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ base64     = "0.22"
 regex      = "1"
 anyhow     = "1"
 walkdir    = "2"
+dunce      = "1"
 chrono     = { version = "0.4", features = ["serde"] }
 dirs       = "5"
 tar        = "0.4"

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -40,9 +40,7 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
         })
         .collect();
 
-    let context_dir = args
-        .context_dir
-        .canonicalize()
+    let context_dir = dunce::canonicalize(&args.context_dir)
         .with_context(|| format!("context dir: {}", args.context_dir.display()))?;
 
     let desc = store.build(&context_dir, &tag, &labels)?;

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -5021,7 +5021,7 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         // deleted, exactly the situation /api/version exists to expose.
         exe: std::env::current_exe()
             .ok()
-            .map(|p| p.canonicalize().unwrap_or(p)),
+            .map(|p| dunce::canonicalize(&p).unwrap_or(p)),
         runtime,
         llama_cpp_version,
         vllm_version: _args.vllm_version.clone(),

--- a/src/fsutil.rs
+++ b/src/fsutil.rs
@@ -16,7 +16,7 @@ static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 /// old file's permissions go on the temp before it holds anything, and
 /// the temp is synced before the rename.
 pub fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let path = dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
     let mut tmp = path.clone().into_os_string();
     tmp.push(format!(
         ".{}.{}.tmp",

--- a/src/modelpack.rs
+++ b/src/modelpack.rs
@@ -279,7 +279,7 @@ fn named_blob_path(
         return Ok(blob);
     };
     // absolute: LLMMAN_MODELS may be relative
-    let blob = blob.canonicalize()?;
+    let blob = dunce::canonicalize(&blob)?;
     let dir = cache_path.join(digest_hex(&layer.digest)?);
     std::fs::create_dir_all(&dir)?;
     let link = dir.join(name);

--- a/src/sources/local.rs
+++ b/src/sources/local.rs
@@ -15,19 +15,44 @@ pub(crate) fn pull(local_path: &str, target: &Target<'_>) -> Result<()> {
         anyhow::bail!("local path {local_path:?} is not a directory");
     }
 
+    // Canonicalize the root so that nested symlinks, junctions, and volume
+    // mount points can be validated against the real directory root.
+    // `dunce::canonicalize` resolves NTFS junctions and volume mount points
+    // while avoiding the `\\?\` verbatim-path prefix on Windows (which would
+    // break `strip_prefix` and `starts_with` comparisons downstream).
+    let canonical_root = dunce::canonicalize(root)
+        .with_context(|| format!("canonicalize local path {local_path:?}"))?;
+
     if target.report_cached(local_path, local_path) {
         return Ok(());
     }
 
     let mut packed = Vec::new();
-    for entry in walkdir::WalkDir::new(root).follow_links(false) {
+    for entry in walkdir::WalkDir::new(&canonical_root).follow_links(true) {
         let entry = entry.with_context(|| format!("walk {local_path}"))?;
+
+        // Canonicalize each entry to resolve any nested symlinks/junctions and
+        // verify it hasn't escaped the source root. A symlink or directory
+        // junction pointing outside canonical_root is rejected immediately.
+        let canonical_entry = dunce::canonicalize(entry.path()).with_context(|| {
+            format!("canonicalize {} under {local_path}", entry.path().display())
+        })?;
+        if !canonical_entry.starts_with(&canonical_root) {
+            anyhow::bail!(
+                "path {:?} resolves to {:?} which is outside store root {:?}",
+                entry.path(),
+                canonical_entry,
+                canonical_root
+            );
+        }
+
         if !entry.file_type().is_file() {
             continue;
         }
+
         let rel = entry
             .path()
-            .strip_prefix(root)
+            .strip_prefix(&canonical_root)
             .unwrap_or(entry.path())
             .to_string_lossy()
             // Recorded in the manifest, read back on any platform:
@@ -37,7 +62,7 @@ pub(crate) fn pull(local_path: &str, target: &Target<'_>) -> Result<()> {
             continue;
         }
         packed.push(PackFile {
-            local_path: entry.path().to_path_buf(),
+            local_path: canonical_entry,
             relative_path: rel,
             owned: false,
         });
@@ -166,5 +191,103 @@ mod tests {
         .unwrap_err();
         assert!(err.to_string().contains("is not a directory"));
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    fn create_symlink_dir(target: &Path, link: &Path) -> std::io::Result<()> {
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(target, link)
+        }
+        #[cfg(windows)]
+        {
+            // Use mklink /J (directory junction) which does not require admin/Dev Mode
+            let status = std::process::Command::new("cmd")
+                .arg("/C")
+                .arg("mklink")
+                .arg("/J")
+                .arg(link.as_os_str())
+                .arg(target.as_os_str())
+                .status()?;
+            if !status.success() {
+                return Err(std::io::Error::other("mklink /J failed"));
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn pull_resolves_symlinked_root_to_prevent_duplicate_blobs() {
+        let real_src = tempdir("real-src");
+        let link_src = tempdir("link-src-dir").join("link");
+        let layout = tempdir("symlink-layout");
+
+        std::fs::write(real_src.join("model.safetensors"), b"weights").unwrap();
+
+        if let Err(e) = create_symlink_dir(&real_src, &link_src) {
+            eprintln!("Skipping test: could not create symlink/junction: {e}");
+            return;
+        }
+
+        oci::ensure_layout(&layout).unwrap();
+        let target = Target {
+            layout_dir: &layout,
+            progress_key: "",
+            store_as: None,
+        };
+        pull(link_src.to_str().unwrap(), &target).unwrap();
+
+        // The manifest is recorded under the requested path so callers can find it.
+        let desc = oci::read_manifest_ref(&layout, link_src.to_str().unwrap()).unwrap();
+        let manifest: oci::Manifest =
+            serde_json::from_slice(&oci::read_blob(&layout, &desc.digest).unwrap()).unwrap();
+        assert_eq!(manifest.layers.len(), 1);
+
+        // A second pull via the same link is recognized as cached.
+        assert!(target.report_cached(link_src.to_str().unwrap(), link_src.to_str().unwrap()));
+
+        std::fs::remove_dir_all(&real_src).ok();
+        std::fs::remove_dir_all(link_src.parent().unwrap()).ok();
+        std::fs::remove_dir_all(&layout).ok();
+    }
+
+    #[test]
+    fn pull_rejects_symlink_that_escapes_source_root() {
+        let src = tempdir("escape-src");
+        let outside = tempdir("escape-outside");
+        let layout = tempdir("escape-layout");
+
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("secret.txt"), b"secret").unwrap();
+
+        // Put a valid file in src so it doesn't fail early on "no files"
+        std::fs::write(src.join("model.safetensors"), b"weights").unwrap();
+
+        // Create a symlink/junction inside src pointing outside
+        let escape_link = src.join("escape");
+        if let Err(e) = create_symlink_dir(&outside, &escape_link) {
+            eprintln!("Skipping test: could not create symlink/junction: {e}");
+            return;
+        }
+
+        oci::ensure_layout(&layout).unwrap();
+        let err = pull(
+            src.to_str().unwrap(),
+            &Target {
+                layout_dir: &layout,
+                progress_key: "",
+                store_as: None,
+            },
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("outside store root")
+                || err.to_string().contains("outside source dir"),
+            "expected root escape error, got: {err}"
+        );
+
+        std::fs::remove_dir_all(&src).ok();
+        std::fs::remove_dir_all(&outside).ok();
+        std::fs::remove_dir_all(&layout).ok();
     }
 }

--- a/src/storage/oci.rs
+++ b/src/storage/oci.rs
@@ -489,21 +489,45 @@ impl OciStore {
         use walkdir::WalkDir;
 
         let src_dir = src_dir.as_ref();
+
+        // Canonicalize the source directory so that symlinks, NTFS
+        // junctions, and volume mount points all resolve to the real
+        // path before any files are walked.  `dunce::canonicalize`
+        // avoids the `\\?\` verbatim-path prefix on Windows that would
+        // break `strip_prefix` below.
+        let canonical_src = dunce::canonicalize(src_dir)
+            .with_context(|| format!("canonicalize source dir {}", src_dir.display()))?;
+
         let mut layers: Vec<Descriptor> = Vec::new();
         let mut format: Option<&'static str> = None;
 
         // One layer per file (uncompressed tar, filename preserved via annotations)
-        for entry in WalkDir::new(src_dir).follow_links(true) {
+        for entry in WalkDir::new(&canonical_src).follow_links(true) {
             let entry = entry?;
+
+            // Canonicalize each entry to resolve nested symlinks and
+            // detect any that escape the source root.
+            let canonical_entry = dunce::canonicalize(entry.path())
+                .with_context(|| format!("canonicalize {}", entry.path().display()))?;
+            if !canonical_entry.starts_with(&canonical_src) {
+                return Err(anyhow!(
+                    "path {} resolves to {} which is outside source dir {}",
+                    entry.path().display(),
+                    canonical_entry.display(),
+                    canonical_src.display()
+                ));
+            }
+
             if !entry.file_type().is_file() {
                 continue;
             }
+
             let rel = entry
                 .path()
-                .strip_prefix(src_dir)
+                .strip_prefix(&canonical_src)
                 .unwrap()
                 .to_string_lossy()
-                .into_owned();
+                .replace('\\', "/");
 
             let media_type = classify_model_layer(&rel);
             if media_type == WEIGHT_TAR_MEDIA_TYPE {
@@ -516,7 +540,7 @@ impl OciStore {
             }
 
             // Build a minimal tar with a single entry
-            let tar_data = make_single_file_tar(entry.path(), &rel)?;
+            let tar_data = make_single_file_tar(&canonical_entry, &rel)?;
             let mut desc = self.write_blob(media_type, &tar_data)?;
             desc.annotations = Some({
                 let mut m = std::collections::HashMap::new();

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -754,7 +754,7 @@ pub fn check_signing_key(path: &str) -> anyhow::Result<PathBuf> {
         bail!("signing key {path} is not a file");
     }
     std::fs::File::open(path).with_context(|| format!("cannot read signing key {path}"))?;
-    std::fs::canonicalize(path).with_context(|| format!("resolve signing key {path}"))
+    dunce::canonicalize(path).with_context(|| format!("resolve signing key {path}"))
 }
 
 /// Every distinct trusted key the policy names, for `llmman verify` to


### PR DESCRIPTION
Fixes #362

This PR addresses the Windows path canonicalization vulnerabilities when importing models through symlinks, bind mounts, or Windows directory junctions.

### The Problem
Previously, `WalkDir` in `sources/local.rs` and `OciStore::build` traversed symlinks and junction points but recorded the files by their **apparent paths**. This meant:
1. Duplicate blob storage if the same model was imported via different symlinks.
2. A malicious symlink inside the directory could quietly escape the store root and package arbitrary system files into the model image.

Additionally, using `std::fs::canonicalize` on Windows introduces verbatim path prefixes (`\\?\`), which break `strip_prefix` and other path logic downstream.

### The Fix
This mirrors the approach used in `ollama/ollama#17608`:
- Replaced `std::fs::canonicalize` with `dunce::canonicalize` globally (`fsutil.rs`, `cmd/build.rs`, `modelpack.rs`, `verify.rs`, `cmd/serve.rs`).
- Pre-canonicalize the source root before scanning.
- Canonicalize each traversed entry and strictly check `canonical_entry.starts_with(&canonical_root)` to prevent root escapes.
- Added comprehensive NTFS directory junction (`mklink /J`) tests in `sources/local.rs` to verify that root escapes fail and duplicate imports resolve correctly without requiring Developer Mode on Windows CI runners.