### PR TITLE
Retry the metadata probes on HTTP 429

### DIFF
--- a/src/hf/api.rs
+++ b/src/hf/api.rs
@@ -22,15 +22,14 @@ pub struct HfFile {
     pub kind: String, // "file" or "directory"
 }
 
-/// Issues an authenticated GET and decodes JSON in a single attempt. This
-/// is a cheap metadata request, so a bad or nonexistent host must fail
-/// fast rather than run the retry backoff.
+/// Issues an authenticated GET and decodes JSON; see `client::probe` for
+/// the (lack of) retries.
 async fn get_json<T: serde::de::DeserializeOwned>(
     client: &reqwest::Client,
     url: &str,
     token: Option<&str>,
 ) -> Result<T> {
-    let body = super::client::once(&format!("GET {url}"), || async {
+    let body = super::client::probe(&format!("GET {url}"), || async {
         let mut req = client.get(url);
         if let Some(t) = token {
             req = req.bearer_auth(t);

--- a/src/hf/client.rs
+++ b/src/hf/client.rs
@@ -116,21 +116,35 @@ fn rand_unit() -> f64 {
     (nanos % 1_000_000) as f64 / 1_000_000.0
 }
 
-/// Runs `attempt` exactly once, with no retry loop or backoff. The cheap
-/// metadata requests (the model-info GET and the HEAD size/etag probes)
-/// use this so a bad or nonexistent host fails immediately rather than
-/// running a full backoff budget. The HF client attaches its bearer token
-/// up front (no 401 auth handshake to retry), and the per-request timeout
-/// reqwest already applies still bounds a slow-but-resolvable host. A 4xx
-/// surfaces as-is.
-pub async fn once<T, F, Fut>(label: &str, attempt: F) -> Result<T>
+/// Runs a cheap metadata request (the model-info GET, the HEAD size/etag
+/// probes): no backoff, so a bad or nonexistent host fails immediately,
+/// except on a 429, which is retried honoring `Retry-After` — a transfer
+/// of hundreds of shards issues hundreds of these and the rate limit is
+/// the one transient error they do hit.
+pub async fn probe<T, F, Fut>(label: &str, mut attempt: F) -> Result<T>
 where
-    F: FnOnce() -> Fut,
+    F: FnMut() -> Fut,
     Fut: std::future::Future<Output = Result<T>>,
 {
-    attempt().await.inspect_err(|e| {
-        eprintln!("[llmman] {label} error: {e:#}");
-    })
+    for i in 1..=MAX_ATTEMPTS {
+        match attempt().await {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                eprintln!("[llmman] {label} error: {e:#}");
+                let throttled = e
+                    .chain()
+                    .find_map(|e| e.downcast_ref::<HttpStatusError>())
+                    .is_some_and(|e| e.status == 429);
+                if !throttled || i == MAX_ATTEMPTS {
+                    return Err(e);
+                }
+                let delay = retry_after_of(&e).unwrap_or_else(|| retry_delay(i));
+                eprintln!("[llmman] {label}: rate limited, retrying in {delay:?}");
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+    unreachable!()
 }
 
 // ---------------------------------------------------------------------------
@@ -277,6 +291,36 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn probe_retries_only_a_429() {
+        let calls = std::cell::Cell::new(0);
+        let err = |status: u16| -> anyhow::Error {
+            HttpStatusError::new("GET x", status, &headers_with_retry_after("0")).into()
+        };
+        let ok: Result<u32> = probe("t", || {
+            calls.set(calls.get() + 1);
+            let n = calls.get();
+            async move {
+                if n < 3 {
+                    Err(err(429))
+                } else {
+                    Ok(n)
+                }
+            }
+        })
+        .await;
+        assert_eq!(ok.unwrap(), 3);
+
+        calls.set(0);
+        let res: Result<u32> = probe("t", || {
+            calls.set(calls.get() + 1);
+            async { Err(err(503)) }
+        })
+        .await;
+        assert!(res.is_err());
+        assert_eq!(calls.get(), 1, "a non-429 is not retried");
+    }
+
     #[test]
     fn is_permanent_sees_through_context_wrapping() {
         let err = anyhow::Error::new(HttpStatusError::new("GET x", 404, &HeaderMap::new()))
@@ -285,9 +329,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn once_runs_the_attempt_a_single_time_on_failure() {
+    async fn probe_runs_the_attempt_a_single_time_on_failure() {
         let attempts = AtomicU32::new(0);
-        let result: Result<()> = once("test", || {
+        let result: Result<()> = probe("test", || {
             attempts.fetch_add(1, Ordering::SeqCst);
             async { Err(anyhow!("boom")) }
         })

--- a/src/hf/pull.rs
+++ b/src/hf/pull.rs
@@ -340,11 +340,9 @@ async fn download_layer(
     let url = format!("{endpoint}{owner}/{repo}/resolve/{commit}/{}", file.path);
     let label = format!("Pulling {}", basename(&file.path));
 
-    // Single attempt: this is a cheap metadata probe, so a bad or
-    // nonexistent host must fail fast rather than run the retry backoff.
-    // Failure is tolerated anyway (falls back to a plain, un-Xet'd GET
+    // Failure is tolerated (falls back to a plain, un-Xet'd GET
     // self-hashed after download).
-    let meta = super::client::once(&format!("HEAD {}", file.path), || {
+    let meta = super::client::probe(&format!("HEAD {}", file.path), || {
         download::head_metadata(head_client, url.clone(), token)
     })
     .await

--- a/src/hf/transfer.rs
+++ b/src/hf/transfer.rs
@@ -347,9 +347,7 @@ mod docker {
         let url = format!("{endpoint}{owner}/{repo}/resolve/{commit}/{}", file.path);
         let label = format!("Transferring {}", basename(&file.path));
 
-        // Single attempt: this is a cheap metadata probe, so a bad or
-        // nonexistent host must fail fast rather than run the retry backoff.
-        let meta = super::super::client::once(&format!("HEAD {}", file.path), || {
+        let meta = super::super::client::probe(&format!("HEAD {}", file.path), || {
             download::head_metadata(head_client, url.clone(), token)
         })
         .await
@@ -536,9 +534,9 @@ mod docker {
     /// times, honoring `Retry-After`/exponential backoff between tries.
     /// It is its own loop rather than a shared helper because `attempt`
     /// needs the attempt number to seed the backoff (see
-    /// `download::should_retry`); the metadata path's `client::once` runs
-    /// a single attempt and the blob-download loop lives in `download.rs`,
-    /// so there is no shared retry helper to call here.
+    /// `download::should_retry`); the metadata path's `client::probe`
+    /// retries only a 429 and the blob-download loop lives in
+    /// `download.rs`, so there is no shared retry helper to call here.
     async fn retry_push<F, Fut>(label: &str, mut attempt: F) -> Result<bool>
     where
         F: FnMut(u32) -> Fut,


### PR DESCRIPTION
The per-file `HEAD` probe and the model-info `GET` were single-attempt so an unreachable host fails fast. Transfers of split models issue hundreds of them and HuggingFace answers some with 429, which has been failing llmman-publisher's hourly runs (`resolve file metadata: HEAD …: HTTP 429`, ~20 times over the last two days). Retry a 429 only, honoring `Retry-After`, the way the downloads already do; other errors still fail immediately.