### PR TITLE
feat(serve): serve Diffusers-layout models (nvidia/Cosmos3-Edge) with vLLM-Omni

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,17 @@ Without a prompt it opens a `>>> ` loop where `/set width|height|steps|seed|cfg|
 adjusts the settings. The same model answers `/v1/images/generations`, `/v1/videos` and
 `/v1/audio/speech` on `llmman serve`.
 
+A Diffusers-layout safetensors repository (a root `model_index.json`), such as NVIDIA's
+Cosmos3 world models, is served by [vLLM-Omni](https://github.com/vllm-project/vllm-omni) (`vllm serve
+--omni`; install `vllm-omni` next to `vllm`, or use `--ociman docker` for the `vllm/vllm-omni` image):
+
+```sh
+llmman run nvidia/Cosmos3-Edge "A robot arm cleaning a plate in a kitchen"              # 640x640 png
+llmman run nvidia/Cosmos3-Edge --video --seconds 2 "A robot arm cleaning a plate"       # 832x480 mp4
+```
+
+See [docs/backends.md](docs/backends.md#vllm-omni-diffusers-pipelines).
+
 ## Commands
 
 | Command | Description |

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -10,6 +10,9 @@ already exists for the model format it finds, and runs it unmodified.
 | safetensors | [`vllm`](https://github.com/vllm-project/vllm) | Your `PATH` |
 | safetensors | `vllm` in a container | `--ociman docker` / `--ociman podman` (Linux only): the `vllm/vllm-openai`, `rocm/vllm` or `vllm/vllm-openai-cpu` image for your GPU and architecture |
 | safetensors | [`mlx_lm.server`](https://github.com/ml-explore/mlx-lm) | Your `PATH`, on Apple Silicon macOS; preferred over `vllm` when present |
+| GGUF diffusion (LTX-2) | llmman itself, on ggml | The `libggml`/`libllama` next to `llama-server`; see [the blog post](https://llmmanorg.github.io/blog/image-audio-and-video-generation/) |
+| Diffusers safetensors | [`vllm serve --omni`](https://github.com/vllm-project/vllm-omni) | Your `PATH`'s `vllm` with the `vllm-omni` package installed |
+| Diffusers safetensors | `vllm serve --omni` in a container | `--ociman docker` / `--ociman podman` (Linux only): the `vllm/vllm-omni` image (CUDA only) |
 
 ## llama.cpp
 
@@ -63,6 +66,40 @@ host architecture:
 already-pulled model needs (without a model, the llama.cpp image).
 `CUDA_VISIBLE_DEVICES` and friends plus every `VLLM_*` variable are
 forwarded into the container.
+
+### vLLM-Omni (Diffusers pipelines)
+
+A safetensors repository laid out as a Diffusers pipeline (a root
+`model_index.json` next to `transformer/`, `vae/`, ...), such as
+[`nvidia/Cosmos3-Edge`](https://huggingface.co/nvidia/Cosmos3-Edge), is
+served by [vLLM-Omni](https://github.com/vllm-project/vllm-omni): the same
+`vllm` launcher with `--omni`. Plain `vllm serve` cannot load one.
+
+```sh
+uv pip install vllm==0.28.0 vllm-omni     # into the environment `vllm` runs from
+llmman run nvidia/Cosmos3-Edge "A robot arm cleaning a plate in a kitchen"
+llmman run nvidia/Cosmos3-Edge --video --seconds 2 "A robot arm cleaning a plate"
+```
+
+If `vllm` is a `#!/path/to/python` script whose Python cannot import
+`vllm_omni`, the load fails up front with a message saying so; otherwise
+vLLM itself reports `unrecognized arguments: --omni`. The model answers
+`/v1/images/generations` and `/v1/videos`, in llama-server's dialect
+(`width`/`height`/`steps`/`cfg_scale`, streamed `image_generation.*`
+events, a video job with a `content_url`) and vLLM-Omni's own (`size`,
+`num_inference_steps`, `guidance_scale`, `num_frames`, `extra_params`);
+unsent fields are left to the model's defaults. There is no
+`/v1/audio/speech` for these models.
+
+Cosmos3's safety guardrails are disabled (`--no-guardrails`): they need
+the `cosmos-guardrail` package and a runtime download of the gated
+`nvidia/Cosmos-1.0-Guardrail`, without which the server refuses to start.
+`LLMMAN_VLLM_OMNI_GUARDRAILS=1` leaves them on. `LLMMAN_LOAD_TIMEOUT` is
+also passed as `--init-timeout`.
+
+With `--ociman`, the image is `vllm/vllm-omni:latest-x86_64` or
+`latest-aarch64` (CUDA only; `--vllm-version` pins vLLM-Omni's release,
+e.g. `v0.28.0`). `--pull-oci <model>` picks it for a pulled Diffusers model.
 
 ### `vllm serve` from llmman's store
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -197,7 +197,8 @@ setting may not behave identically.
 | `LLMMAN_KV_CACHE_TYPE` | KV-cache quantization (`--cache-type-k`/`--cache-type-v`), e.g. `f16` (default), `q8_0`, `q4_0`. Trades output quality for memory at long context lengths. |
 | `LLMMAN_LLM_LIBRARY` | Forces which GPU backend `llmman serve`/`run` picks (`cpu`, `cuda`/`cuda12`/`cuda_v12`, `cuda13`/`cuda_v13`, `rocm`, `vulkan`, or macOS-only `metal`), bypassing autodetection. Has no effect when a `llama-server` binary is already on `PATH` (its own backend is fixed), or on macOS's local-binary download (one asset per architecture, no separate choice to make). |
 | `LLMMAN_IGPU_ENABLE` | Counts integrated GPUs (Vulkan only) when probing for an accelerator. Defaults to disabled, since an integrated GPU is usually a worse choice than the discrete/CPU fallback it would otherwise be skipped in favor of. |
-| `LLMMAN_LOAD_TIMEOUT` | How long to allow a model load to stall before giving up. Zero or negative means wait forever. Defaults to 10 minutes (`vllm` can take several minutes to load a large safetensors model). |
+| `LLMMAN_LOAD_TIMEOUT` | How long to allow a model load to stall before giving up. Zero or negative means wait forever. Defaults to 10 minutes (`vllm` can take several minutes to load a large safetensors model). Also passed to vLLM-Omni as `--init-timeout` (a day when unbounded). |
+| `LLMMAN_VLLM_OMNI_GUARDRAILS` | When set (`1`/`true`/`yes`/`on`), a Diffusers-layout model served by vLLM-Omni keeps its safety guardrails on; llmman otherwise passes `--no-guardrails`. See [backends.md](backends.md#vllm-omni-diffusers-pipelines). |
 | `LLMMAN_TMPDIR` | Staging directory for `llama-server` release downloads, overriding the default `tmp` subdirectory of the install root. |
 | `LLMMAN_VERIFY` | Overrides the signature-verification mode (`off`, `warn`, or `enforce`) for every reference, ignoring what `[verify]` selected. Does *not* supply trusted keys — those still come from `llmman.conf`, so `enforce` with no configured keys fails every check rather than passing them. Intended for CI, which can demand `enforce` without editing config files. See [verification.md](verification.md). |
 | `LLMMAN_SIGN_PASSWORD` | Passphrase for the `--sign-key` private key used by `push`/`transfer`, when it is an encrypted PEM. Falls back to `COSIGN_PASSWORD`. Read by the CLI process, which does the signing itself; neither key nor passphrase reaches the daemon. |
@@ -211,6 +212,7 @@ setting may not behave identically.
 |---------|-------------------------------------|-----------------------|
 | `llama-server` | Passed as `--ctx-size` as-is for generation models (llama-server allocates the KV cache at that size and caps each request slot to the model's trained context). Embedding models are always capped to their trained context, and `0` means that context. | `--ctx-size 262144` (256k), or the model's trained context if smaller. If the load then fails with an out-of-memory error, llmman retries with the context halved (down to a 16384 floor) before giving up. |
 | `vLLM` | Positive values are passed as `--max-model-len`; oversized values are rejected by vLLM. `0` is not forwarded. | Uses vLLM's model-derived default. |
+| `vllm serve --omni` | Not forwarded: a diffusion pipeline has no context window. | — |
 | `mlx_lm.server` | Not currently forwarded. | Uses `mlx_lm.server` defaults. |
 
 GPU device-selection variables `llmman serve` forwards to every

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -78,6 +78,7 @@ Environment Variables:
       LLMMAN_LLM_LIBRARY             Set backend (cpu/cuda/cuda13/rocm/vulkan/metal) to bypass GPU autodetection
       LLMMAN_IGPU_ENABLE             Enable integrated GPUs
       LLMMAN_LOAD_TIMEOUT            How long to allow model loads to stall before giving up (default \"10m\")
+      LLMMAN_VLLM_OMNI_GUARDRAILS    Keep a Diffusers-layout model's vLLM-Omni safety guardrails on (default: off)
       LLMMAN_TMPDIR                  Staging directory for llama-server release downloads
       LLAMA_ARG_FIT                  Enable llama.cpp automatic fit of unset memory options (default \"on\")
       LLAMA_ARG_FIT_TARGET           Target free VRAM margin per device for llama.cpp fit (MiB)
@@ -369,6 +370,10 @@ impl RunningModel {
 enum Engine {
     LlamaServer,
     Vllm,
+    /// `vllm serve --omni` (the vLLM-Omni plugin) for a [`ModelPath::Omni`]
+    /// model. Killed like [`Engine::Vllm`]; its media routes speak a
+    /// different dialect — see [`omni_images`] and [`omni_videos`].
+    VllmOmni,
     /// `mlx_lm.server` (the `mlx-lm` PyPI package) — Apple Silicon's own
     /// Metal-accelerated alternative to `vllm` for a
     /// [`ModelPath::SafeTensors`] directory, picked instead of it when
@@ -386,6 +391,7 @@ impl Engine {
         match self {
             Engine::LlamaServer => "llama-server",
             Engine::Vllm => "vllm",
+            Engine::VllmOmni => "vllm-omni",
             Engine::Mlx => "mlx",
         }
     }
@@ -434,7 +440,7 @@ impl Drop for ModelProcess {
             // indefinitely. spawn_vllm_server puts this child in its own
             // process group so the whole group can be killed here.
             #[cfg(unix)]
-            ModelProcess::Local(Engine::Vllm, _, pid) => {
+            ModelProcess::Local(Engine::Vllm | Engine::VllmOmni, _, pid) => {
                 if let Some(pid) = pid {
                     let result = unsafe { libc::kill(-(*pid as libc::pid_t), libc::SIGKILL) };
                     if result != 0 {
@@ -446,7 +452,7 @@ impl Drop for ModelProcess {
                 }
             }
             #[cfg(not(unix))]
-            ModelProcess::Local(Engine::Vllm, _, _) => {}
+            ModelProcess::Local(Engine::Vllm | Engine::VllmOmni, _, _) => {}
             // `mlx_lm.server` runs entirely as one process — a single
             // background generation thread plus a `ThreadingHTTPServer`,
             // no forked worker tree of its own the way vllm has above —
@@ -459,6 +465,12 @@ impl Drop for ModelProcess {
 }
 
 impl ModelProcess {
+    fn engine(&self) -> Engine {
+        match self {
+            ModelProcess::Local(engine, _, _) | ModelProcess::Container(_, engine, _) => *engine,
+        }
+    }
+
     /// True if the underlying child process hasn't exited on its own since
     /// this model was marked running. Nothing else ever tells `mgr.running`
     /// about a process exiting unexpectedly: every other removal is a
@@ -498,7 +510,7 @@ impl ModelProcess {
                 }
             }
             #[cfg(unix)]
-            ModelProcess::Local(Engine::Vllm, _, pid) => {
+            ModelProcess::Local(Engine::Vllm | Engine::VllmOmni, _, pid) => {
                 if let Some(pid) = pid {
                     unsafe { libc::kill(-(*pid as libc::pid_t), libc::SIGKILL) };
                 }
@@ -1933,6 +1945,16 @@ fn vllm_serve_args(
     args
 }
 
+/// `vllm <args>`, in its own process group so [`ModelProcess`]'s Drop can
+/// kill vllm's whole worker tree (not just this pid) without killing us.
+fn vllm_command(vllm: &Path, args: Vec<String>) -> tokio::process::Command {
+    let mut cmd = tokio::process::Command::new(vllm);
+    cmd.args(args).kill_on_drop(true);
+    #[cfg(unix)]
+    cmd.process_group(0);
+    cmd
+}
+
 async fn spawn_vllm_server(
     model_dir: &Path,
     port: u16,
@@ -1940,21 +1962,130 @@ async fn spawn_vllm_server(
     max_model_len: Option<u32>,
 ) -> anyhow::Result<tokio::process::Child> {
     let vllm = which_binary("vllm")?;
-    let mut cmd = tokio::process::Command::new(&vllm);
-    cmd.args(vllm_serve_args(
+    let args = vllm_serve_args(
         model_dir.to_str().context("non-UTF-8 model path")?,
         "127.0.0.1",
         port,
         model_name,
         max_model_len,
-    ));
-    // Own process group so ModelProcess's Drop impl can kill vllm's whole
-    // worker tree, not just this one pid, without also killing ourselves.
-    #[cfg(unix)]
-    cmd.process_group(0);
-    cmd.kill_on_drop(true)
+    );
+    vllm_command(&vllm, args)
         .spawn()
         .with_context(|| format!("spawn vllm from {}", vllm.display()))
+}
+
+/// Set (`1`/`true`/...) to keep Cosmos3's safety guardrails on under
+/// vLLM-Omni; see [`vllm_omni_serve_args`].
+const VLLM_OMNI_GUARDRAILS_VAR: &str = "LLMMAN_VLLM_OMNI_GUARDRAILS";
+
+/// argv after `vllm` for a [`ModelPath::Omni`] model: [`vllm_serve_args`]
+/// plus `--omni` (the vLLM-Omni plugin picks the pipeline from
+/// `model_index.json`), no `--max-model-len` (no context window).
+///
+/// `--no-guardrails` unless `LLMMAN_VLLM_OMNI_GUARDRAILS` is set: Cosmos3's
+/// guardrails need the `cosmos-guardrail` package and a runtime download of
+/// the gated `nvidia/Cosmos-1.0-Guardrail`, and vLLM-Omni refuses to start
+/// without them — a model served from llmman's store has neither.
+/// `--init-timeout` mirrors llmman's load deadline so vLLM-Omni's own
+/// (10 minutes) does not give up first.
+fn vllm_omni_serve_args(
+    model_dir: &str,
+    host: &str,
+    port: u16,
+    model_name: &str,
+    guardrails: bool,
+    init_timeout: Duration,
+) -> Vec<String> {
+    let mut args = vllm_serve_args(model_dir, host, port, model_name, None);
+    args.push("--omni".into());
+    if !guardrails {
+        args.push("--no-guardrails".into());
+    }
+    args.push("--init-timeout".into());
+    args.push(init_timeout.as_secs().max(1).to_string());
+    args
+}
+
+/// [`vllm_omni_serve_args`] from the environment; an unbounded
+/// `LLMMAN_LOAD_TIMEOUT` becomes a day.
+fn vllm_omni_serve_args_from_env(
+    model_dir: &str,
+    host: &str,
+    port: u16,
+    model_name: &str,
+) -> Vec<String> {
+    let guardrails = crate::env_flag_set(VLLM_OMNI_GUARDRAILS_VAR);
+    let init_timeout = load_timeout_from_env().unwrap_or(Duration::from_secs(24 * 3600));
+    vllm_omni_serve_args(model_dir, host, port, model_name, guardrails, init_timeout)
+}
+
+/// `vllm serve --omni` from the `vllm` on `PATH`. Stdio is piped like a
+/// llama-server's so a startup failure's reason reaches `wait_for_ready`.
+async fn spawn_vllm_omni_server(
+    model_dir: &Path,
+    port: u16,
+    model_name: &str,
+) -> anyhow::Result<(tokio::process::Child, OutputTail)> {
+    let vllm = which_binary("vllm")?;
+    if !vllm_has_omni_plugin(&vllm).await {
+        anyhow::bail!(
+            "{} has no vllm-omni plugin, which a Diffusers-layout model needs \
+             (`uv pip install vllm-omni` into the same environment, or serve it \
+             with --ociman docker to use the vllm/vllm-omni image)",
+            vllm.display()
+        );
+    }
+    let args = vllm_omni_serve_args_from_env(
+        model_dir.to_str().context("non-UTF-8 model path")?,
+        "127.0.0.1",
+        port,
+        model_name,
+    );
+    let mut cmd = vllm_command(&vllm, args);
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+    crate::debug_log!("spawning {}: {:?}", vllm.display(), cmd);
+    let mut child = cmd
+        .spawn()
+        .with_context(|| format!("spawn vllm --omni from {}", vllm.display()))?;
+    let tail = tail_child_output(&mut child);
+    Ok((child, tail))
+}
+
+/// Longest [`vllm_has_omni_plugin`] waits before assuming yes.
+const OMNI_PLUGIN_PROBE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Whether the Python behind the `vllm` console script can `import
+/// vllm_omni` — a clear error up front instead of vLLM's "unrecognized
+/// arguments: --omni" after importing torch. When the launcher is not a
+/// `#!/path/to/python` script, or the probe fails or stalls, the answer
+/// is yes and vLLM itself reports.
+async fn vllm_has_omni_plugin(vllm: &Path) -> bool {
+    let Some(python) = console_script_interpreter(vllm) else {
+        return true;
+    };
+    let probe = tokio::process::Command::new(&python)
+        .args(["-c", "import vllm_omni"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true)
+        .status();
+    match tokio::time::timeout(OMNI_PLUGIN_PROBE_TIMEOUT, probe).await {
+        Ok(Ok(status)) => status.success(),
+        Ok(Err(_)) | Err(_) => true,
+    }
+}
+
+/// The interpreter of a `#!/path/to/python` script (not `#!/usr/bin/env`).
+fn console_script_interpreter(script: &Path) -> Option<PathBuf> {
+    let mut head = [0u8; 512];
+    let n = std::fs::File::open(script)
+        .and_then(|mut f| std::io::Read::read(&mut f, &mut head))
+        .ok()?;
+    let first = std::str::from_utf8(&head[..n]).ok()?.lines().next()?;
+    let interp = first.strip_prefix("#!")?.split_whitespace().next()?;
+    (!interp.ends_with("/env") && interp.contains("python")).then(|| PathBuf::from(interp))
 }
 
 /// Spawns `mlx_lm.server` (installed on `PATH` by `pip install mlx-lm`
@@ -3710,6 +3841,7 @@ async fn ensure_model(
             (ModelPath::SafeTensors(dir), Some(ociman)) => {
                 let mut child = crate::container::spawn_vllm(
                     ociman,
+                    crate::container::ContainerEngine::Vllm,
                     dir,
                     state.0.vllm_version.as_deref(),
                     port,
@@ -3719,6 +3851,28 @@ async fn ensure_model(
                 )?;
                 stderr_tail = Some(tail_child_output(&mut child));
                 ModelProcess::Container(ociman, Engine::Vllm, child)
+            }
+            // Diffusers-layout models go to vLLM-Omni (`vllm serve --omni`),
+            // never to plain vllm or mlx, which cannot load one.
+            (ModelPath::Omni(dir), Some(ociman)) => {
+                let mut child = crate::container::spawn_vllm(
+                    ociman,
+                    crate::container::ContainerEngine::VllmOmni,
+                    dir,
+                    state.0.vllm_version.as_deref(),
+                    port,
+                    |model_dir, host| {
+                        vllm_omni_serve_args_from_env(model_dir, host, port, model_ref)
+                    },
+                )?;
+                stderr_tail = Some(tail_child_output(&mut child));
+                ModelProcess::Container(ociman, Engine::VllmOmni, child)
+            }
+            (ModelPath::Omni(dir), None) => {
+                let (child, tail) = spawn_vllm_omni_server(dir, port, model_ref).await?;
+                stderr_tail = Some(tail);
+                let pid = child.id();
+                ModelProcess::Local(Engine::VllmOmni, child, pid)
             }
             (ModelPath::SafeTensors(_dir), None) if use_mlx_for_safetensors() => {
                 let child = spawn_mlx_server(port).await?;
@@ -7245,8 +7399,32 @@ async fn proxy_openai_passthrough(
             }
         }
     }
-    let (mut req, target, activity, response_model_override) =
+    let (req, target, activity, response_model_override) =
         resolve_openai_request(state, headers, body).await?;
+    forward_openai_request(
+        state,
+        headers,
+        req,
+        target,
+        activity,
+        response_model_override,
+        llama_path,
+    )
+    .await
+}
+
+/// [`proxy_openai_passthrough`] after the model is loaded: wire checks,
+/// then the proxy. Split out for [`handle_openai_media`].
+async fn forward_openai_request(
+    state: &AppState,
+    headers: &HeaderMap,
+    mut req: serde_json::Value,
+    target: Target,
+    activity: ActivityGuard,
+    response_model_override: Option<String>,
+    llama_path: &str,
+) -> Result<Response, AppError> {
+    let embeddings = llama_path == "/v1/embeddings";
     if let Some(refusal) = unsupported_on_wire(&target, llama_path) {
         drop(activity);
         return Ok(refusal);
@@ -7342,14 +7520,15 @@ async fn handle_openai_embeddings(
 //    /v1/audio/speech) --------------------------------------------------------
 //
 // Pass-throughs to a diffusion model's backend (crate::mediagen::server),
-// like handle_openai_embeddings.
+// like handle_openai_embeddings — except for an `Engine::VllmOmni`
+// backend; see omni_images and omni_videos.
 
 async fn handle_openai_images(
     State(state): State<AppState>,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, AppError> {
-    proxy_openai_passthrough(&state, &headers, body, "/v1/images/generations").await
+    handle_openai_media(&state, &headers, body, "/v1/images/generations").await
 }
 
 async fn handle_openai_videos(
@@ -7357,7 +7536,294 @@ async fn handle_openai_videos(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, AppError> {
-    proxy_openai_passthrough(&state, &headers, body, "/v1/videos").await
+    handle_openai_media(&state, &headers, body, "/v1/videos").await
+}
+
+/// [`proxy_openai_passthrough`], but translated for a vLLM-Omni backend.
+async fn handle_openai_media(
+    state: &AppState,
+    headers: &HeaderMap,
+    body: Bytes,
+    route: &str,
+) -> Result<Response, AppError> {
+    let (req, target, activity, override_) = resolve_openai_request(state, headers, body).await?;
+    if local_engine(state, &target).await == Some(Engine::VllmOmni) {
+        return if route == "/v1/videos" {
+            omni_videos(state, &target, req, activity).await
+        } else {
+            omni_images(state, &target, req, activity).await
+        };
+    }
+    forward_openai_request(state, headers, req, target, activity, override_, route).await
+}
+
+/// The engine behind a [`Target::Local`]; `None` for anything else, or a
+/// backend unloaded since `ensure_model` (the request then fails on its own).
+async fn local_engine(state: &AppState, target: &Target) -> Option<Engine> {
+    let Target::Local(port) = target else {
+        return None;
+    };
+    let mgr = state.0.manager.lock().await;
+    mgr.running
+        .values()
+        .find(|m| m.port == *port)
+        .map(|m| m.process.engine())
+}
+
+// -- vLLM-Omni media dialect --------------------------------------------------
+//
+// `llmman run` and crate::mediagen speak llama-server's image API
+// (`width`/`height`/`steps`/`cfg_scale`, streamed `image_generation.*`
+// events, a synchronous `/v1/videos` job with a `content_url`). vLLM-Omni
+// speaks OpenAI's (`size`, `num_inference_steps`, `guidance_scale`, no
+// image streaming, a multipart asynchronous `/v1/videos`). Fields a
+// client did not send are not invented — the model's defaults apply.
+
+/// llama-server image fields renamed to vLLM-Omni's; `stream` removed and
+/// returned (vLLM-Omni's text-to-image does not stream). `Err` names a
+/// request that cannot be expressed: one dimension without the other
+/// (llama-server fills in a default; vLLM-Omni's `size` needs both).
+fn omni_image_request(mut req: serde_json::Value) -> Result<(serde_json::Value, bool), String> {
+    let stream = req["stream"].as_bool().unwrap_or(false);
+    let Some(obj) = req.as_object_mut() else {
+        return Ok((req, stream));
+    };
+    obj.remove("stream");
+    let dim = |v: Option<serde_json::Value>| v.and_then(|v| v.as_u64()).filter(|n| *n > 0);
+    let (width, height) = (dim(obj.remove("width")), dim(obj.remove("height")));
+    match (width, height) {
+        (Some(w), Some(h)) if !obj.contains_key("size") => {
+            obj.insert("size".into(), serde_json::json!(format!("{w}x{h}")));
+        }
+        (Some(_), None) | (None, Some(_)) => {
+            return Err("vLLM-Omni needs both width and height, or neither".into());
+        }
+        _ => {}
+    }
+    for (llama, omni) in [
+        ("steps", "num_inference_steps"),
+        ("cfg_scale", "guidance_scale"),
+    ] {
+        if let Some(v) = obj.remove(llama) {
+            if !obj.contains_key(omni) && v.as_f64().is_some_and(|n| n > 0.0) {
+                obj.insert(omni.into(), v);
+            }
+        }
+    }
+    if !obj.contains_key("response_format") {
+        obj.insert("response_format".into(), "b64_json".into());
+    }
+    Ok((req, stream))
+}
+
+/// `POST /v1/images/generations` on a vLLM-Omni backend. A streaming
+/// client gets one `image_generation.completed` event per image; a
+/// non-streaming one gets vLLM-Omni's response as is.
+async fn omni_images(
+    state: &AppState,
+    target: &Target,
+    req: serde_json::Value,
+    activity: ActivityGuard,
+) -> Result<Response, AppError> {
+    let (req, stream) = match omni_image_request(req) {
+        Ok(ok) => ok,
+        Err(m) => {
+            drop(activity);
+            return Err(AppError::status(StatusCode::BAD_REQUEST, m));
+        }
+    };
+    let resp = state
+        .0
+        .client
+        .post(target.url("/v1/images/generations"))
+        .json(&req)
+        .send()
+        .await
+        .with_context(|| format!("proxy request to {}", target.describe()))?;
+    if !stream || !resp.status().is_success() {
+        return Ok(relay(resp, activity));
+    }
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .context("decode vllm-omni image response")?;
+    let created = body["created"]
+        .as_i64()
+        .unwrap_or_else(|| chrono::Utc::now().timestamp());
+    let mut events = String::new();
+    for image in body["data"].as_array().into_iter().flatten() {
+        let ev = serde_json::json!({
+            "type": "image_generation.completed",
+            "b64_json": image["b64_json"],
+            "revised_prompt": image["revised_prompt"],
+            "created_at": created,
+        });
+        events.push_str(&format!("data: {ev}\n\n"));
+    }
+    drop(activity);
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        .body(Body::from(events))
+        .context("build image event stream")?)
+}
+
+/// Form fields for vLLM-Omni's `/v1/videos` from a JSON body: llama-server
+/// names renamed (`steps`, `cfg_scale`, `frames`, `audio`), fractional
+/// `seconds` rounded to the whole seconds it takes, everything else by
+/// name (objects as JSON text, which is how it reads `extra_params`).
+fn omni_video_fields(req: &serde_json::Value) -> Vec<(String, String)> {
+    let Some(obj) = req.as_object() else {
+        return Vec::new();
+    };
+    let renamed = |name: &str| match name {
+        "steps" => Some("num_inference_steps"),
+        "cfg_scale" => Some("guidance_scale"),
+        "frames" => Some("num_frames"),
+        "audio" => Some("generate_sound"),
+        _ => None,
+    };
+    let text = |value: &serde_json::Value| match value {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Null => None,
+        other => Some(other.to_string()),
+    };
+    let mut fields: Vec<(String, String)> = Vec::new();
+    // Native names first, so an explicit one wins over its alias.
+    for (name, value) in obj {
+        if matches!(name.as_str(), "stream" | "response_format") || renamed(name).is_some() {
+            continue;
+        }
+        let value = if name == "seconds" {
+            match value.as_f64().or_else(|| value.as_str()?.parse().ok()) {
+                Some(s) if s > 0.0 => {
+                    serde_json::Value::String((s.round().max(1.0) as u64).to_string())
+                }
+                _ => continue,
+            }
+        } else {
+            value.clone()
+        };
+        if let Some(text) = text(&value) {
+            fields.push((name.clone(), text));
+        }
+    }
+    for (name, value) in obj {
+        let Some(native) = renamed(name) else {
+            continue;
+        };
+        if fields.iter().any(|(existing, _)| existing == native) {
+            continue;
+        }
+        if let Some(text) = text(value) {
+            fields.push((native.to_string(), text));
+        }
+    }
+    fields
+}
+
+/// A `multipart/form-data` body of text fields and its `content-type`.
+/// Both come from the caller: a name that is not a plain identifier is
+/// dropped (it would be written into a header), and the boundary is
+/// re-salted until no value contains it.
+fn multipart_form(fields: &[(String, String)]) -> (Vec<u8>, String) {
+    let fields: Vec<&(String, String)> = fields
+        .iter()
+        .filter(|(name, _)| {
+            !name.is_empty() && name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
+        })
+        .collect();
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let boundary = (0u32..)
+        .map(|salt| format!("----llmman{}{stamp:x}{salt:x}", std::process::id()))
+        .find(|b| !fields.iter().any(|(_, v)| v.contains(b.as_str())))
+        .unwrap_or_default();
+    let mut body = Vec::new();
+    for (name, value) in fields {
+        body.extend_from_slice(
+            format!("--{boundary}\r\nContent-Disposition: form-data; name=\"{name}\"\r\n\r\n")
+                .as_bytes(),
+        );
+        body.extend_from_slice(value.as_bytes());
+        body.extend_from_slice(b"\r\n");
+    }
+    body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+    (body, format!("multipart/form-data; boundary={boundary}"))
+}
+
+/// How often [`omni_videos`] polls the job, and how long before it gives up.
+const OMNI_VIDEO_POLL: Duration = Duration::from_secs(1);
+const OMNI_VIDEO_MAX_WAIT: Duration = Duration::from_secs(60 * 60);
+
+/// `POST /v1/videos` on a vLLM-Omni backend: submit the multipart job,
+/// poll `GET /v1/videos/{id}` until `completed`/`failed`, answer with the
+/// job plus the `content_url` [`handle_openai_video_get`] serves.
+async fn omni_videos(
+    state: &AppState,
+    target: &Target,
+    req: serde_json::Value,
+    activity: ActivityGuard,
+) -> Result<Response, AppError> {
+    let (body, content_type) = multipart_form(&omni_video_fields(&req));
+    let resp = state
+        .0
+        .client
+        .post(target.url("/v1/videos"))
+        .header("content-type", content_type)
+        .body(body)
+        .send()
+        .await
+        .with_context(|| format!("proxy request to {}", target.describe()))?;
+    if !resp.status().is_success() {
+        return Ok(relay(resp, activity));
+    }
+    let mut job: serde_json::Value = resp.json().await.context("decode vllm-omni video job")?;
+    let id = job["id"]
+        .as_str()
+        .context("vllm-omni video job has no id")?
+        .to_string();
+    let poll_url = target.url(&format!("/v1/videos/{id}"));
+    let deadline = Instant::now() + OMNI_VIDEO_MAX_WAIT;
+    while !matches!(job["status"].as_str(), Some("completed" | "failed")) {
+        if Instant::now() >= deadline {
+            drop(activity);
+            return Err(AppError::status(
+                StatusCode::GATEWAY_TIMEOUT,
+                format!("video job {id} did not finish within {OMNI_VIDEO_MAX_WAIT:?}"),
+            ));
+        }
+        sleep(OMNI_VIDEO_POLL).await;
+        let resp = state
+            .0
+            .client
+            .get(&poll_url)
+            .timeout(Duration::from_secs(30))
+            .send()
+            .await
+            .with_context(|| format!("poll video job {id} on {}", target.describe()))?;
+        // A failed job comes back as its own error status and JSON body.
+        if !resp.status().is_success() {
+            return Ok(relay(resp, activity));
+        }
+        job = resp.json().await.context("decode vllm-omni video job")?;
+    }
+    drop(activity);
+    if job["status"] == "failed" {
+        let message = job["error"]["message"]
+            .as_str()
+            .unwrap_or("video generation failed")
+            .to_string();
+        let body = serde_json::json!({
+            "error": { "message": message, "type": "server_error" }
+        });
+        return Ok((StatusCode::INTERNAL_SERVER_ERROR, Json(body)).into_response());
+    }
+    job["content_url"] = serde_json::json!(format!("/v1/videos/{id}/content"));
+    Ok(Json(job).into_response())
 }
 
 /// `GET /v1/videos/:id[/content]`: a completed video lives in the
@@ -8631,6 +9097,7 @@ fn pull_oci_engine(model: Option<&str>) -> anyhow::Result<crate::container::Cont
     })?;
     Ok(match format {
         crate::modelpack::ModelFormat::SafeTensors => crate::container::ContainerEngine::Vllm,
+        crate::modelpack::ModelFormat::Omni => crate::container::ContainerEngine::VllmOmni,
         crate::modelpack::ModelFormat::Gguf | crate::modelpack::ModelFormat::Diffusion => {
             crate::container::ContainerEngine::LlamaServer
         }
@@ -8653,7 +9120,8 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         let ociman = _args.ociman.context("--pull-oci requires --ociman")?;
         let engine = pull_oci_engine(_args.model.as_deref())?;
         let version = match engine {
-            crate::container::ContainerEngine::Vllm => _args.vllm_version.as_deref(),
+            crate::container::ContainerEngine::Vllm
+            | crate::container::ContainerEngine::VllmOmni => _args.vllm_version.as_deref(),
             crate::container::ContainerEngine::LlamaServer => _args.llama_cpp_version.as_deref(),
         };
         crate::container::pull_image(ociman, engine, version)?;
@@ -12650,6 +13118,217 @@ mod tests {
             [&args[2..i], &args[i + 2..]].concat()
         };
         assert_eq!(rest(&local), rest(&container));
+    }
+
+    // -- vLLM-Omni (Diffusers-layout models) -----------------------------------
+
+    #[test]
+    fn vllm_omni_serve_args_add_omni_and_disable_guardrails_by_default() {
+        let args = vllm_omni_serve_args(
+            "/models",
+            "0.0.0.0",
+            8000,
+            "nvidia/Cosmos3-Edge",
+            false,
+            Duration::from_secs(600),
+        );
+        // vllm-omni's own recipe: `vllm serve <model> --omni --host --port`
+        assert_eq!(args[0], "serve");
+        assert_eq!(args[1], "/models");
+        assert!(args.contains(&"--omni".to_string()));
+        assert!(args.contains(&"--no-guardrails".to_string()));
+        let i = args.iter().position(|a| a == "--init-timeout").unwrap();
+        assert_eq!(args[i + 1], "600");
+        let i = args
+            .iter()
+            .position(|a| a == "--served-model-name")
+            .unwrap();
+        assert_eq!(args[i + 1], "nvidia/Cosmos3-Edge");
+        // a diffusion pipeline has no context window
+        assert!(!args.contains(&"--max-model-len".to_string()));
+    }
+
+    #[test]
+    fn vllm_omni_serve_args_keep_guardrails_when_asked() {
+        let args = vllm_omni_serve_args("/m", "127.0.0.1", 8000, "m", true, Duration::from_secs(1));
+        assert!(args.contains(&"--omni".to_string()));
+        assert!(!args.contains(&"--no-guardrails".to_string()));
+    }
+
+    #[test]
+    fn vllm_omni_engine_has_its_own_label() {
+        assert_eq!(Engine::VllmOmni.label(), "vllm-omni");
+    }
+
+    #[test]
+    fn console_script_interpreter_reads_a_python_shebang_only() {
+        let dir = std::env::temp_dir().join(format!("llmman-shebang-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let script = dir.join("vllm");
+        std::fs::write(
+            &script,
+            "#!/opt/venv/bin/python3\n# -*- coding: utf-8 -*-\n",
+        )
+        .unwrap();
+        assert_eq!(
+            console_script_interpreter(&script),
+            Some(PathBuf::from("/opt/venv/bin/python3"))
+        );
+        std::fs::write(&script, "#!/usr/bin/env python3\nimport sys\n").unwrap();
+        assert_eq!(console_script_interpreter(&script), None);
+        std::fs::write(&script, "#!/bin/sh\nexec vllm \"$@\"\n").unwrap();
+        assert_eq!(console_script_interpreter(&script), None);
+        std::fs::write(&script, b"\x7fELF\x02\x01\x01").unwrap();
+        assert_eq!(console_script_interpreter(&script), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn omni_image_request_translates_llama_server_fields() {
+        // what `llmman run` (crate::imagegen) sends
+        let req = serde_json::json!({
+            "model": "nvidia/Cosmos3-Edge",
+            "prompt": "a manatee",
+            "stream": true,
+            "response_format": "b64_json",
+            "width": 640,
+            "height": 480,
+            "steps": 8,
+            "seed": 42,
+            "cfg_scale": 5.0,
+            "negative_prompt": "blurry"
+        });
+        let (out, stream) = omni_image_request(req).unwrap();
+        assert!(stream);
+        assert_eq!(
+            out,
+            serde_json::json!({
+                "model": "nvidia/Cosmos3-Edge",
+                "prompt": "a manatee",
+                "response_format": "b64_json",
+                "size": "640x480",
+                "num_inference_steps": 8,
+                "seed": 42,
+                "guidance_scale": 5.0,
+                "negative_prompt": "blurry"
+            })
+        );
+    }
+
+    #[test]
+    fn omni_image_request_leaves_a_native_request_alone_and_invents_nothing() {
+        // A vLLM-Omni-dialect client: nothing renamed, nothing added but
+        // the response format, and no size when none was asked for (the
+        // model's own default is the one that works for Cosmos3-Edge).
+        let req = serde_json::json!({
+            "model": "m", "prompt": "p", "size": "1024x1024",
+            "num_inference_steps": 50, "guidance_scale": 7.0
+        });
+        let (out, stream) = omni_image_request(req.clone()).unwrap();
+        assert!(!stream);
+        let mut expected = req;
+        expected["response_format"] = "b64_json".into();
+        assert_eq!(out, expected);
+        let (out, _) =
+            omni_image_request(serde_json::json!({"model": "m", "prompt": "p"})).unwrap();
+        assert!(out.get("size").is_none());
+        assert!(out.get("num_inference_steps").is_none());
+        // zero means "model default", as it does for llama-server
+        let (out, _) = omni_image_request(
+            serde_json::json!({"prompt": "p", "width": 0, "height": 0, "steps": 0}),
+        )
+        .unwrap();
+        assert!(out.get("size").is_none());
+        assert!(out.get("num_inference_steps").is_none());
+        // an explicit native field wins over a translated one
+        let (out, _) = omni_image_request(
+            serde_json::json!({"prompt": "p", "steps": 8, "num_inference_steps": 30}),
+        )
+        .unwrap();
+        assert_eq!(out["num_inference_steps"], 30);
+        // one dimension without the other cannot be expressed as a `size`
+        let err = omni_image_request(serde_json::json!({"prompt": "p", "width": 768})).unwrap_err();
+        assert!(err.contains("both width and height"), "{err}");
+    }
+
+    #[test]
+    fn omni_video_fields_translate_and_round_seconds() {
+        let req = serde_json::json!({
+            "model": "nvidia/Cosmos3-Edge",
+            "prompt": "waves",
+            "stream": false,
+            "seconds": 2.4,
+            "fps": 24,
+            "steps": 20,
+            "cfg_scale": 5.0,
+            "audio": false,
+            "seed": 7,
+            "extra_params": {"guardrails": false}
+        });
+        let fields: std::collections::HashMap<String, String> =
+            omni_video_fields(&req).into_iter().collect();
+        assert_eq!(fields["model"], "nvidia/Cosmos3-Edge");
+        assert_eq!(fields["prompt"], "waves");
+        assert_eq!(fields["seconds"], "2", "SecondStr is a whole number");
+        assert_eq!(fields["fps"], "24");
+        assert_eq!(fields["num_inference_steps"], "20");
+        assert_eq!(fields["guidance_scale"], "5.0");
+        assert_eq!(fields["generate_sound"], "false");
+        assert_eq!(fields["seed"], "7");
+        assert_eq!(fields["extra_params"], r#"{"guardrails":false}"#);
+        assert!(!fields.contains_key("stream"));
+        assert!(!fields.contains_key("steps"));
+        // sub-second clips round up to one second, not zero
+        let fields: std::collections::HashMap<String, String> =
+            omni_video_fields(&serde_json::json!({"prompt": "p", "seconds": 0.3}))
+                .into_iter()
+                .collect();
+        assert_eq!(fields["seconds"], "1");
+        // `frames` is llama-server's name for num_frames; a native one wins
+        let fields: std::collections::HashMap<String, String> =
+            omni_video_fields(&serde_json::json!({"prompt": "p", "frames": 33, "num_frames": 49}))
+                .into_iter()
+                .collect();
+        assert_eq!(fields["num_frames"], "49");
+    }
+
+    #[test]
+    fn multipart_form_is_well_formed_and_readable_back() {
+        let fields = vec![
+            ("model".to_string(), "m".to_string()),
+            ("prompt".to_string(), "a b\r\nc".to_string()),
+        ];
+        let (body, content_type) = multipart_form(&fields);
+        let boundary = content_type
+            .strip_prefix("multipart/form-data; boundary=")
+            .unwrap();
+        let text = String::from_utf8(body.clone()).unwrap();
+        assert!(text.starts_with(&format!("--{boundary}\r\n")));
+        assert!(text.ends_with(&format!("--{boundary}--\r\n")));
+        // a name that is not an identifier would land in a header: dropped
+        let (filtered, _) = multipart_form(&[
+            ("ok_1".to_string(), "v".to_string()),
+            ("bad\"\r\nX: y".to_string(), "v".to_string()),
+        ]);
+        let filtered = String::from_utf8(filtered).unwrap();
+        assert!(filtered.contains("name=\"ok_1\""));
+        assert!(!filtered.contains("bad"), "{filtered}");
+        // a value containing the would-be boundary forces a different one
+        let (_, ct2) = multipart_form(&[("prompt".to_string(), format!("x{boundary}y"))]);
+        assert_ne!(ct2, content_type);
+        // and the same parser the daemon uses for uploads agrees
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", content_type.parse().unwrap());
+        let body = Bytes::from(body);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        assert_eq!(
+            rt.block_on(multipart_text_field(&body, &headers, "prompt")),
+            Some("a b\r\nc".to_string())
+        );
+        assert_eq!(
+            rt.block_on(multipart_text_field(&body, &headers, "model")),
+            Some("m".to_string())
+        );
     }
 
     /// `/api/embed` takes a string or an array of strings, and nothing

--- a/src/cmd/show.rs
+++ b/src/cmd/show.rs
@@ -68,14 +68,18 @@ pub fn run(args: &ShowArgs) -> anyhow::Result<()> {
                 None
             }
         },
-        ModelPath::SafeTensors(_) | ModelPath::Diffusion(_) => None,
+        ModelPath::SafeTensors(_) | ModelPath::Diffusion(_) | ModelPath::Omni(_) => None,
     };
     let safetensors_config = match &resolved {
-        ModelPath::SafeTensors(dir) => read_json_file(&dir.join("config.json")),
+        ModelPath::SafeTensors(dir) | ModelPath::Omni(dir) => {
+            read_json_file(&dir.join("config.json"))
+        }
         ModelPath::Gguf(..) | ModelPath::Diffusion(_) => None,
     };
     let tokenizer_config = match &resolved {
-        ModelPath::SafeTensors(dir) => read_json_file(&dir.join("tokenizer_config.json")),
+        ModelPath::SafeTensors(dir) | ModelPath::Omni(dir) => {
+            read_json_file(&dir.join("tokenizer_config.json"))
+        }
         ModelPath::Gguf(..) | ModelPath::Diffusion(_) => None,
     };
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -243,6 +243,24 @@ impl VllmBackend {
         Ok(format!("docker.io/vllm/{repo}:{v}-{suffix}"))
     }
 
+    /// The `vllm/vllm-omni` image for a Diffusers-layout model: CUDA only,
+    /// `<version>-{x86_64,aarch64}`; `version` is vLLM-Omni's release.
+    fn omni_image_ref(self, arch: HostArch, version: Option<&str>) -> Result<String> {
+        let v = version.unwrap_or("latest");
+        let suffix = match (self, arch) {
+            (VllmBackend::Cuda12 | VllmBackend::Cuda13, HostArch::X86_64) => "x86_64",
+            (VllmBackend::Cuda12 | VllmBackend::Cuda13, HostArch::Aarch64) => "aarch64",
+            (VllmBackend::Rocm, _) => anyhow::bail!(
+                "an AMD GPU was detected, but vllm/vllm-omni publishes only CUDA images \
+                 (install vllm-omni locally and drop --ociman to serve this model)"
+            ),
+            (VllmBackend::Cpu, _) => anyhow::bail!(
+                "no CUDA GPU was detected, and vllm/vllm-omni publishes only CUDA images"
+            ),
+        };
+        Ok(format!("docker.io/vllm/vllm-omni:{v}-{suffix}"))
+    }
+
     /// GPU passthrough plus what vLLM's deployment docs ask for: `--ipc=host`
     /// (its workers share tensors over `/dev/shm`) and, for the CPU image,
     /// `SYS_NICE` and an unconfined seccomp profile for NUMA thread binding.
@@ -270,6 +288,8 @@ pub enum ContainerEngine {
     LlamaServer,
     /// `vllm/vllm-openai`, `rocm/vllm` or `vllm/vllm-openai-cpu` (safetensors).
     Vllm,
+    /// `vllm/vllm-omni` (Diffusers-layout safetensors: `vllm serve --omni`).
+    VllmOmni,
 }
 
 /// The image [`spawn`] / [`spawn_vllm`] would run here for `engine`.
@@ -279,6 +299,10 @@ fn image_for(engine: ContainerEngine, version: Option<&str>) -> Result<String> {
         ContainerEngine::Vllm => {
             let (backend, arch) = VllmBackend::detect()?;
             backend.image_ref(arch, version)
+        }
+        ContainerEngine::VllmOmni => {
+            let (backend, arch) = VllmBackend::detect()?;
+            backend.omni_image_ref(arch, version)
         }
     }
 }
@@ -560,21 +584,28 @@ fn run_args(engine_args: Vec<String>, port: u16, passthrough_vars: &[&str]) -> V
 }
 
 /// The vLLM counterpart of [`spawn`]: `vllm serve` on a safetensors
-/// directory (mounted at `/models`) in the image [`VllmBackend`] picks.
+/// directory (mounted at `/models`) in the image [`VllmBackend`] picks for
+/// `engine` (`Vllm` or `VllmOmni`; same `vllm` binary and mount).
 /// `serve_args` builds the argv after `vllm` from the in-container model
-/// dir and bind address, so it's `cmd::serve::vllm_serve_args` unchanged.
-/// `--entrypoint vllm` is explicit because `rocm/vllm`'s default is a
-/// shell. Every `VLLM_*` env var is forwarded, as a local child would
-/// inherit them.
+/// dir and bind address. `--entrypoint vllm` is explicit because
+/// `rocm/vllm`'s default is a shell and `vllm/vllm-omni`'s is empty.
+/// Every `VLLM_*` env var is forwarded, as a local child would inherit
+/// them, plus the Hub token variables (guardrail downloads).
 pub fn spawn_vllm(
     ociman: ContainerManager,
+    engine: ContainerEngine,
     model_dir: &Path,
     vllm_version: Option<&str>,
     port: u16,
     serve_args: impl FnOnce(&str, &str) -> Vec<String>,
 ) -> Result<tokio::process::Child> {
     let (backend, arch) = VllmBackend::detect()?;
-    let image = backend.image_ref(arch, vllm_version)?;
+    let image = match engine {
+        ContainerEngine::VllmOmni => backend.omni_image_ref(arch, vllm_version)?,
+        ContainerEngine::Vllm | ContainerEngine::LlamaServer => {
+            backend.image_ref(arch, vllm_version)?
+        }
+    };
     eprintln!(
         "[llmman] {}: detected {:?} on {:?}, using image {:?}",
         ociman.binary(),
@@ -585,7 +616,9 @@ pub fn spawn_vllm(
     let model_dir = mount_source(model_dir)?;
     let vllm_vars: Vec<String> = std::env::vars_os()
         .filter_map(|(k, _)| k.into_string().ok())
-        .filter(|k| k.starts_with("VLLM_"))
+        .filter(|k| {
+            k.starts_with("VLLM_") || matches!(k.as_str(), "HF_TOKEN" | "HUGGING_FACE_HUB_TOKEN")
+        })
         .collect();
     let vllm_vars: Vec<&str> = vllm_vars.iter().map(String::as_str).collect();
     let args = vllm_run_args(backend, image, &model_dir, port, &vllm_vars, serve_args);
@@ -956,6 +989,42 @@ mod tests {
             .to_string();
         assert!(err.contains("rocm/vllm"), "{err}");
         assert!(err.contains("LLMMAN_LLM_LIBRARY=cpu"), "{err}");
+    }
+
+    #[test]
+    fn vllm_omni_image_refs_match_docker_hub_tag_spellings() {
+        // hub.docker.com/r/vllm/vllm-omni/tags: latest-x86_64, latest-aarch64,
+        // v0.28.0-x86_64, ... — one CUDA build, no -cu129 variant.
+        for cuda in [VllmBackend::Cuda12, VllmBackend::Cuda13] {
+            assert_eq!(
+                cuda.omni_image_ref(HostArch::X86_64, None).unwrap(),
+                "docker.io/vllm/vllm-omni:latest-x86_64"
+            );
+            assert_eq!(
+                cuda.omni_image_ref(HostArch::Aarch64, None).unwrap(),
+                "docker.io/vllm/vllm-omni:latest-aarch64"
+            );
+            assert_eq!(
+                cuda.omni_image_ref(HostArch::Aarch64, Some("v0.28.0"))
+                    .unwrap(),
+                "docker.io/vllm/vllm-omni:v0.28.0-aarch64"
+            );
+        }
+    }
+
+    #[test]
+    fn vllm_omni_has_only_cuda_images() {
+        let err = VllmBackend::Rocm
+            .omni_image_ref(HostArch::X86_64, None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("vllm/vllm-omni"), "{err}");
+        assert!(err.contains("--ociman"), "{err}");
+        let err = VllmBackend::Cpu
+            .omni_image_ref(HostArch::X86_64, None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("CUDA"), "{err}");
     }
 
     #[test]

--- a/src/hf/api.rs
+++ b/src/hf/api.rs
@@ -276,6 +276,81 @@ fn basename_lower(path: &str) -> String {
     path.rsplit('/').next().unwrap_or(path).to_lowercase()
 }
 
+/// A Diffusers pipeline in safetensors (a root `model_index.json`, e.g.
+/// `nvidia/Cosmos3-Edge`): pulled as safetensors, served by vLLM-Omni.
+pub fn is_diffusers_repo(files: &[HfFile]) -> bool {
+    files
+        .iter()
+        .any(|f| f.kind == "file" && f.path == crate::modelpack::DIFFUSERS_MODEL_INDEX)
+        && files
+            .iter()
+            .any(|f| f.kind == "file" && basename_lower(&f.path).ends_with(".safetensors"))
+}
+
+/// Substrings of the `_class_name`s vLLM-Omni registers with
+/// `final_output_type="video"` (its `diffusion/registry.py`), lowercased.
+const VIDEO_PIPELINE_HINTS: &[&str] = &[
+    "video",
+    "omni",
+    "cosmos",
+    "wan",
+    "ltx",
+    "magi",
+    "helios",
+    "lingbot",
+    "longcat",
+    "minimaxh3",
+];
+
+/// A Diffusers pipeline's `outputTypes` from its `_class_name`: the video
+/// families vLLM-Omni serves also make video, anything else only images.
+pub fn diffusers_outputs(class_name: Option<&str>) -> Vec<&'static str> {
+    let lower = class_name.unwrap_or("").to_lowercase();
+    if VIDEO_PIPELINE_HINTS.iter().any(|h| lower.contains(h)) {
+        vec!["image", "video"]
+    } else {
+        vec!["image"]
+    }
+}
+
+/// [`diffusers_pipeline_class`] for a transfer, which keeps no layers:
+/// fetches the index from the Hub. `None` on failure.
+pub async fn fetch_diffusers_pipeline_class(
+    client: &reqwest::Client,
+    endpoint: &str,
+    owner: &str,
+    repo: &str,
+    commit: &str,
+    token: Option<&str>,
+) -> Option<String> {
+    let url = format!(
+        "{endpoint}{owner}/{repo}/resolve/{commit}/{}",
+        crate::modelpack::DIFFUSERS_MODEL_INDEX
+    );
+    pipeline_class(&get_json(client, &url, token).await.ok()?)
+}
+
+fn pipeline_class(index: &serde_json::Value) -> Option<String> {
+    index.get("_class_name")?.as_str().map(str::to_string)
+}
+
+/// The `_class_name` of the pipeline index among `layers`, already
+/// downloaded into the OCI layout at `layout_dir`.
+pub fn diffusers_pipeline_class(
+    layout_dir: &std::path::Path,
+    layers: &[oci::Descriptor],
+) -> Option<String> {
+    let index = layers.iter().find(|d| {
+        d.annotations
+            .as_ref()
+            .and_then(|a| a.get(oci::ANNOTATION_FILEPATH))
+            .is_some_and(|p| p == crate::modelpack::DIFFUSERS_MODEL_INDEX)
+    })?;
+    let hex = index.digest.strip_prefix("sha256:")?;
+    let bytes = std::fs::read(layout_dir.join("blobs").join("sha256").join(hex)).ok()?;
+    pipeline_class(&serde_json::from_slice(&bytes).ok()?)
+}
+
 /// Like [`select_gguf`], but when no quant is requested prefers the fast
 /// `distilled` variant that diffusion repos ship next to the `dev` one.
 pub fn select_diffusion_gguf(files: &[HfFile], tag: &str) -> Result<Vec<HfFile>> {
@@ -721,5 +796,84 @@ mod tests {
             None
         );
         assert_eq!(diffusion_default_text_encoder("flux-dev-Q8_0.gguf"), None);
+    }
+
+    /// `nvidia/Cosmos3-Edge`'s listing (weights only; assets elided).
+    fn cosmos3_repo() -> Vec<HfFile> {
+        vec![
+            file("README.md", 10),
+            file("config.json", 1),
+            file("model_index.json", 1),
+            file("model.safetensors.index.json", 1),
+            file("scheduler/scheduler_config.json", 1),
+            file("transformer/config.json", 1),
+            file(
+                "transformer/diffusion_pytorch_model-00001-of-00002.safetensors",
+                5,
+            ),
+            file(
+                "transformer/diffusion_pytorch_model-00002-of-00002.safetensors",
+                2,
+            ),
+            file("vae/config.json", 1),
+            file("vae/diffusion_pytorch_model.safetensors", 1),
+            file("vision_encoder/model.safetensors", 1),
+            file("assets/example_i2v_input.jpg", 1),
+        ]
+    }
+
+    #[test]
+    fn diffusers_repo_is_detected_by_its_root_pipeline_index() {
+        let files = cosmos3_repo();
+        assert!(is_diffusers_repo(&files));
+        // Not the GGUF-sidecar kind: nothing in it is named like an LTX VAE,
+        // so it must fall through to the safetensors pull, nested paths intact.
+        assert!(!is_diffusion_repo(&files));
+        assert!(select_gguf(&files, "").is_err());
+        let picked = select_downloadable_hf_files(&files);
+        let paths: Vec<&str> = picked.iter().map(|f| f.path.as_str()).collect();
+        assert!(paths.contains(&"model_index.json"));
+        assert!(paths.contains(&"vae/diffusion_pytorch_model.safetensors"));
+        assert!(paths.contains(&"transformer/config.json"));
+        assert!(!paths.contains(&"assets/example_i2v_input.jpg"));
+        // A plain LLM repo, and an index without weights, are not one.
+        assert!(!is_diffusers_repo(&[
+            file("config.json", 1),
+            file("model.safetensors", 1)
+        ]));
+        assert!(!is_diffusers_repo(&[file("model_index.json", 1)]));
+        // A nested index does not make the repo a pipeline.
+        assert!(!is_diffusers_repo(&[
+            file("model.safetensors", 1),
+            file("demo/model_index.json", 1)
+        ]));
+    }
+
+    #[test]
+    fn diffusers_outputs_follow_the_pipeline_class() {
+        assert_eq!(
+            diffusers_outputs(Some("Cosmos3OmniPipeline")),
+            vec!["image", "video"]
+        );
+        for video in [
+            "WanPipeline",
+            "LTX2Pipeline",
+            "HunyuanVideo15Pipeline",
+            "Magi2Pipeline",
+        ] {
+            assert_eq!(
+                diffusers_outputs(Some(video)),
+                vec!["image", "video"],
+                "{video}"
+            );
+        }
+        for image in ["QwenImagePipeline", "FluxPipeline", "LancePipeline"] {
+            assert_eq!(diffusers_outputs(Some(image)), vec!["image"], "{image}");
+        }
+        assert_eq!(
+            diffusers_outputs(None),
+            vec!["image"],
+            "unknown: at least an image model"
+        );
     }
 }

--- a/src/hf/pull.rs
+++ b/src/hf/pull.rs
@@ -223,6 +223,12 @@ pub async fn pull(reference: &str, layout_dir: &Path, progress_key: &str) -> Res
                     .await?;
             indexed_layers.sort_by_key(|(i, _)| *i);
             let layers: Vec<Descriptor> = indexed_layers.into_iter().map(|(_, d)| d).collect();
+            // A Diffusers pipeline (served by vLLM-Omni) generates media,
+            // not text: say so in the config, as a GGUF diffusion pull does.
+            if api::is_diffusers_repo(&files) {
+                let class = api::diffusers_pipeline_class(layout_dir, &layers);
+                meta.diffusion_outputs = api::diffusers_outputs(class.as_deref());
+            }
             oci::build_cncf_manifest(layout_dir, &meta, &format!("{owner}/{repo}"), "", layers)?
         }
     };

--- a/src/hf/transfer.rs
+++ b/src/hf/transfer.rs
@@ -261,6 +261,19 @@ mod docker {
                     )]));
                     layers.push(d);
                 }
+                // See the same step in pull.rs.
+                if api::is_diffusers_repo(&files) {
+                    let class = api::fetch_diffusers_pipeline_class(
+                        &api_client,
+                        &endpoint,
+                        &owner,
+                        &repo,
+                        &commit,
+                        token.as_deref(),
+                    )
+                    .await;
+                    meta.diffusion_outputs = api::diffusers_outputs(class.as_deref());
+                }
                 (layers, String::new())
             }
         };

--- a/src/modelpack.rs
+++ b/src/modelpack.rs
@@ -37,7 +37,14 @@ pub enum ModelPath {
     /// plus the sidecars pulled next to it (see
     /// `crate::hf::oci::ANNOTATION_ROLE`).
     Diffusion(DiffusionPaths),
+    /// A Diffusers-layout safetensors directory (a root `model_index.json`,
+    /// weights in `transformer/`, `vae/`, ...) such as `nvidia/Cosmos3-Edge`
+    /// — served by vLLM-Omni (`vllm serve --omni`); plain vllm cannot.
+    Omni(PathBuf),
 }
+
+/// The Diffusers pipeline index that marks a [`ModelPath::Omni`] repo.
+pub const DIFFUSERS_MODEL_INDEX: &str = "model_index.json";
 
 /// The files of a resolved [`ModelPath::Diffusion`] model.
 #[derive(Debug, Clone, Default)]
@@ -61,7 +68,7 @@ impl ModelPath {
     pub fn path(&self) -> &Path {
         match self {
             ModelPath::Gguf(p, _) => p,
-            ModelPath::SafeTensors(p) => p,
+            ModelPath::SafeTensors(p) | ModelPath::Omni(p) => p,
             ModelPath::Diffusion(d) => &d.model,
         }
     }
@@ -73,7 +80,7 @@ impl ModelPath {
     pub fn mmproj(&self) -> Option<&Path> {
         match self {
             ModelPath::Gguf(_, mmproj) => mmproj.as_deref(),
-            ModelPath::SafeTensors(_) | ModelPath::Diffusion(_) => None,
+            ModelPath::SafeTensors(_) | ModelPath::Diffusion(_) | ModelPath::Omni(_) => None,
         }
     }
 
@@ -85,6 +92,7 @@ impl ModelPath {
             ModelPath::Gguf(..) => "gguf",
             ModelPath::SafeTensors(_) => "safetensors",
             ModelPath::Diffusion(_) => "diffusion",
+            ModelPath::Omni(_) => "omni",
         }
     }
 }
@@ -129,6 +137,19 @@ fn is_safetensors_layer(l: &crate::storage::oci::Descriptor) -> bool {
     layer_filepath(l)
         .map(|p| p.to_lowercase().ends_with(".safetensors"))
         .unwrap_or(false)
+}
+
+/// The layer holding the repo's *root* `model_index.json` (a Diffusers
+/// pipeline index; a nested one is some vendored pipeline's, not this
+/// repo's).
+fn is_diffusers_index_layer(l: &crate::storage::oci::Descriptor) -> bool {
+    layer_filepath(l) == Some(DIFFUSERS_MODEL_INDEX)
+}
+
+/// A Diffusers-layout repo: a root `model_index.json` next to safetensors.
+fn is_diffusers_manifest(manifest: &crate::storage::oci::Manifest) -> bool {
+    manifest.layers.iter().any(is_diffusers_index_layer)
+        && manifest.layers.iter().any(is_safetensors_layer)
 }
 
 /// True if a (already-confirmed-GGUF) layer looks like a multimodal
@@ -316,10 +337,12 @@ pub fn capabilities(store: &OciStore, manifest: &crate::storage::oci::Manifest) 
     };
 
     // A diffusion model generates media instead of text: its capabilities
-    // are exactly the output types it was pulled with.
+    // are exactly the output types it was pulled with. A Diffusers-layout
+    // repo pulled before those were recorded still generates images.
     let outputs = config_types("outputTypes");
     if outputs.iter().any(|t| t == CAPABILITY_IMAGE)
         || manifest.layers.iter().any(|l| layer_role(l).is_some())
+        || is_diffusers_manifest(manifest)
     {
         let mut caps: Vec<String> = outputs
             .into_iter()
@@ -374,15 +397,19 @@ pub enum ModelFormat {
     Gguf,
     SafeTensors,
     Diffusion,
+    /// Diffusers-layout safetensors — see [`ModelPath::Omni`].
+    Omni,
 }
 
-/// [`resolve_model`]'s classification: diffusion > GGUF > safetensors,
-/// `None` for "no servable model layer".
+/// [`resolve_model`]'s classification: diffusion > GGUF > Diffusers
+/// (omni) > safetensors, `None` for "no servable model layer".
 fn manifest_format(manifest: &crate::storage::oci::Manifest) -> Option<ModelFormat> {
     if manifest.layers.iter().any(|l| layer_role(l).is_some()) {
         Some(ModelFormat::Diffusion)
     } else if gguf_layers(manifest).is_some() {
         Some(ModelFormat::Gguf)
+    } else if is_diffusers_manifest(manifest) {
+        Some(ModelFormat::Omni)
     } else if manifest.layers.iter().any(is_safetensors_layer) {
         Some(ModelFormat::SafeTensors)
     } else {
@@ -403,7 +430,7 @@ fn no_servable_layer(model_ref: &str, manifest: &crate::storage::oci::Manifest) 
     } else {
         anyhow!(
             "no servable model layer in {model_ref} — found {exts:?} files; \
-             llmman serve supports GGUF (llama-server) and safetensors (vllm/mlx)"
+             llmman serve supports GGUF (llama-server) and safetensors (vllm/vllm-omni/mlx)"
         )
     }
 }
@@ -493,14 +520,39 @@ pub fn resolve_model(
         return Ok(ModelPath::Gguf(primary_path, mmproj_path));
     }
 
-    // ── safetensors → vllm / mlx_lm.server ──────────────────────────────
-    debug_assert_eq!(format, ModelFormat::SafeTensors);
+    // ── safetensors → vllm / vllm-omni / mlx_lm.server ──────────────────
     let model_dir = extract_safetensors_dir(store_path, cache_path, &desc.digest, &manifest)?;
-    Ok(ModelPath::SafeTensors(model_dir))
+    Ok(match format {
+        ModelFormat::Omni => ModelPath::Omni(model_dir),
+        _ => {
+            debug_assert_eq!(format, ModelFormat::SafeTensors);
+            ModelPath::SafeTensors(model_dir)
+        }
+    })
+}
+
+/// The model directory of an extracted checkout: the parent of the
+/// shallowest `config.json` or `model_index.json` (a Diffusers repo has a
+/// `config.json` per component, so "first in layer order" is wrong), else
+/// the checkout root.
+fn safetensors_model_dir(cache_dir: &Path, rel_paths: &[&str]) -> PathBuf {
+    rel_paths
+        .iter()
+        .filter(|p| {
+            Path::new(p)
+                .file_name()
+                .is_some_and(|n| n == "config.json" || n == DIFFUSERS_MODEL_INDEX)
+        })
+        .min_by_key(|p| p.matches('/').count())
+        .and_then(|p| Path::new(p).parent())
+        // `join("")` would leave a trailing separator on the root case.
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .map(|parent| cache_dir.join(parent))
+        .unwrap_or_else(|| cache_dir.to_path_buf())
 }
 
 /// Extract CNCF-format safetensors layers to a cache directory and return the
-/// model directory (parent of `config.json`).
+/// model directory (see [`safetensors_model_dir`]).
 fn extract_safetensors_dir(
     store_path: &Path,
     cache_path: &Path,
@@ -545,24 +597,13 @@ fn extract_safetensors_dir(
         eprintln!("[llmman] extracted {rel_path}");
     }
 
-    // Model dir = parent of config.json
-    for layer in &manifest.layers {
-        let Some(rel_path) = layer_filepath(layer) else {
-            continue;
-        };
-        if Path::new(rel_path)
-            .file_name()
-            .map(|n| n == "config.json")
-            .unwrap_or(false)
-        {
-            let config = cache_dir.join(rel_path);
-            return config
-                .parent()
-                .map(|p| p.to_path_buf())
-                .ok_or_else(|| anyhow!("config.json has no parent directory"));
-        }
-    }
-    Ok(cache_dir)
+    let rel_paths: Vec<&str> = manifest
+        .layers
+        .iter()
+        .filter_map(layer_filepath)
+        .filter(|p| crate::sources::is_safe_relative_path(p))
+        .collect();
+    Ok(safetensors_model_dir(&cache_dir, &rel_paths))
 }
 
 #[cfg(test)]
@@ -760,6 +801,111 @@ mod tests {
         assert_eq!(manifest_format(&m), Some(ModelFormat::Diffusion));
         let (_, m) = manifest_with(vec![descriptor("sha256:a", "README.md")]);
         assert_eq!(manifest_format(&m), None);
+    }
+
+    /// The layers `llmman pull nvidia/Cosmos3-Edge` records (the
+    /// Diffusers layout: a root pipeline index, per-component subdirs).
+    fn cosmos3_layers() -> Vec<crate::storage::oci::Descriptor> {
+        vec![
+            descriptor("sha256:a", "config.json"),
+            descriptor("sha256:b", "model_index.json"),
+            descriptor("sha256:c", "scheduler/scheduler_config.json"),
+            descriptor("sha256:d", "transformer/config.json"),
+            descriptor(
+                "sha256:e",
+                "transformer/diffusion_pytorch_model-00001-of-00002.safetensors",
+            ),
+            descriptor("sha256:f", "vae/config.json"),
+            descriptor("sha256:g", "vae/diffusion_pytorch_model.safetensors"),
+            descriptor("sha256:h", "vision_encoder/model.safetensors"),
+        ]
+    }
+
+    #[test]
+    fn a_root_model_index_makes_a_safetensors_repo_omni() {
+        let (_, m) = manifest_with(cosmos3_layers());
+        assert_eq!(manifest_format(&m), Some(ModelFormat::Omni));
+        // a GGUF transformer with role-annotated sidecars still wins
+        let mut layers = cosmos3_layers();
+        let mut vae = descriptor("sha256:z", "vae.safetensors");
+        vae.annotations.get_or_insert_with(Default::default).insert(
+            crate::hf::oci::ANNOTATION_ROLE.to_string(),
+            "vae".to_string(),
+        );
+        layers.push(descriptor("sha256:y", "ltx.gguf"));
+        layers.push(vae);
+        let (_, m) = manifest_with(layers);
+        assert_eq!(manifest_format(&m), Some(ModelFormat::Diffusion));
+    }
+
+    #[test]
+    fn a_nested_model_index_or_one_without_weights_is_not_omni() {
+        // A pipeline vendored inside an LLM repo does not make it one.
+        let (_, m) = manifest_with(vec![
+            descriptor("sha256:a", "config.json"),
+            descriptor("sha256:b", "model.safetensors"),
+            descriptor("sha256:c", "examples/pipeline/model_index.json"),
+        ]);
+        assert_eq!(manifest_format(&m), Some(ModelFormat::SafeTensors));
+        // An index with nothing to serve is still nothing to serve.
+        let (_, m) = manifest_with(vec![descriptor("sha256:a", "model_index.json")]);
+        assert_eq!(manifest_format(&m), None);
+    }
+
+    #[test]
+    fn capabilities_of_an_omni_model_are_media_even_without_recorded_outputs() {
+        // Pulled before the pull recorded outputTypes: still not a chat model.
+        let (store, m) = manifest_with(cosmos3_layers());
+        assert_eq!(capabilities(&store, &m), vec!["image"]);
+        let (store, mut m) = manifest_with(cosmos3_layers());
+        m.config = store
+            .write_blob(
+                "application/vnd.cncf.model.config.v1+json",
+                br#"{"config":{"format":"safetensors","capabilities":{"inputTypes":["text"],"outputTypes":["image","video"]}}}"#,
+            )
+            .unwrap();
+        assert_eq!(capabilities(&store, &m), vec!["image", "video"]);
+    }
+
+    #[test]
+    fn model_dir_is_the_parent_of_the_shallowest_config_json() {
+        let cache = Path::new("/cache/abc");
+        // Diffusers: transformer/config.json is listed before the root one.
+        let dir = safetensors_model_dir(
+            cache,
+            &[
+                "transformer/config.json",
+                "vae/config.json",
+                "config.json",
+                "model_index.json",
+            ],
+        );
+        assert_eq!(dir, cache);
+        // A plain LLM checkout, as before.
+        assert_eq!(
+            safetensors_model_dir(cache, &["config.json", "model.safetensors"]),
+            cache
+        );
+        // A repo whose only config.json is nested still resolves into it.
+        assert_eq!(
+            safetensors_model_dir(cache, &["sub/config.json", "sub/model.safetensors"]),
+            cache.join("sub")
+        );
+        // A pure Diffusers repo: no root config.json, only the pipeline
+        // index there and a config.json per component.
+        assert_eq!(
+            safetensors_model_dir(cache, &["vae/config.json", "model_index.json"]),
+            cache
+        );
+        assert_eq!(safetensors_model_dir(cache, &["a.safetensors"]), cache);
+    }
+
+    #[test]
+    fn omni_variant_reports_its_format_and_path() {
+        let p = ModelPath::Omni(PathBuf::from("/cache/cosmos"));
+        assert_eq!(p.format(), "omni");
+        assert_eq!(p.path(), Path::new("/cache/cosmos"));
+        assert_eq!(p.mmproj(), None);
     }
 
     #[test]


### PR DESCRIPTION
`llmman run nvidia/Cosmos3-Edge "..."` now works, with and without `--ociman`, by forking vLLM-Omni (`vllm serve --omni`) for Diffusers-layout safetensors repos. Before, a repo with a root `model_index.json` was classified as a plain LLM and handed to `vllm serve`, which cannot load it.

- **Detection**: `ModelFormat::Omni` / `ModelPath::Omni` for a manifest with a root `model_index.json`. The pull records `outputTypes: [image, video]` from the pipeline `_class_name` so `llmman run` uses the image client. Extracted model dir is now the *shallowest* `config.json`/`model_index.json` (Diffusers repos have one per component).
- **Local**: `vllm serve <dir> --omni --no-guardrails --init-timeout <LLMMAN_LOAD_TIMEOUT>` from the `vllm` on PATH, after a bounded check that its Python can `import vllm_omni`.
- **`--ociman`**: `vllm/vllm-omni:<version|latest>-<arch>` (CUDA only); `--pull-oci` maps to it.
- **Dialect bridge**: the media routes translate llama-server's dialect (`width`/`height`/`steps`/`cfg_scale`, streamed `image_generation.*`, sync `/v1/videos` job with `content_url`) to vLLM-Omni's (`size`/`num_inference_steps`/`guidance_scale`, multipart async `/v1/videos` polled to completion). Native requests pass through; unsent fields keep the model's defaults.
- **Guardrails** off by default: they need `cosmos-guardrail` plus a gated Hub download the served model lacks, and the server refuses to start without them. `LLMMAN_VLLM_OMNI_GUARDRAILS=1` keeps them on.

## Verification

DGX Spark (GB10, CUDA 13), `nvidia/Cosmos3-Edge`:

| | without `--ociman` | `--ociman docker` |
|---|---|---|
| `llmman ps` | `vllm-omni (local)` | `vllm-omni (container/docker)` |
| `llmman run … "prompt"` | 640×640 PNG, 67 s cold | 640×640 PNG, 73 s cold |
| `--video --seconds 2` | 832×480, 49 frames, 31 s | same, 32 s |
| native API / `--audio` | works / clean 400 | works / clean 400 |
| unload | worker tree + GPU memory freed | container removed |

fmt, clippy `-D warnings`, 853 unit tests, and the podman feature build are clean.

Cosmos3-Edge is also a text reasoner; a Diffusers-layout repo now always goes to vLLM-Omni, so chat against it is not a supported path.
