### PR TITLE
feat(serve): run safetensors models in a vLLM container with --ociman

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -8,6 +8,7 @@ already exists for the model format it finds, and runs it unmodified.
 | GGUF | [`llama-server`](https://github.com/ggml-org/llama.cpp) | Your `PATH` if it is there; otherwise a prebuilt upstream release matching your OS/arch/GPU, downloaded and cached on first use |
 | GGUF | `llama-server` in a container | `--ociman docker` / `--ociman podman` (Linux only): the `ghcr.io/ggml-org/llama.cpp:server-<backend>` image for your GPU |
 | safetensors | [`vllm`](https://github.com/vllm-project/vllm) | Your `PATH` |
+| safetensors | `vllm` in a container | `--ociman docker` / `--ociman podman` (Linux only): the `vllm/vllm-openai`, `rocm/vllm` or `vllm/vllm-openai-cpu` image for your GPU and architecture |
 | safetensors | [`mlx_lm.server`](https://github.com/ml-explore/mlx-lm) | Your `PATH`, on Apple Silicon macOS; preferred over `vllm` when present |
 
 ## llama.cpp
@@ -42,6 +43,26 @@ Safetensors models are served by a separately installed `vllm`. Plain
 [vllm-metal](https://github.com/vllm-project/vllm-metal) is installed.
 `LLMMAN_CONTEXT_LENGTH` is forwarded as `--max-model-len`;
 `LLMMAN_LOAD_TIMEOUT` (default 10 minutes) bounds a stalled load.
+
+### In a container
+
+On Linux, `--ociman docker` (or `podman`) runs `vllm serve` from a vLLM
+image for a safetensors model, picked by the same GPU probe plus the
+host architecture:
+
+| Host GPU | x86_64 | aarch64 |
+|----------|--------|---------|
+| NVIDIA (CUDA 13) | `vllm/vllm-openai:latest-x86_64` | `vllm/vllm-openai:latest-aarch64` |
+| NVIDIA (CUDA 12) | `vllm/vllm-openai:latest-x86_64-cu129` | `vllm/vllm-openai:latest-aarch64-cu129` |
+| AMD (ROCm) | `rocm/vllm:latest` | not published upstream (`LLMMAN_LLM_LIBRARY=cpu` for the CPU image) |
+| Vulkan-only or none | `vllm/vllm-openai-cpu:latest-x86_64` | `vllm/vllm-openai-cpu:latest-arm64` |
+
+`--vllm-version <tag>` pins the release (the arch suffix is added for the
+`vllm/` images; for `rocm/vllm` it is the whole tag).
+`llmman serve --ociman docker --pull-oci <model>` pulls the image an
+already-pulled model needs (without a model, the llama.cpp image).
+`CUDA_VISIBLE_DEVICES` and friends plus every `VLLM_*` variable are
+forwarded into the container.
 
 ### `vllm serve` from llmman's store
 

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -90,11 +90,13 @@ pub struct ServeArgs {
     #[arg(value_name = "MODEL")]
     pub model: Option<String>,
 
-    /// Run llama-server in a container (docker or podman) instead of as a
-    /// local process — Linux only. Auto-selects the matching
-    /// ghcr.io/ggml-org/llama.cpp:server-<backend> image for whatever GPU
-    /// acceleration the host has (see crate::container); no local
-    /// llama-server binary is required on PATH when this is set.
+    /// Run the inference engine in a container (docker or podman) instead
+    /// of as a local process — Linux only. GGUF: llama-server from the
+    /// ghcr.io/ggml-org/llama.cpp:server-<backend> image; safetensors:
+    /// `vllm serve` from the vllm/vllm-openai (NVIDIA), rocm/vllm (AMD) or
+    /// vllm/vllm-openai-cpu image for the host's architecture. Both use
+    /// the same GPU probe (see crate::container); neither binary is
+    /// required on PATH.
     #[arg(long, value_name = "docker|podman")]
     pub ociman: Option<crate::container::ContainerManager>,
 
@@ -112,12 +114,23 @@ pub struct ServeArgs {
     #[arg(long, value_name = "TAG")]
     pub llama_cpp_version: Option<String>,
 
-    /// Proactively pull the ghcr.io/ggml-org/llama.cpp image `--ociman`
-    /// would run, as its own explicit foreground step, then exit — this
-    /// process does not go on to bind the listener or serve — with the
-    /// pull's own progress (a real `docker pull`/`podman pull` progress
-    /// bar) inherited directly to this process's stdout/stderr — only
-    /// meaningful together with --ociman, ignored otherwise.
+    /// With --ociman, pin the vLLM image tag for safetensors models (e.g.
+    /// `v0.28.0`) instead of the floating `latest`. The architecture
+    /// suffix (`-x86_64`/`-aarch64`, `-arm64` for the CPU image) is added
+    /// automatically for the vllm/ images — pick a release that image
+    /// actually publishes; for rocm/vllm the value is the whole tag.
+    #[arg(long, value_name = "TAG", requires = "ociman")]
+    pub vllm_version: Option<String>,
+
+    /// Proactively pull the image `--ociman` would run, as its own
+    /// explicit foreground step, then exit — this process does not go on
+    /// to bind the listener or serve — with the pull's own progress (a
+    /// real `docker pull`/`podman pull` progress bar) inherited directly
+    /// to this process's stdout/stderr — only meaningful together with
+    /// --ociman, ignored otherwise. Given a safetensors MODEL, this is the
+    /// vLLM image (see --vllm-version); given a GGUF MODEL or none, the
+    /// ghcr.io/ggml-org/llama.cpp one (see --llama-cpp-version). MODEL
+    /// must already be pulled.
     ///
     /// `--ociman`'s underlying `docker run`/`podman run` pulls an image
     /// that isn't already cached on its own, but silently: `serve` is
@@ -207,6 +220,8 @@ struct Inner {
     exe: Option<PathBuf>,
     ociman: Option<crate::container::ContainerManager>,
     llama_cpp_version: Option<String>,
+    // --vllm-version; only meaningful with --ociman.
+    vllm_version: Option<String>,
     // See context_length_from_env's doc comment — forwarded to
     // backends that expose a context-size flag.
     ctx_size: Option<u32>,
@@ -318,11 +333,9 @@ struct RunningModel {
 impl RunningModel {
     fn processor(&self) -> String {
         match &self.process {
-            ModelProcess::Local(Engine::LlamaServer, _, _) => "llama-server (local)".into(),
-            ModelProcess::Local(Engine::Vllm, _, _) => "vllm (local)".into(),
-            ModelProcess::Local(Engine::Mlx, _, _) => "mlx (local)".into(),
-            ModelProcess::Container(ociman, _) => {
-                format!("llama-server (container/{})", ociman.binary())
+            ModelProcess::Local(engine, _, _) => format!("{} (local)", engine.label()),
+            ModelProcess::Container(ociman, engine, _) => {
+                format!("{} (container/{})", engine.label(), ociman.binary())
             }
         }
     }
@@ -330,7 +343,7 @@ impl RunningModel {
     fn pid(&self) -> Option<u32> {
         match &self.process {
             ModelProcess::Local(_, child, _) => child.id(),
-            ModelProcess::Container(_, child) => child.id(),
+            ModelProcess::Container(_, _, child) => child.id(),
         }
     }
 
@@ -338,18 +351,18 @@ impl RunningModel {
     /// [`RunningModel::processor`]: that is prose for `/api/ps`, and its
     /// container form carries the runtime binary, which would put
     /// `docker` and `podman` in a label for the same engine. A container
-    /// runs llama-server (see `container::spawn`), so it reports as one.
+    /// reports as whichever engine it runs (llama-server via
+    /// `container::spawn`, vllm via `container::spawn_vllm`).
     fn engine_label(&self) -> &'static str {
         match &self.process {
-            ModelProcess::Local(Engine::LlamaServer, _, _) => "llama-server",
-            ModelProcess::Local(Engine::Vllm, _, _) => "vllm",
-            ModelProcess::Local(Engine::Mlx, _, _) => "mlx",
-            ModelProcess::Container(_, _) => "llama-server",
+            ModelProcess::Local(engine, _, _) | ModelProcess::Container(_, engine, _) => {
+                engine.label()
+            }
         }
     }
 }
 
-/// Which local engine a [`ModelProcess::Local`] is running — see
+/// Which engine a [`ModelProcess`] is running — see
 /// [`RunningModel::processor`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Engine {
@@ -365,12 +378,24 @@ enum Engine {
     Mlx,
 }
 
+impl Engine {
+    /// The engine's name as `llmman ps` and the `llmman_model_up`
+    /// metric's `engine` label spell it.
+    fn label(self) -> &'static str {
+        match self {
+            Engine::LlamaServer => "llama-server",
+            Engine::Vllm => "vllm",
+            Engine::Mlx => "mlx",
+        }
+    }
+}
+
 /// A running inference backend: either a local `llama-server`/`vllm`/
 /// `mlx_lm.server` process (killed via `Child::kill_on_drop`, except
 /// `Engine::Vllm` — see this Drop impl) or an attached `docker run`/
-/// `podman run` process, gracefully stopped via SIGTERM on drop since
-/// `kill_on_drop`'s SIGKILL can't be forwarded to (and so doesn't stop)
-/// the container.
+/// `podman run` process running `Engine::LlamaServer` or `Engine::Vllm`,
+/// gracefully stopped via SIGTERM on drop since `kill_on_drop`'s SIGKILL
+/// can't be forwarded to (and so doesn't stop) the container.
 enum ModelProcess {
     // `Option<u32>` is the pid captured right after spawn, not
     // `child.id()` at drop time: `is_alive`'s `try_wait` reaps the child
@@ -384,13 +409,19 @@ enum ModelProcess {
         tokio::process::Child,
         #[cfg_attr(not(unix), allow(dead_code))] Option<u32>,
     ),
-    Container(crate::container::ContainerManager, tokio::process::Child),
+    Container(
+        crate::container::ContainerManager,
+        Engine,
+        tokio::process::Child,
+    ),
 }
 
 impl Drop for ModelProcess {
     fn drop(&mut self) {
         match self {
-            ModelProcess::Container(_, child) => {
+            // Either engine: `--init` forwards the SIGTERM, and a vllm
+            // worker tree dies with its container.
+            ModelProcess::Container(_, _, child) => {
                 if let Some(pid) = child.id() {
                     crate::container::stop(pid);
                 }
@@ -446,7 +477,7 @@ impl ModelProcess {
     fn is_alive(&mut self) -> bool {
         let child = match self {
             ModelProcess::Local(_, child, _) => child,
-            ModelProcess::Container(_, child) => child,
+            ModelProcess::Container(_, _, child) => child,
         };
         matches!(child.try_wait(), Ok(None))
     }
@@ -460,7 +491,7 @@ impl ModelProcess {
     /// safety net — see that loop's own comment).
     async fn stop_and_wait(&mut self) {
         match self {
-            ModelProcess::Container(_, child) => {
+            ModelProcess::Container(_, _, child) => {
                 if let Some(pid) = child.id() {
                     crate::container::stop(pid);
                 }
@@ -478,7 +509,7 @@ impl ModelProcess {
         // beyond confirming the process is actually gone.
         let child = match self {
             ModelProcess::Local(_, child, _) => child,
-            ModelProcess::Container(_, child) => child,
+            ModelProcess::Container(_, _, child) => child,
         };
         let _ = child.kill().await;
     }
@@ -1927,9 +1958,12 @@ fn vllm_max_model_len(ctx_size: Option<u32>, ctx_size_explicit: bool) -> Option<
     ctx_size.filter(|n| ctx_size_explicit && *n > 0)
 }
 
-/// argv after the `vllm` binary, kept separate so context forwarding is testable.
+/// argv after the `vllm` binary, shared with `container::spawn_vllm`
+/// (which passes its `/models` mount and `0.0.0.0`) and kept separate so
+/// context forwarding is testable.
 fn vllm_serve_args(
     model_dir: &str,
+    host: &str,
     port: u16,
     model_name: &str,
     max_model_len: Option<u32>,
@@ -1940,7 +1974,7 @@ fn vllm_serve_args(
         "--port".into(),
         port.to_string(),
         "--host".into(),
-        "127.0.0.1".into(),
+        host.into(),
         // Register the model under the same name used in API requests so
         // {"model": "<ref>"} is accepted by vllm's OpenAI-compatible API.
         "--served-model-name".into(),
@@ -1963,6 +1997,7 @@ async fn spawn_vllm_server(
     let mut cmd = tokio::process::Command::new(&vllm);
     cmd.args(vllm_serve_args(
         model_dir.to_str().context("non-UTF-8 model path")?,
+        "127.0.0.1",
         port,
         model_name,
         max_model_len,
@@ -2068,8 +2103,9 @@ const POLL_INTERVAL: Duration = Duration::from_millis(500);
 
 /// Polls `process`'s `/health` endpoint until ready, bailing out early
 /// if `process` itself exits first (so a crash-on-startup doesn't hang
-/// the caller for the whole deadline). `stderr_tail`, when given
-/// (llama-server only), includes the crash reason in the error.
+/// the caller for the whole deadline). `stderr_tail`, when given (every
+/// piped child — see `ensure_model`), includes the crash reason in the
+/// error.
 async fn wait_for_ready(
     client: &Client,
     port: u16,
@@ -3674,9 +3710,12 @@ async fn ensure_model(
             // full precedence chain this `.or` implements.
             threads: request_threads.or(state.0.threads),
         };
-        // Only llama-server children (local or containerized) capture a
-        // stderr tail — every OOM retry below only fires for those.
+        // Every piped child gets an output tail for crash reasons; only
+        // llama-server ones join the OOM retry loop below, whose
+        // fallbacks are llama-server flags.
         let mut stderr_tail: Option<OutputTail> = None;
+        let mut oom_retryable = false;
+        let max_model_len = vllm_max_model_len(ctx_size, state.0.ctx_size_explicit);
         process = match (&model_path, state.0.ociman) {
             // container::spawn ignores llama_opts.threads; see that
             // field's doc comment.
@@ -3689,13 +3728,15 @@ async fn ensure_model(
                     llama_opts,
                 )?;
                 stderr_tail = Some(tail_child_output(&mut child));
-                ModelProcess::Container(ociman, child)
+                oom_retryable = true;
+                ModelProcess::Container(ociman, Engine::LlamaServer, child)
             }
             (ModelPath::Gguf(path, mmproj), None) => {
                 let bin = local_llama_server_bin(state).await?;
                 let (child, tail) =
                     spawn_llama_server(&bin, path, mmproj.as_deref(), llama_opts).await?;
                 stderr_tail = Some(tail);
+                oom_retryable = true;
                 ModelProcess::Local(Engine::LlamaServer, child, None)
             }
             // diffusion models run in this binary (see mediagen_backend)
@@ -3709,20 +3750,36 @@ async fn ensure_model(
                     port,
                 )?;
                 stderr_tail = Some(tail_child_output(&mut child));
-                ModelProcess::Container(ociman, child)
+                oom_retryable = true;
+                ModelProcess::Container(ociman, Engine::LlamaServer, child)
             }
             (ModelPath::Diffusion(_), None) => {
                 let (child, tail) = spawn_mediagen_backend(model_ref, port, state).await?;
                 stderr_tail = Some(tail);
+                oom_retryable = true;
                 ModelProcess::Local(Engine::LlamaServer, child, None)
             }
-            (ModelPath::SafeTensors(_dir), _) if use_mlx_for_safetensors() => {
+            // --ociman is Linux-only and mlx Metal-only, so this never
+            // competes with the mlx arm.
+            (ModelPath::SafeTensors(dir), Some(ociman)) => {
+                let mut child = crate::container::spawn_vllm(
+                    ociman,
+                    dir,
+                    state.0.vllm_version.as_deref(),
+                    port,
+                    |model_dir, host| {
+                        vllm_serve_args(model_dir, host, port, model_ref, max_model_len)
+                    },
+                )?;
+                stderr_tail = Some(tail_child_output(&mut child));
+                ModelProcess::Container(ociman, Engine::Vllm, child)
+            }
+            (ModelPath::SafeTensors(_dir), None) if use_mlx_for_safetensors() => {
                 let child = spawn_mlx_server(port).await?;
                 let pid = child.id();
                 ModelProcess::Local(Engine::Mlx, child, pid)
             }
-            (ModelPath::SafeTensors(dir), _) => {
-                let max_model_len = vllm_max_model_len(ctx_size, state.0.ctx_size_explicit);
+            (ModelPath::SafeTensors(dir), None) => {
                 let child = spawn_vllm_server(dir, port, model_ref, max_model_len).await?;
                 let pid = child.id();
                 ModelProcess::Local(Engine::Vllm, child, pid)
@@ -3732,8 +3789,7 @@ async fn ensure_model(
         match wait_for_ready(&state.0.client, port, &mut process, stderr_tail.as_ref()).await {
             Ok(()) => break,
             Err(e) => {
-                let looks_oom = stderr_tail.is_some() // llama-server only
-                    && looks_like_oom(&e.to_string());
+                let looks_oom = oom_retryable && looks_like_oom(&e.to_string());
                 if !looks_oom {
                     return Err(e.into());
                 }
@@ -8737,6 +8793,32 @@ fn metrics_router(enabled: bool) -> Router<AppState> {
         .layer(middleware::from_fn(track_metrics))
 }
 
+/// Which image `--pull-oci` warms up: the one `ensure_model` would run
+/// for `model` (read off its stored manifest), or llama-server's when no
+/// model is named — pulling both would cost a GGUF-only host the vLLM
+/// image's several GB for nothing.
+fn pull_oci_engine(model: Option<&str>) -> anyhow::Result<crate::container::ContainerEngine> {
+    // Same guard as the pre-load below: a pair warms its local half, a
+    // provider-routed reference has no local weights.
+    let model = model
+        .map(crate::hybrid::local_half)
+        .filter(|m| !crate::providers::is_remote_ref(m));
+    let Some(model) = model else {
+        return Ok(crate::container::ContainerEngine::LlamaServer);
+    };
+    let model_ref = crate::shortnames::resolve_ollama_api(model)?;
+    let store_path = default_store()?;
+    let format = crate::modelpack::stored_format(&store_path, &model_ref).with_context(|| {
+        format!("--pull-oci: pull {model_ref} first to learn which image it needs")
+    })?;
+    Ok(match format {
+        crate::modelpack::ModelFormat::SafeTensors => crate::container::ContainerEngine::Vllm,
+        crate::modelpack::ModelFormat::Gguf | crate::modelpack::ModelFormat::Diffusion => {
+            crate::container::ContainerEngine::LlamaServer
+        }
+    })
+}
+
 async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
     if _args.ociman.is_some() && !cfg!(target_os = "linux") {
         anyhow::bail!("--ociman is only supported on Linux");
@@ -8751,7 +8833,12 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
     // listener and serving forever.
     if _args.pull_oci {
         let ociman = _args.ociman.context("--pull-oci requires --ociman")?;
-        crate::container::pull_image(ociman, _args.llama_cpp_version.as_deref())?;
+        let engine = pull_oci_engine(_args.model.as_deref())?;
+        let version = match engine {
+            crate::container::ContainerEngine::Vllm => _args.vllm_version.as_deref(),
+            crate::container::ContainerEngine::LlamaServer => _args.llama_cpp_version.as_deref(),
+        };
+        crate::container::pull_image(ociman, engine, version)?;
         return Ok(());
     }
     // Same idea as --pull-oci above, but for the local (non-container)
@@ -8870,6 +8957,7 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
             .map(|p| p.canonicalize().unwrap_or(p)),
         ociman: _args.ociman,
         llama_cpp_version: _args.llama_cpp_version.clone(),
+        vllm_version: _args.vllm_version.clone(),
         ctx_size,
         ctx_size_explicit: ctx_size_explicit.is_some(),
         hybrid_local_bytes: crate::hybrid::local_budget_bytes_from_env(ctx_size),
@@ -11210,6 +11298,7 @@ mod tests {
             exe: None,
             ociman: None,
             llama_cpp_version: None,
+            vllm_version: None,
             ctx_size: None,
             ctx_size_explicit: false,
             hybrid_local_bytes: None,
@@ -12705,7 +12794,13 @@ mod tests {
             (Some(4096), Some("4096")),
             (None, None),
         ] {
-            let args = vllm_serve_args("/models/qwen", 8000, "qwen3.5:0.8b", max_model_len);
+            let args = vllm_serve_args(
+                "/models/qwen",
+                "127.0.0.1",
+                8000,
+                "qwen3.5:0.8b",
+                max_model_len,
+            );
             let pos = args.iter().position(|arg| arg == "--max-model-len");
 
             match expected {
@@ -12716,6 +12811,27 @@ mod tests {
                 None => assert!(pos.is_none()),
             }
         }
+    }
+
+    /// Local and container `vllm serve` argv differ only in dir and host.
+    #[test]
+    fn vllm_serve_args_differ_between_local_and_container_only_in_dir_and_host() {
+        let local = vllm_serve_args("/cache/abc/model", "127.0.0.1", 8000, "m", Some(4096));
+        let container = vllm_serve_args("/models", "0.0.0.0", 8000, "m", Some(4096));
+        assert_eq!(local[0], "serve");
+        assert_eq!(local[1], "/cache/abc/model");
+        assert_eq!(container[1], "/models");
+        let host = |args: &[String]| {
+            let i = args.iter().position(|a| a == "--host").unwrap();
+            args[i + 1].clone()
+        };
+        assert_eq!(host(&local), "127.0.0.1");
+        assert_eq!(host(&container), "0.0.0.0");
+        let rest = |args: &[String]| {
+            let i = args.iter().position(|a| a == "--host").unwrap();
+            [&args[2..i], &args[i + 2..]].concat()
+        };
+        assert_eq!(rest(&local), rest(&container));
     }
 
     /// `/api/embed` takes a string or an array of strings, and nothing
@@ -14238,7 +14354,7 @@ mod tests {
             let mut dead =
                 running_model_fixture(Some(Duration::from_secs(1)), Duration::from_secs(10), 0);
             match &mut dead.process {
-                ModelProcess::Local(_, child, _) | ModelProcess::Container(_, child) => {
+                ModelProcess::Local(_, child, _) | ModelProcess::Container(_, _, child) => {
                     child.kill().await.expect("kill the placeholder process")
                 }
             }

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,10 +1,13 @@
-//! Runs `llama-server` inside a container (Linux only, via `--ociman
-//! docker|podman`) instead of as a local process, auto-selecting the
-//! matching `ghcr.io/ggml-org/llama.cpp:server-<backend>` image for
-//! whatever GPU acceleration the host actually has — see
+//! Runs `llama-server` (or, for a safetensors model, `vllm serve`) inside
+//! a container (Linux only, via `--ociman docker|podman`) instead of as a
+//! local process, auto-selecting the matching
+//! `ghcr.io/ggml-org/llama.cpp:server-<backend>` image for whatever GPU
+//! acceleration the host actually has — see
 //! <https://github.com/ggml-org/llama.cpp/blob/master/docs/docker.md> for
 //! the full image list and their `docker run` flags, which
-//! [`GpuBackend::engine_args`] mirrors for the subset detected here.
+//! [`GpuBackend::engine_args`] mirrors for the subset detected here. The
+//! same host probe picks the vLLM image (`vllm/vllm-openai`, `rocm/vllm`
+//! or `vllm/vllm-openai-cpu`, per architecture) — see [`VllmBackend`].
 //!
 //! This is the same problem ggml's own dynamic backend loading
 //! (`GGML_BACKEND_DL=ON`, `ggml_backend_load_all` in
@@ -157,6 +160,129 @@ fn backend_from_hostgpu(gpu: HostGpu) -> GpuBackend {
     }
 }
 
+/// The architectures vLLM publishes images for. Its Docker Hub tags spell
+/// the architecture out (unlike llama.cpp's multi-arch manifests), so the
+/// host architecture is part of the image choice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HostArch {
+    X86_64,
+    Aarch64,
+}
+
+impl HostArch {
+    /// From `std::env::consts::ARCH`; `None` for anything without an image.
+    fn parse(arch: &str) -> Option<HostArch> {
+        match arch {
+            "x86_64" => Some(HostArch::X86_64),
+            "aarch64" => Some(HostArch::Aarch64),
+            _ => None,
+        }
+    }
+
+    fn detect() -> Result<HostArch> {
+        HostArch::parse(std::env::consts::ARCH).with_context(|| {
+            format!(
+                "vLLM publishes no container image for {} hosts (only x86_64 and aarch64)",
+                std::env::consts::ARCH
+            )
+        })
+    }
+}
+
+/// The vLLM image family for a host — derived from [`GpuBackend`] so both
+/// engines share the one [`crate::hostgpu::detect`] probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VllmBackend {
+    /// `vllm/vllm-openai`'s `-cu129` tags, for a CUDA 12 driver.
+    Cuda12,
+    /// `vllm/vllm-openai`'s default (CUDA 13) tags.
+    Cuda13,
+    /// `rocm/vllm`: amd64 only upstream.
+    Rocm,
+    /// `vllm/vllm-openai-cpu`: also what a Vulkan-only host gets, since
+    /// vLLM has no Vulkan backend.
+    Cpu,
+}
+
+impl VllmBackend {
+    fn from_gpu(backend: GpuBackend) -> VllmBackend {
+        match backend {
+            GpuBackend::Cuda12 => VllmBackend::Cuda12,
+            GpuBackend::Cuda13 => VllmBackend::Cuda13,
+            GpuBackend::Rocm => VllmBackend::Rocm,
+            GpuBackend::Cpu | GpuBackend::Vulkan => VllmBackend::Cpu,
+        }
+    }
+
+    /// This host's backend and architecture, from the shared GPU probe.
+    fn detect() -> Result<(VllmBackend, HostArch)> {
+        Ok((VllmBackend::from_gpu(detect_backend()), HostArch::detect()?))
+    }
+
+    /// The `docker.io/`-qualified image (so podman doesn't prompt for a
+    /// registry). `version` replaces the floating `latest`: `<version>-<arch>`
+    /// (`-cu129` for CUDA 12) for the `vllm/` images, the whole tag for
+    /// `rocm/vllm` (whose `rocmX.Y_..._vllm_Z` tags carry no arch suffix).
+    /// Arch spellings are Docker Hub's: the GPU image says `aarch64`, the
+    /// CPU image `arm64`.
+    fn image_ref(self, arch: HostArch, version: Option<&str>) -> Result<String> {
+        let v = version.unwrap_or("latest");
+        let (repo, suffix) = match (self, arch) {
+            (VllmBackend::Rocm, HostArch::X86_64) => return Ok(format!("docker.io/rocm/vllm:{v}")),
+            (VllmBackend::Rocm, HostArch::Aarch64) => anyhow::bail!(
+                "an AMD GPU was detected, but rocm/vllm publishes no aarch64 image \
+                 (set LLMMAN_LLM_LIBRARY=cpu to run vllm/vllm-openai-cpu instead)"
+            ),
+            (VllmBackend::Cuda12, HostArch::X86_64) => ("vllm-openai", "x86_64-cu129"),
+            (VllmBackend::Cuda12, HostArch::Aarch64) => ("vllm-openai", "aarch64-cu129"),
+            (VllmBackend::Cuda13, HostArch::X86_64) => ("vllm-openai", "x86_64"),
+            (VllmBackend::Cuda13, HostArch::Aarch64) => ("vllm-openai", "aarch64"),
+            (VllmBackend::Cpu, HostArch::X86_64) => ("vllm-openai-cpu", "x86_64"),
+            (VllmBackend::Cpu, HostArch::Aarch64) => ("vllm-openai-cpu", "arm64"),
+        };
+        Ok(format!("docker.io/vllm/{repo}:{v}-{suffix}"))
+    }
+
+    /// GPU passthrough plus what vLLM's deployment docs ask for: `--ipc=host`
+    /// (its workers share tensors over `/dev/shm`) and, for the CPU image,
+    /// `SYS_NICE` and an unconfined seccomp profile for NUMA thread binding.
+    fn engine_args(self) -> Vec<String> {
+        let mut args = match self {
+            VllmBackend::Cuda12 | VllmBackend::Cuda13 => GpuBackend::Cuda12.engine_args(),
+            VllmBackend::Rocm => GpuBackend::Rocm.engine_args(),
+            VllmBackend::Cpu => vec![
+                "--security-opt".into(),
+                "seccomp=unconfined".into(),
+                "--cap-add".into(),
+                "SYS_NICE".into(),
+            ],
+        };
+        args.push("--ipc=host".into());
+        args
+    }
+}
+
+/// Which engine's image a container run is for; cmd::serve knows this from
+/// the model's format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContainerEngine {
+    /// `ghcr.io/ggml-org/llama.cpp` (GGUF and diffusion models).
+    LlamaServer,
+    /// `vllm/vllm-openai`, `rocm/vllm` or `vllm/vllm-openai-cpu` (safetensors).
+    Vllm,
+}
+
+/// The image [`spawn`] / [`spawn_vllm`] would run here for `engine`.
+fn image_for(engine: ContainerEngine, version: Option<&str>) -> Result<String> {
+    match engine {
+        ContainerEngine::LlamaServer => Ok(detect_backend().image_ref(version)),
+        ContainerEngine::Vllm => {
+            let (backend, arch) = VllmBackend::detect()?;
+            backend.image_ref(arch, version)
+        }
+    }
+}
+
 /// Runs `llama-server` inside a container: `docker run --rm --init -t`
 /// (or `podman run` with the same flags), auto-selecting the image for
 /// whatever [`detect_backend`] found. Returns the running child process
@@ -182,10 +308,11 @@ fn backend_from_hostgpu(gpu: HostGpu) -> GpuBackend {
 /// stdin isn't a real terminal — the common case, since `llmman serve`
 /// itself is normally daemonized with stdin closed (see daemon.rs).
 ///
-/// Pulls the image [`spawn`] would run for the current host's detected GPU
-/// backend, with the pull's own progress output (a real `docker pull`/
+/// Pulls the image [`spawn`] or [`spawn_vllm`] would run for `engine` on
+/// this host, with the pull's own progress output (a real `docker pull`/
 /// `podman pull` progress bar — not something llmman re-implements)
-/// inherited directly to this process's stdout/stderr.
+/// inherited directly to this process's stdout/stderr. `version` is the
+/// engine's pin (`--llama-cpp-version` / `--vllm-version`), if any.
 ///
 /// `spawn`'s underlying `docker run`/`podman run` would pull an image that
 /// isn't already cached locally on its own, but silently and without any
@@ -197,9 +324,12 @@ fn backend_from_hostgpu(gpu: HostGpu) -> GpuBackend {
 /// first prompt to whoever's waiting on it) should call this — in the
 /// foreground, before `serve` is even started — rather than relying on
 /// `spawn`'s own implicit pull.
-pub fn pull_image(ociman: ContainerManager, llama_cpp_version: Option<&str>) -> Result<()> {
-    let backend = detect_backend();
-    let image = backend.image_ref(llama_cpp_version);
+pub fn pull_image(
+    ociman: ContainerManager,
+    engine: ContainerEngine,
+    version: Option<&str>,
+) -> Result<()> {
+    let image = image_for(engine, version)?;
     eprintln!("[llmman] {}: pulling {image}...", ociman.binary());
     let status = std::process::Command::new(ociman.binary())
         .args(["pull", &image])
@@ -326,21 +456,20 @@ pub fn spawn(
         .file_name()
         .and_then(|n| n.to_str())
         .context("model path has no valid UTF-8 filename")?;
-    let model_dir_str = model_dir
-        .to_str()
-        .context("model directory is not valid UTF-8")?;
+    let model_dir = mount_source(model_dir)?;
 
-    let mut args = run_args(backend, port);
+    let mut args = run_args(
+        backend.engine_args(),
+        port,
+        crate::cmd::serve::LLAMA_CPP_ENV_PASSTHROUGH_VARS,
+    );
     args.push("-v".into());
-    args.push(format!("{model_dir_str}:/models:ro"));
+    args.push(format!("{model_dir}:/models:ro"));
     let mmproj_file = mmproj_path
         .map(|p| -> Result<&str> {
             let dir = p.parent().context("mmproj path has no parent directory")?;
-            let dir_str = dir
-                .to_str()
-                .context("mmproj directory is not valid UTF-8")?;
             args.push("-v".into());
-            args.push(format!("{dir_str}:/mmproj:ro"));
+            args.push(format!("{}:/mmproj:ro", mount_source(dir)?));
             p.file_name()
                 .and_then(|n| n.to_str())
                 .context("mmproj path has no valid UTF-8 filename")
@@ -403,9 +532,12 @@ pub fn spawn(
 }
 
 /// The `run` prefix every container here starts with: attached with an
-/// init, the port published, the GPU passed through, and the GPU / llama.cpp
-/// env vars forwarded (`docker run` does not inherit the environment).
-fn run_args(backend: GpuBackend, port: u16) -> Vec<String> {
+/// init, the port published, the GPU passed through (`engine_args`), and
+/// the GPU-visibility env vars plus the engine's own `passthrough_vars`
+/// forwarded (`docker run` does not inherit the environment). `-e NAME`
+/// without a value: the engine copies it from our environment, so a
+/// secret (`VLLM_API_KEY`) never appears in argv or the debug log.
+fn run_args(engine_args: Vec<String>, port: u16, passthrough_vars: &[&str]) -> Vec<String> {
     let mut args: Vec<String> = vec![
         "run".into(),
         "--rm".into(),
@@ -414,17 +546,82 @@ fn run_args(backend: GpuBackend, port: u16) -> Vec<String> {
         "-p".into(),
         format!("127.0.0.1:{port}:{port}"),
     ];
-    args.extend(backend.engine_args());
+    args.extend(engine_args);
     for var in crate::cmd::serve::GPU_VISIBLE_DEVICE_VARS
         .iter()
-        .chain(crate::cmd::serve::LLAMA_CPP_ENV_PASSTHROUGH_VARS)
-        .chain(crate::cmd::serve::MEDIAGEN_ENV_PASSTHROUGH_VARS)
+        .chain(passthrough_vars)
     {
-        if let Ok(val) = std::env::var(var) {
+        if std::env::var_os(var).is_some() {
             args.push("-e".into());
-            args.push(format!("{var}={val}"));
+            args.push(var.to_string());
         }
     }
+    args
+}
+
+/// The vLLM counterpart of [`spawn`]: `vllm serve` on a safetensors
+/// directory (mounted at `/models`) in the image [`VllmBackend`] picks.
+/// `serve_args` builds the argv after `vllm` from the in-container model
+/// dir and bind address, so it's `cmd::serve::vllm_serve_args` unchanged.
+/// `--entrypoint vllm` is explicit because `rocm/vllm`'s default is a
+/// shell. Every `VLLM_*` env var is forwarded, as a local child would
+/// inherit them.
+pub fn spawn_vllm(
+    ociman: ContainerManager,
+    model_dir: &Path,
+    vllm_version: Option<&str>,
+    port: u16,
+    serve_args: impl FnOnce(&str, &str) -> Vec<String>,
+) -> Result<tokio::process::Child> {
+    let (backend, arch) = VllmBackend::detect()?;
+    let image = backend.image_ref(arch, vllm_version)?;
+    eprintln!(
+        "[llmman] {}: detected {:?} on {:?}, using image {:?}",
+        ociman.binary(),
+        backend,
+        arch,
+        image
+    );
+    let model_dir = mount_source(model_dir)?;
+    let vllm_vars: Vec<String> = std::env::vars_os()
+        .filter_map(|(k, _)| k.into_string().ok())
+        .filter(|k| k.starts_with("VLLM_"))
+        .collect();
+    let vllm_vars: Vec<&str> = vllm_vars.iter().map(String::as_str).collect();
+    let args = vllm_run_args(backend, image, &model_dir, port, &vllm_vars, serve_args);
+    run(ociman, args)
+}
+
+/// A bind-mount source: absolute (a relative `-v` source is a named
+/// volume to the engine, and `LLMMAN_MODELS` may be relative) and UTF-8.
+fn mount_source(dir: &Path) -> Result<String> {
+    let dir = dir
+        .canonicalize()
+        .with_context(|| format!("resolving {}", dir.display()))?;
+    dir.to_str()
+        .map(str::to_owned)
+        .with_context(|| format!("{} is not valid UTF-8", dir.display()))
+}
+
+/// [`spawn_vllm`]'s argv, split out so the ordering (`-v`/`--entrypoint`
+/// before the image, `serve ...` after) is testable without an engine.
+fn vllm_run_args(
+    backend: VllmBackend,
+    image: String,
+    model_dir: &str,
+    port: u16,
+    passthrough_vars: &[&str],
+    serve_args: impl FnOnce(&str, &str) -> Vec<String>,
+) -> Vec<String> {
+    let mut args = run_args(backend.engine_args(), port, passthrough_vars);
+    args.extend([
+        "-v".into(),
+        format!("{model_dir}:/models:ro"),
+        "--entrypoint".into(),
+        "vllm".into(),
+        image,
+    ]);
+    args.extend(serve_args("/models", "0.0.0.0"));
     args
 }
 
@@ -471,7 +668,12 @@ pub fn spawn_mediagen(
             .with_context(|| format!("{} is not valid UTF-8", p.display()))
     };
     let (exe, store, cache) = (utf8(&exe)?, utf8(store_path)?, utf8(cache_path)?);
-    let mut args = run_args(backend, port);
+    let passthrough = [
+        crate::cmd::serve::LLAMA_CPP_ENV_PASSTHROUGH_VARS,
+        crate::cmd::serve::MEDIAGEN_ENV_PASSTHROUGH_VARS,
+    ]
+    .concat();
+    let mut args = run_args(backend.engine_args(), port, &passthrough);
     args.extend([
         "-v".into(),
         format!("{exe}:/usr/local/bin/llmman:ro"),
@@ -644,6 +846,204 @@ mod tests {
     fn container_manager_binary_names() {
         assert_eq!(ContainerManager::Docker.binary(), "docker");
         assert_eq!(ContainerManager::Podman.binary(), "podman");
+    }
+
+    #[test]
+    fn host_arch_parses_only_the_two_architectures_vllm_ships() {
+        assert_eq!(HostArch::parse("x86_64"), Some(HostArch::X86_64));
+        assert_eq!(HostArch::parse("aarch64"), Some(HostArch::Aarch64));
+        assert_eq!(HostArch::parse("s390x"), None);
+        assert_eq!(HostArch::parse("riscv64"), None);
+        assert_eq!(HostArch::parse(""), None);
+    }
+
+    #[test]
+    fn cuda_12_hosts_get_the_cu129_vllm_image() {
+        assert_eq!(
+            VllmBackend::from_gpu(GpuBackend::Cuda12),
+            VllmBackend::Cuda12
+        );
+        assert_eq!(
+            VllmBackend::from_gpu(GpuBackend::Cuda13),
+            VllmBackend::Cuda13
+        );
+        assert_eq!(
+            VllmBackend::Cuda12
+                .image_ref(HostArch::X86_64, None)
+                .unwrap(),
+            "docker.io/vllm/vllm-openai:latest-x86_64-cu129"
+        );
+        assert_eq!(
+            VllmBackend::Cuda12
+                .image_ref(HostArch::Aarch64, Some("v0.28.0"))
+                .unwrap(),
+            "docker.io/vllm/vllm-openai:v0.28.0-aarch64-cu129"
+        );
+    }
+
+    #[test]
+    fn vulkan_host_runs_the_vllm_cpu_image() {
+        assert_eq!(VllmBackend::from_gpu(GpuBackend::Vulkan), VllmBackend::Cpu);
+        assert_eq!(VllmBackend::from_gpu(GpuBackend::Cpu), VllmBackend::Cpu);
+        assert_eq!(VllmBackend::from_gpu(GpuBackend::Rocm), VllmBackend::Rocm);
+    }
+
+    #[test]
+    fn vllm_image_refs_match_docker_hub_tag_spellings() {
+        assert_eq!(
+            VllmBackend::Cuda13
+                .image_ref(HostArch::X86_64, None)
+                .unwrap(),
+            "docker.io/vllm/vllm-openai:latest-x86_64"
+        );
+        assert_eq!(
+            VllmBackend::Cuda13
+                .image_ref(HostArch::Aarch64, None)
+                .unwrap(),
+            "docker.io/vllm/vllm-openai:latest-aarch64"
+        );
+        assert_eq!(
+            VllmBackend::Rocm.image_ref(HostArch::X86_64, None).unwrap(),
+            "docker.io/rocm/vllm:latest"
+        );
+        assert_eq!(
+            VllmBackend::Cpu.image_ref(HostArch::X86_64, None).unwrap(),
+            "docker.io/vllm/vllm-openai-cpu:latest-x86_64"
+        );
+        assert_eq!(
+            VllmBackend::Cpu.image_ref(HostArch::Aarch64, None).unwrap(),
+            "docker.io/vllm/vllm-openai-cpu:latest-arm64"
+        );
+    }
+
+    #[test]
+    fn vllm_image_ref_pins_to_the_given_version() {
+        assert_eq!(
+            VllmBackend::Cuda13
+                .image_ref(HostArch::X86_64, Some("v0.11.0"))
+                .unwrap(),
+            "docker.io/vllm/vllm-openai:v0.11.0-x86_64"
+        );
+        assert_eq!(
+            VllmBackend::Cuda13
+                .image_ref(HostArch::Aarch64, Some("v0.11.0"))
+                .unwrap(),
+            "docker.io/vllm/vllm-openai:v0.11.0-aarch64"
+        );
+        assert_eq!(
+            VllmBackend::Cpu
+                .image_ref(HostArch::Aarch64, Some("v0.11.0"))
+                .unwrap(),
+            "docker.io/vllm/vllm-openai-cpu:v0.11.0-arm64"
+        );
+        // rocm/vllm's tags carry no arch suffix: the pin is the whole tag.
+        assert_eq!(
+            VllmBackend::Rocm
+                .image_ref(
+                    HostArch::X86_64,
+                    Some("rocm7.14.1_cdna_ubuntu24.04_py3.14_pytorch_2.11_vllm_0.23.0")
+                )
+                .unwrap(),
+            "docker.io/rocm/vllm:rocm7.14.1_cdna_ubuntu24.04_py3.14_pytorch_2.11_vllm_0.23.0"
+        );
+    }
+
+    #[test]
+    fn rocm_vllm_has_no_aarch64_image() {
+        let err = VllmBackend::Rocm
+            .image_ref(HostArch::Aarch64, None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("rocm/vllm"), "{err}");
+        assert!(err.contains("LLMMAN_LLM_LIBRARY=cpu"), "{err}");
+    }
+
+    #[test]
+    fn vllm_engine_args_add_ipc_host_on_top_of_gpu_passthrough() {
+        assert_eq!(
+            VllmBackend::Cuda13.engine_args(),
+            vec!["--gpus", "all", "--ipc=host"]
+        );
+        let rocm = VllmBackend::Rocm.engine_args();
+        assert!(
+            rocm.starts_with(&GpuBackend::Rocm.engine_args()),
+            "{rocm:?}"
+        );
+        assert_eq!(rocm.last().map(String::as_str), Some("--ipc=host"));
+    }
+
+    #[test]
+    fn vllm_cpu_engine_args_grant_what_its_numa_thread_binding_needs() {
+        assert_eq!(
+            VllmBackend::Cpu.engine_args(),
+            vec![
+                "--security-opt",
+                "seccomp=unconfined",
+                "--cap-add",
+                "SYS_NICE",
+                "--ipc=host"
+            ]
+        );
+    }
+
+    #[test]
+    fn vllm_run_args_put_the_mount_and_entrypoint_before_the_image_and_serve_after() {
+        let args = vllm_run_args(
+            VllmBackend::Cuda13,
+            "docker.io/vllm/vllm-openai:latest-x86_64".into(),
+            "/cache/abc/model",
+            8000,
+            &[],
+            |dir, host| {
+                vec![
+                    "serve".into(),
+                    dir.into(),
+                    "--host".into(),
+                    host.into(),
+                    "--served-model-name".into(),
+                    "m".into(),
+                ]
+            },
+        );
+        let image = args
+            .iter()
+            .position(|a| a == "docker.io/vllm/vllm-openai:latest-x86_64")
+            .expect("image present");
+        let before = &args[..image];
+        assert!(before.contains(&"--gpus".to_string()), "{before:?}");
+        assert!(before.contains(&"--ipc=host".to_string()), "{before:?}");
+        assert!(
+            before.contains(&"/cache/abc/model:/models:ro".to_string()),
+            "{before:?}"
+        );
+        assert_eq!(&before[before.len() - 2..], &["--entrypoint", "vllm"]);
+        assert_eq!(
+            &args[image + 1..],
+            &[
+                "serve",
+                "/models",
+                "--host",
+                "0.0.0.0",
+                "--served-model-name",
+                "m"
+            ]
+        );
+    }
+
+    #[test]
+    fn run_args_forward_only_the_requested_passthrough_vars() {
+        const VAR: &str = "LLMMAN_TEST_RUN_ARGS_PASSTHROUGH";
+        std::env::set_var(VAR, "1");
+        let args = run_args(vec![], 8080, &[]);
+        assert_eq!(
+            &args[..6],
+            &["run", "--rm", "--init", "-t", "-p", "127.0.0.1:8080:8080"]
+        );
+        assert!(!args.contains(&VAR.to_string()), "{args:?}");
+        let args = run_args(vec![], 8080, &[VAR]);
+        assert!(args.windows(2).any(|w| w == ["-e", VAR]), "{args:?}");
+        // The value stays out of argv (it may be a secret).
+        assert!(!args.iter().any(|a| a.starts_with(&format!("{VAR}="))));
     }
 
     /// Exercises real end-to-end backend detection (via

--- a/src/hostgpu.rs
+++ b/src/hostgpu.rs
@@ -1,9 +1,10 @@
 //! Cross-platform detection of the GPU/accelerator, if any, available on
 //! the local host — used by [`crate::llama_release`] to pick which
 //! prebuilt `llama-server` release asset to download for this machine,
-//! and by [`crate::container`] to pick which
-//! `ghcr.io/ggml-org/llama.cpp` container image to run instead (`--ociman`)
-//! — both share this one probe rather than detecting the host twice.
+//! and by [`crate::container`] to pick which `ghcr.io/ggml-org/llama.cpp`
+//! (or, for a safetensors model, vLLM) container image to run instead
+//! (`--ociman`) — all share this one probe rather than detecting the host
+//! twice.
 //!
 //! Detection calls the real vendor APIs — the CUDA Driver API, the HIP
 //! runtime API, and the Vulkan API — the same libraries and entry points

--- a/src/modelpack.rs
+++ b/src/modelpack.rs
@@ -368,6 +368,58 @@ fn gguf_layers(
     Some((primary, mmproj))
 }
 
+/// Which [`ModelPath`] variant a manifest resolves to — see [`stored_format`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelFormat {
+    Gguf,
+    SafeTensors,
+    Diffusion,
+}
+
+/// [`resolve_model`]'s classification: diffusion > GGUF > safetensors,
+/// `None` for "no servable model layer".
+fn manifest_format(manifest: &crate::storage::oci::Manifest) -> Option<ModelFormat> {
+    if manifest.layers.iter().any(|l| layer_role(l).is_some()) {
+        Some(ModelFormat::Diffusion)
+    } else if gguf_layers(manifest).is_some() {
+        Some(ModelFormat::Gguf)
+    } else if manifest.layers.iter().any(is_safetensors_layer) {
+        Some(ModelFormat::SafeTensors)
+    } else {
+        None
+    }
+}
+
+/// The "nothing servable" error, naming the file extensions that were there.
+fn no_servable_layer(model_ref: &str, manifest: &crate::storage::oci::Manifest) -> anyhow::Error {
+    let exts: std::collections::HashSet<String> = manifest
+        .layers
+        .iter()
+        .filter_map(|l| layer_filepath(l))
+        .filter_map(|p| Path::new(p).extension()?.to_str().map(|e| e.to_lowercase()))
+        .collect();
+    if exts.is_empty() {
+        anyhow!("no servable model layer found in {model_ref}")
+    } else {
+        anyhow!(
+            "no servable model layer in {model_ref} — found {exts:?} files; \
+             llmman serve supports GGUF (llama-server) and safetensors (vllm/mlx)"
+        )
+    }
+}
+
+/// What [`resolve_model`] would resolve `model_ref` to, read off its
+/// manifest without extracting anything (for `--pull-oci`, which only
+/// needs to know which engine's image to pull).
+pub fn stored_format(store_path: &Path, model_ref: &str) -> anyhow::Result<ModelFormat> {
+    let store = OciStore::open(store_path)?;
+    let desc = store
+        .find(model_ref)
+        .with_context(|| format!("model not found in store: {model_ref}"))?;
+    let manifest = store.read_manifest(&desc.digest)?;
+    manifest_format(&manifest).ok_or_else(|| no_servable_layer(model_ref, &manifest))
+}
+
 /// Resolve `model_ref` (already present in the `OciStore` at `store_path`)
 /// to either a `.gguf` file or an extracted safetensors directory, caching
 /// any extraction under `cache_path`.
@@ -382,8 +434,12 @@ pub fn resolve_model(
         .with_context(|| format!("model not found in store: {model_ref}"))?;
     let manifest = store.read_manifest(&desc.digest)?;
 
+    let Some(format) = manifest_format(&manifest) else {
+        return Err(no_servable_layer(model_ref, &manifest));
+    };
+
     // ── diffusion → crate::mediagen ───────────────────────────────────────
-    if manifest.layers.iter().any(|l| layer_role(l).is_some()) {
+    if format == ModelFormat::Diffusion {
         let (primary, _) = gguf_layers(&manifest)
             .ok_or_else(|| anyhow!("{model_ref}: diffusion model has no transformer GGUF layer"))?;
         // Every file keeps its name (see named_blob_path); a GGUF in a tar
@@ -438,26 +494,9 @@ pub fn resolve_model(
     }
 
     // ── safetensors → vllm / mlx_lm.server ──────────────────────────────
-    if manifest.layers.iter().any(is_safetensors_layer) {
-        let model_dir = extract_safetensors_dir(store_path, cache_path, &desc.digest, &manifest)?;
-        return Ok(ModelPath::SafeTensors(model_dir));
-    }
-
-    // Nothing usable found — report what was present.
-    let exts: std::collections::HashSet<String> = manifest
-        .layers
-        .iter()
-        .filter_map(|l| layer_filepath(l))
-        .filter_map(|p| Path::new(p).extension()?.to_str().map(|e| e.to_lowercase()))
-        .collect();
-    if exts.is_empty() {
-        anyhow::bail!("no servable model layer found in {model_ref}");
-    } else {
-        anyhow::bail!(
-            "no servable model layer in {model_ref} — found {exts:?} files; \
-             llmman serve supports GGUF (llama-server) and safetensors (vllm/mlx)"
-        );
-    }
+    debug_assert_eq!(format, ModelFormat::SafeTensors);
+    let model_dir = extract_safetensors_dir(store_path, cache_path, &desc.digest, &manifest)?;
+    Ok(ModelPath::SafeTensors(model_dir))
 }
 
 /// Extract CNCF-format safetensors layers to a cache directory and return the
@@ -698,6 +737,29 @@ mod tests {
             )
             .unwrap();
         assert_eq!(capabilities(&store, &m), vec!["completion"]);
+    }
+
+    #[test]
+    fn manifest_format_follows_resolve_models_precedence() {
+        let (_, m) = manifest_with(vec![
+            descriptor("sha256:a", "model.Q4_K_M.gguf"),
+            descriptor("sha256:b", "extra.safetensors"),
+        ]);
+        assert_eq!(manifest_format(&m), Some(ModelFormat::Gguf));
+        let (_, m) = manifest_with(vec![
+            descriptor("sha256:a", "config.json"),
+            descriptor("sha256:b", "model-00001-of-00002.safetensors"),
+        ]);
+        assert_eq!(manifest_format(&m), Some(ModelFormat::SafeTensors));
+        let mut vae = descriptor("sha256:b", "vae.safetensors");
+        vae.annotations.get_or_insert_with(Default::default).insert(
+            crate::hf::oci::ANNOTATION_ROLE.to_string(),
+            "vae".to_string(),
+        );
+        let (_, m) = manifest_with(vec![descriptor("sha256:a", "ltx.gguf"), vae]);
+        assert_eq!(manifest_format(&m), Some(ModelFormat::Diffusion));
+        let (_, m) = manifest_with(vec![descriptor("sha256:a", "README.md")]);
+        assert_eq!(manifest_format(&m), None);
     }
 
     #[test]


### PR DESCRIPTION
`--ociman docker|podman` only containerized llama-server; a safetensors model still needed a local `vllm`. This runs `vllm serve` in a container too, picking the image with the same `hostgpu::detect` probe plus the host architecture:

| Host GPU | x86_64 | aarch64 |
|---|---|---|
| CUDA 13 | `vllm/vllm-openai:<ver>-x86_64` | `vllm/vllm-openai:<ver>-aarch64` |
| CUDA 12 | `vllm/vllm-openai:<ver>-x86_64-cu129` | `vllm/vllm-openai:<ver>-aarch64-cu129` |
| ROCm | `rocm/vllm:<ver>` | error (not published upstream) |
| Vulkan / none | `vllm/vllm-openai-cpu:<ver>-x86_64` | `vllm/vllm-openai-cpu:<ver>-arm64` |

- `--vllm-version <TAG>` pins the tag like `--llama-cpp-version`.
- `--pull-oci` pulls the image the named MODEL needs (new `modelpack::stored_format`); with no MODEL, the llama.cpp image as before.
- `ModelProcess::Container` carries its `Engine`, so `llmman ps` / `llmman_model_up` say `vllm`.
- Env passthrough is `-e NAME` so `VLLM_API_KEY` stays out of argv; bind-mount sources are canonicalized.

fmt/clippy clean, unit tests pass. Not run end-to-end (developed on macOS); the `docker run` argv is unit-tested.
