### PR TITLE
feat(mediagen): run the ai/cosmos3-* GGUFs on ggml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if 1.0.4",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +689,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -688,6 +708,21 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -750,6 +785,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +804,15 @@ checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
  "bytes",
  "either",
+]
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -803,7 +853,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -899,6 +949,21 @@ checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if 1.0.4",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1022,6 +1087,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1150,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1207,37 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn 2.0.117",
 ]
 
@@ -1201,10 +1360,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "filetime"
@@ -1388,6 +1573,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
@@ -1395,8 +1592,8 @@ dependencies = [
  "cfg-if 1.0.4",
  "js-sys",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -1640,7 +1837,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1772,6 +1969,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,6 +1993,21 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -2014,7 +2232,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "clap",
@@ -2023,6 +2241,7 @@ dependencies = [
  "futures",
  "hex",
  "hf-xet",
+ "image",
  "indicatif",
  "libc",
  "libloading",
@@ -2033,6 +2252,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tar",
+ "tokenizers",
  "tokio",
  "tokio-util",
  "toml",
@@ -2082,6 +2302,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ae8f6d608c795738406608304d30a2dfbdc8e58e44f7ba43236da5208ded3c"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "pastey",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2119,6 +2355,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2140,10 +2382,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "more-asserts"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
 
 [[package]]
 name = "multer"
@@ -2160,6 +2434,16 @@ dependencies = [
  "mime",
  "spin 0.9.9",
  "version_check",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2301,6 +2585,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2647,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,6 +2681,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2389,6 +2707,12 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quinn"
@@ -2420,7 +2744,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.2",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -2458,9 +2782,25 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -2470,7 +2810,26 @@ checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2485,7 +2844,38 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools",
+ "rayon",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2578,7 +2968,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -2623,7 +3013,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3083,6 +3473,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3338,6 +3740,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "fancy-regex",
+ "getrandom 0.3.4",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "paste",
+ "rand 0.9.5",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3372,7 +3807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
 dependencies = [
  "pin-project-lite",
- "rand",
+ "rand 0.10.2",
  "tokio",
 ]
 
@@ -3629,6 +4064,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3639,6 +4089,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unit-prefix"
@@ -4365,14 +4821,14 @@ checksum = "c3b8da8cc70aa2e3c500c0400e012df82c656ab9fca47f9f939fffc5afd89aca"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "crc32fast",
  "futures",
  "http 1.4.0",
  "hyper",
  "more-asserts",
- "rand",
+ "rand 0.10.2",
  "redb",
  "reqwest 0.13.4",
  "reqwest-middleware",
@@ -4400,7 +4856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73503c223783dccc864abde22115e09d12f190448a0baf58ab2c54bc709e2f99"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "blake3",
  "bytemuck",
  "bytes",
@@ -4412,7 +4868,7 @@ dependencies = [
  "itertools",
  "lz4_flex",
  "more-asserts",
- "rand",
+ "rand 0.10.2",
  "regex",
  "safe-transmute",
  "serde",
@@ -4440,7 +4896,7 @@ dependencies = [
  "http 1.4.0",
  "itertools",
  "more-asserts",
- "rand",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -4480,7 +4936,7 @@ dependencies = [
  "more-asserts",
  "oneshot",
  "pin-project",
- "rand",
+ "rand 0.10.2",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -4525,6 +4981,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4620,4 +5096,19 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,11 @@ flate2     = "1"
 zip        = { version = "2", default-features = false, features = ["deflate"] }
 libloading = "0.8"
 multer     = "3"
+# Cosmos3 prompts are tokenized from the pack's tokenizer.json (mediagen::cosmos3);
+# pure-Rust build, the pre-tokenizer regexes need fancy-regex's lookahead.
+tokenizers = { version = "0.22", default-features = false, features = ["fancy-regex"] }
+# conditioning images for image-to-video and action runs
+image      = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 
 # Real Xet-protocol downloads for HuggingFace files too large for the
 # plain-HTTP path to reliably serve — see src/xet_fetch.rs. Its

--- a/README.md
+++ b/README.md
@@ -127,8 +127,40 @@ Without a prompt it opens a `>>> ` loop where `/set width|height|steps|seed|cfg|
 adjusts the settings. The same model answers `/v1/images/generations`, `/v1/videos` and
 `/v1/audio/speech` on `llmman serve`.
 
-A Diffusers-layout safetensors repository (a root `model_index.json`), such as NVIDIA's
-Cosmos3 world models, is served by [vLLM-Omni](https://github.com/vllm-project/vllm-omni) (`vllm serve
+NVIDIA's Cosmos3 world models are published as GGUFs under `ai/` (`ai/cosmos3-edge`,
+`ai/cosmos3-nano`, `ai/cosmos3-super`; `:latest` is Q4_K_M, with `:q8_0` and `:bf16` tags) and run
+on the same ggml path — on Metal, CUDA and Vulkan, natively or with `--ociman docker`. They need
+no separate text encoder: the prompt goes through the transformer's own understanding stream.
+
+```sh
+llmman run ai/cosmos3-edge "A ginger cat on a woven mat in a sunlit room"                # 768x512 png, 35 steps
+llmman run ai/cosmos3-nano --video --seconds 2 --width 832 --height 480 "waves on a beach"  # 45-frame mp4 with sound
+llmman run ai/cosmos3-edge --video --image cat.png --seconds 2 "the cat looks around"       # image-to-video
+llmman run ai/cosmos3-edge --video --input-video clip.mp4 --seconds 2 "..."                # video-to-video: continues
+                                                                                           # the clip's first 5 frames
+```
+
+Nano and Super generate a synchronized soundtrack (`"audio": false` on `/v1/videos` turns it off;
+the 10-25 sound tokens are more sensitive to 4-bit weights than the video is, so prefer `:q8_0` when
+the soundtrack matters), and
+all three are world models: an action run rolls a robot or vehicle forward from an observation
+(`forward_dynamics`), reads the actions off an observed clip (`inverse_dynamics`), or predicts both
+the future video and the actions (`policy`), for the embodiment domains and canvas tiers of
+[`CosmosActionCondition`](https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/cosmos/pipeline_cosmos3_omni.py):
+
+```sh
+llmman run ai/cosmos3-nano --video --input-video bridge_0.mp4 --action-mode forward_dynamics \
+    --action-domain bridge_orig_lerobot --actions bridge_0.json --action-chunk 16 --fps 5 --steps 30 \
+    "Put the pot to the left of the purple item."            # the rollout as mp4
+llmman run ai/cosmos3-nano --video --input-video bridge_0.mp4 --action-mode inverse_dynamics \
+    --action-domain bridge_orig_lerobot --action-chunk 16 --fps 5 --steps 30 "..."   # plus the actions as json
+```
+
+Over HTTP the same runs are `POST /v1/videos` with `image` / `video` (base64) and
+`action: {mode, domain, chunk_size, actions, resolution_tier, view_point}`; the job carries `actions`.
+
+The same repositories as Diffusers-layout safetensors (a root `model_index.json`, e.g. `nvidia/Cosmos3-Edge`)
+are instead served by [vLLM-Omni](https://github.com/vllm-project/vllm-omni) (`vllm serve
 --omni`; install `vllm-omni` next to `vllm`, or use `--ociman docker` for the `vllm/vllm-omni` image):
 
 ```sh

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -10,7 +10,7 @@ already exists for the model format it finds, and runs it unmodified.
 | safetensors | [`vllm`](https://github.com/vllm-project/vllm) | Your `PATH` |
 | safetensors | `vllm` in a container | `--ociman docker` / `--ociman podman` (Linux only): the `vllm/vllm-openai`, `rocm/vllm` or `vllm/vllm-openai-cpu` image for your GPU and architecture |
 | safetensors | [`mlx_lm.server`](https://github.com/ml-explore/mlx-lm) | Your `PATH`, on Apple Silicon macOS; preferred over `vllm` when present |
-| GGUF diffusion (LTX-2) | llmman itself, on ggml | The `libggml`/`libllama` next to `llama-server`; see [the blog post](https://llmmanorg.github.io/blog/image-audio-and-video-generation/) |
+| GGUF diffusion (LTX-2, Cosmos3) | llmman itself, on ggml | The `libggml`/`libllama` next to `llama-server`; see [the blog post](https://llmmanorg.github.io/blog/image-audio-and-video-generation/) |
 | Diffusers safetensors | [`vllm serve --omni`](https://github.com/vllm-project/vllm-omni) | Your `PATH`'s `vllm` with the `vllm-omni` package installed |
 | Diffusers safetensors | `vllm serve --omni` in a container | `--ociman docker` / `--ociman podman` (Linux only): the `vllm/vllm-omni` image (CUDA only) |
 

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -122,6 +122,44 @@ pub struct RunArgs {
     /// Media generation models only: length of a --video / --audio clip.
     #[arg(long, hide = true, default_value_t = 0.0)]
     pub seconds: f32,
+    /// Media generation models only: conditioning image (PNG/JPEG) for
+    /// image-to-video, or an action run's first frame.
+    #[arg(long, hide = true, value_name = "PATH")]
+    pub image: Option<std::path::PathBuf>,
+    /// Media generation models only: the conditioning video of a
+    /// video-to-video or action run.
+    #[arg(long, hide = true, value_name = "PATH")]
+    pub input_video: Option<std::path::PathBuf>,
+    /// Video-to-video: latent frames kept from --input-video (default 0,1).
+    #[arg(long, hide = true, value_name = "IDX,IDX", default_value = "")]
+    pub condition_frames: String,
+    /// Video-to-video: take the conditioning frames from the end of the clip.
+    #[arg(long, hide = true)]
+    pub condition_keep_last: bool,
+    /// Cosmos3 action run: forward_dynamics, inverse_dynamics or policy.
+    #[arg(long, hide = true, value_name = "MODE")]
+    pub action_mode: Option<String>,
+    /// Cosmos3 action run: embodiment domain (bridge_orig_lerobot, av, ...).
+    #[arg(long, hide = true, default_value = "")]
+    pub action_domain: String,
+    /// Cosmos3 action run: JSON file with the [T][D] actions (forward dynamics).
+    #[arg(long, hide = true, value_name = "PATH")]
+    pub actions: Option<std::path::PathBuf>,
+    /// Cosmos3 action run: action transitions in the chunk.
+    #[arg(long, hide = true, default_value_t = 0)]
+    pub action_chunk: u32,
+    /// Cosmos3 action run: conditioning canvas tier (256, 480, 704, 720).
+    #[arg(long, hide = true, default_value_t = 480)]
+    pub action_tier: u32,
+    /// Cosmos3 action run: camera viewpoint (ego_view, third_person_view, ...).
+    #[arg(long, hide = true, default_value = "ego_view")]
+    pub action_view: String,
+    /// Media generation models only: frames per second of the clip.
+    #[arg(long, hide = true, default_value_t = 0.0)]
+    pub fps: f32,
+    /// Cosmos3: scheduler flow shift (the reference action runs use 10).
+    #[arg(long, hide = true)]
+    pub flow_shift: Option<f32>,
     #[arg(
         value_name = "PROMPT",
         trailing_var_arg = true,
@@ -239,6 +277,23 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
                     cfg_scale: args.cfg_scale,
                     negative: args.negative.clone(),
                     seconds: args.seconds,
+                    fps: args.fps,
+                    flow_shift: args.flow_shift,
+                    image: args.image.clone(),
+                    input_video: args.input_video.clone(),
+                    condition_frames: args.condition_frames.clone(),
+                    condition_keep_last: args.condition_keep_last,
+                    action: args
+                        .action_mode
+                        .as_ref()
+                        .map(|mode| crate::imagegen::ActionOptions {
+                            mode: mode.clone(),
+                            domain: args.action_domain.clone(),
+                            actions: args.actions.clone(),
+                            chunk: args.action_chunk,
+                            tier: args.action_tier,
+                            view: args.action_view.clone(),
+                        }),
                 };
                 return crate::imagegen::run(&model, &prompt, interactive, opts);
             }

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -8204,10 +8204,9 @@ async fn mediagen_backend(model_ref: &str, port: u16, args: &ServeArgs) -> anyho
     let ModelPath::Diffusion(paths) = resolve_model(&store_path, &cache_path, model_ref)? else {
         anyhow::bail!("{model_ref} is not a diffusion model");
     };
-    let text_encoder = paths
-        .text_encoder
-        .clone()
-        .ok_or_else(|| anyhow!("{model_ref}: no text encoder in the model pack"))?;
+    if paths.text_encoder.is_none() && crate::mediagen::needs_text_encoder(&paths.model) {
+        anyhow::bail!("{model_ref}: no text encoder in the model pack");
+    }
     let pinned = args.llama_cpp_version.clone();
     let lib_dir = tokio::task::spawn_blocking(move || llama_lib_dir(pinned.as_deref())).await??;
     // the graph builders hold `&'static Api`
@@ -8218,7 +8217,8 @@ async fn mediagen_backend(model_ref: &str, port: u16, args: &ServeArgs) -> anyho
         vae: paths.vae.clone(),
         audio_vae: paths.audio_vae.clone(),
         text_proj: paths.text_proj.clone(),
-        text_model: text_encoder,
+        text_model: paths.text_encoder.clone(),
+        files: paths.files.clone(),
         use_gpu: true,
         // llama.cpp's own env var for -ngl
         text_gpu_layers: std::env::var("LLAMA_ARG_N_GPU_LAYERS")

--- a/src/imagegen.rs
+++ b/src/imagegen.rs
@@ -34,6 +34,28 @@ pub struct ImageOptions {
     pub negative: String,
     /// `--video` / `--audio` clip length; 0 = server default.
     pub seconds: f32,
+    /// `--fps`; 0 = server default.
+    pub fps: f32,
+    pub flow_shift: Option<f32>,
+    /// `--image`: conditioning image for image-to-video / an action run.
+    pub image: Option<PathBuf>,
+    /// `--input-video`: a video-to-video or action run's conditioning clip.
+    pub input_video: Option<PathBuf>,
+    /// `--condition-frames`: comma-separated latent frame indexes.
+    pub condition_frames: String,
+    pub condition_keep_last: bool,
+    pub action: Option<ActionOptions>,
+}
+
+/// `--action-*`: a Cosmos3 action run.
+#[derive(Debug, Clone, Default)]
+pub struct ActionOptions {
+    pub mode: String,
+    pub domain: String,
+    pub actions: Option<PathBuf>,
+    pub chunk: u32,
+    pub tier: u32,
+    pub view: String,
 }
 
 impl ImageOptions {
@@ -71,14 +93,57 @@ impl ImageOptions {
 
     /// The `/v1/videos` request: no streaming, the mp4 is fetched from
     /// the job's `content_url` afterwards.
-    fn video_request(&self, model: &str, prompt: &str) -> serde_json::Value {
+    fn video_request(&self, model: &str, prompt: &str) -> Result<serde_json::Value> {
         let mut req = self.request(model, prompt);
         req["stream"] = false.into();
         req.as_object_mut().map(|o| o.remove("response_format"));
         if self.seconds > 0.0 {
             req["seconds"] = self.seconds.into();
         }
-        req
+        if self.fps > 0.0 {
+            req["fps"] = self.fps.into();
+        }
+        if let Some(f) = self.flow_shift {
+            req["flow_shift"] = f.into();
+        }
+        let b64 = |path: &PathBuf| -> Result<String> {
+            let bytes = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
+            Ok(base64::engine::general_purpose::STANDARD.encode(bytes))
+        };
+        if let Some(p) = &self.image {
+            req["image"] = b64(p)?.into();
+        }
+        if let Some(p) = &self.input_video {
+            req["video"] = b64(p)?.into();
+            if !self.condition_frames.is_empty() {
+                let idx: Vec<i64> = self
+                    .condition_frames
+                    .split(',')
+                    .map(|v| v.trim().parse::<i64>())
+                    .collect::<Result<_, _>>()
+                    .context("--condition-frames takes comma-separated integers")?;
+                req["condition_frames"] = idx.into();
+            }
+            if self.condition_keep_last {
+                req["condition_video_keep"] = "last".into();
+            }
+        }
+        if let Some(a) = &self.action {
+            let mut act = serde_json::json!({
+                "mode": a.mode, "domain": a.domain, "resolution_tier": a.tier, "view_point": a.view,
+            });
+            if a.chunk > 0 {
+                act["chunk_size"] = a.chunk.into();
+            }
+            if let Some(p) = &a.actions {
+                let text =
+                    std::fs::read_to_string(p).with_context(|| format!("read {}", p.display()))?;
+                act["actions"] = serde_json::from_str(&text)
+                    .with_context(|| format!("parse {}", p.display()))?;
+            }
+            req["action"] = act;
+        }
+        Ok(req)
     }
 
     /// The `/v1/audio/speech` request: OpenAI's field is `input`.
@@ -276,13 +341,20 @@ fn generate_video(model: &str, prompt: &str, opts: &ImageOptions) -> Result<Path
     let _pb = Spinner(spinner("Generating video..."));
     let resp = client
         .post(format!("{}/v1/videos", crate::daemon::server()))
-        .json(&opts.video_request(model, prompt))
+        .json(&opts.video_request(model, prompt)?)
         .send()
         .context("request /v1/videos")?;
     if !resp.status().is_success() {
         return Err(fail(resp));
     }
     let job: serde_json::Value = resp.json().context("decode /v1/videos response")?;
+    if let Some(actions) = job.get("actions").filter(|a| a.is_array()) {
+        // an action run's predictions, next to the video
+        let path = output_path(prompt, "json");
+        std::fs::write(&path, serde_json::to_string_pretty(actions)?)
+            .with_context(|| format!("write {}", path.display()))?;
+        println!("Actions saved to: {}", path.display());
+    }
     let Some(content_url) = job["content_url"].as_str() else {
         anyhow::bail!(
             "the server generated {} frames but has no ffmpeg to mux an mp4; install ffmpeg next to llama-server",
@@ -513,7 +585,7 @@ mod tests {
             seed: Some(1),
             ..Default::default()
         };
-        let v = opts.video_request("m", "waves");
+        let v = opts.video_request("m", "waves").unwrap();
         assert_eq!(v["stream"], false);
         assert_eq!(v["seconds"], 2.0);
         assert!(v.get("response_format").is_none());

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ enum Commands {
     /// Launch an integration
     Launch(cmd::launch::LaunchArgs),
     /// Run a model interactively or with a one-shot prompt
-    Run(cmd::run::RunArgs),
+    Run(Box<cmd::run::RunArgs>),
     /// Package model files into a local OCI image
     Build(cmd::build::BuildArgs),
     /// Log in to a container registry or HuggingFace

--- a/src/mediagen/backend.rs
+++ b/src/mediagen/backend.rs
@@ -99,6 +99,36 @@ impl Backend {
         Some((free, total))
     }
 
+    /// The GPU backend's name (`"Metal"`, `"CUDA0"`, `"Vulkan0"`, ...), `""` without one.
+    pub fn gpu_name(&self) -> String {
+        if self.gpu.is_null() {
+            return String::new();
+        }
+        unsafe { std::ffi::CStr::from_ptr((self.api.ggml_backend_name)(self.gpu)) }
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    /// Does the GPU run `ggml_conv_2d_direct` (F16 kernel), or would it fall back to CPU?
+    pub fn supports_direct_conv(&self) -> bool {
+        let (Some(conv), Some(supports)) = (
+            self.api.ggml_conv_2d_direct,
+            self.api.ggml_backend_supports_op,
+        ) else {
+            return false;
+        };
+        if self.gpu.is_null() {
+            return false;
+        }
+        let Ok(ctx) = Ctx::new(self.api, 16 * 1024, true) else {
+            return false;
+        };
+        let k = ctx.new_tensor(ffi::ty::F16, &[3, 3, 8, 8]);
+        let x = ctx.new_tensor(ffi::ty::F32, &[16, 16, 8, 2]);
+        let y = unsafe { conv(ctx.raw, k, x, 1, 1, 1, 1, 1, 1) };
+        unsafe { supports(self.gpu, y) }
+    }
+
     /// Recreates the scheduler, freeing its compute buffers, and the GPU
     /// backend if it is in an error state.
     pub fn release_compute(&mut self) -> Result<()> {

--- a/src/mediagen/cosmos3/audio.rs
+++ b/src/mediagen/cosmos3/audio.rs
@@ -1,0 +1,219 @@
+//! The sound tokenizer's Oobleck decoder (diffusers `Cosmos3AVAEAudioTokenizer`):
+//! 25 latent frames/s to 48 kHz stereo. Activations are `[T, C, 1]`.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+
+use crate::mediagen::backend::{Backend, Ctx, Graph};
+use crate::mediagen::ffi::{self, Tensor};
+use crate::mediagen::weights::{read_safetensors_raw, write_safetensors_raw, RawTensor, Weights};
+
+pub const SAMPLE_RATE: i32 = 48000;
+pub const HOP: i64 = 1920;
+pub const LATENT_DIM: i64 = 64;
+/// `dec_strides` reversed: the decoder's upsampling ratios.
+const STRIDES: [i64; 5] = [8, 6, 5, 4, 2];
+
+/// Rewrites `src` as `dst` with every `X.weight_g`/`X.weight_v` pair folded into
+/// `X.weight = g * v / ||v||` (norm over all but the first dimension, as
+/// `weight_norm(dim=0)` does).
+pub fn fold_weight_norm(src: &Path, dst: &Path) -> Result<()> {
+    let tensors = read_safetensors_raw(src)?;
+    let by_name: HashMap<&str, &RawTensor> = tensors.iter().map(|t| (t.name.as_str(), t)).collect();
+    let mut out = Vec::new();
+    for t in &tensors {
+        if t.name.ends_with(".weight_g") {
+            continue;
+        }
+        let Some(stem) = t.name.strip_suffix(".weight_v") else {
+            out.push(RawTensor {
+                name: t.name.clone(),
+                dtype: t.dtype.clone(),
+                shape: t.shape.clone(),
+                bytes: t.bytes.clone(),
+            });
+            continue;
+        };
+        let g_name = format!("{stem}.weight_g");
+        let g = by_name
+            .get(g_name.as_str())
+            .with_context(|| format!("{} without {g_name}", t.name))?
+            .f32s()?;
+        let mut v = t.f32s()?;
+        let d0 = *t
+            .shape
+            .first()
+            .filter(|&&d| d > 0)
+            .with_context(|| format!("{}: bad shape", t.name))? as usize;
+        if g.len() != d0 || !v.len().is_multiple_of(d0) {
+            bail!("{}: {} norms for {d0} rows of {}", g_name, g.len(), v.len());
+        }
+        let per = v.len() / d0;
+        for (i, row) in v.chunks_exact_mut(per).enumerate() {
+            let norm = row.iter().map(|x| (*x as f64).powi(2)).sum::<f64>().sqrt() as f32;
+            let s = g[i] / norm;
+            row.iter_mut().for_each(|x| *x *= s);
+        }
+        out.push(RawTensor {
+            name: format!("{stem}.weight"),
+            dtype: "F32".into(),
+            shape: t.shape.clone(),
+            bytes: v.iter().flat_map(|x| x.to_le_bytes()).collect(),
+        });
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    write_safetensors_raw(dst, &out, "weight_norm folded")
+}
+
+/// Snake parameters as the graph uses them: alpha -> exp(alpha), beta -> 1 / (exp(beta) + eps).
+pub fn transform(name: &str, data: &mut [f32]) {
+    if name.ends_with(".alpha") {
+        for v in data.iter_mut() {
+            *v = v.exp();
+        }
+    } else if name.ends_with(".beta") {
+        for v in data.iter_mut() {
+            *v = 1.0 / (v.exp() + 1e-9);
+        }
+    }
+}
+
+fn param(g: &Ctx, t: Tensor) -> Tensor {
+    let n: i64 = ffi::shape(t).iter().product();
+    g.reshape_3d(t, 1, n, 1)
+}
+
+fn snake(g: &Ctx, w: &Weights, prefix: &str, x: Tensor) -> Result<Tensor> {
+    let a = param(g, w.get(&format!("{prefix}.alpha"))?);
+    let ib = param(g, w.get(&format!("{prefix}.beta"))?);
+    let s = g.sin(g.mul(x, a));
+    Ok(g.add(x, g.mul(g.sqr(s), ib)))
+}
+
+fn conv1d(g: &Ctx, w: &Weights, prefix: &str, x: Tensor, pad: i32, dil: i32) -> Result<Tensor> {
+    let k = w.get(&format!("{prefix}.weight"))?;
+    let mut y = g.conv_1d(k, x, 1, pad, dil);
+    if let Some(b) = w.opt(&format!("{prefix}.bias")) {
+        y = g.add(y, param(g, b));
+    }
+    Ok(y)
+}
+
+/// `ConvTranspose1d(k = 2s, stride s, padding ceil(s/2), output_padding s % 2)`.
+fn conv_transpose(g: &Ctx, w: &Weights, prefix: &str, x: Tensor, stride: i64) -> Result<Tensor> {
+    let k = w.get(&format!("{prefix}.weight"))?; // [K, OC, IC]
+    let [t, c, ..] = ffi::shape(x);
+    let y = g.conv_transpose_1d(k, g.reshape_2d(x, t, c), stride as i32, 0, 1); // [(t-1)s + K, OC]
+    let pad = (stride + 1) / 2;
+    let out_pad = stride % 2;
+    let [ty, oc, ..] = ffi::shape(y);
+    let keep = ty - pad - (pad - out_pad);
+    let nb = ffi::strides(y);
+    let mut y = g.cont(g.view_2d(y, keep, oc, nb[1], (pad as usize) * nb[0]));
+    y = g.reshape_3d(y, keep, oc, 1);
+    if let Some(b) = w.opt(&format!("{prefix}.bias")) {
+        y = g.add(y, param(g, b));
+    }
+    Ok(y)
+}
+
+fn res_unit(g: &Ctx, w: &Weights, prefix: &str, x: Tensor, dil: i32) -> Result<Tensor> {
+    let h = snake(g, w, &format!("{prefix}.snake1"), x)?;
+    let h = conv1d(g, w, &format!("{prefix}.conv1"), h, 3 * dil, dil)?;
+    let h = snake(g, w, &format!("{prefix}.snake2"), h)?;
+    let h = conv1d(g, w, &format!("{prefix}.conv2"), h, 0, 1)?;
+    Ok(g.add(x, h))
+}
+
+/// Decodes sound latents `[T][64]` to interleaved stereo PCM at 48 kHz.
+pub fn decode(w: &Weights, be: &Backend, latents: &[f32], n_frames: i64) -> Result<Vec<f32>> {
+    if latents.len() as i64 != n_frames * LATENT_DIM {
+        bail!("sound latents do not match {n_frames} x {LATENT_DIM}");
+    }
+    // [T][C] -> ggml [T, C, 1]
+    let mut x = vec![0f32; latents.len()];
+    for t in 0..n_frames as usize {
+        for c in 0..LATENT_DIM as usize {
+            x[t + n_frames as usize * c] = latents[t * LATENT_DIM as usize + c];
+        }
+    }
+    let mut gr = Graph::new(be.api, 4 * 1024)?;
+    let z = gr.input_f32(&[n_frames, LATENT_DIM, 1], &x, "sound");
+    let g = &gr.ctx;
+    let mut h = conv1d(g, w, "decoder.conv1", z, 3, 1)?;
+    for (i, &stride) in STRIDES.iter().enumerate() {
+        let p = format!("decoder.block.{i}");
+        h = snake(g, w, &format!("{p}.snake1"), h)?;
+        h = conv_transpose(g, w, &format!("{p}.conv_t1"), h, stride)?;
+        h = res_unit(g, w, &format!("{p}.res_unit1"), h, 1)?;
+        h = res_unit(g, w, &format!("{p}.res_unit2"), h, 3)?;
+        h = res_unit(g, w, &format!("{p}.res_unit3"), h, 9)?;
+    }
+    h = snake(g, w, "decoder.snake1", h)?;
+    h = conv1d(g, w, "decoder.conv2", h, 3, 1)?;
+    let out = g.cont(g.clamp(h, -1.0, 1.0)); // [N, 2, 1]
+    gr.mark_output(out);
+    gr.compute(be)?;
+    let [n, ch, ..] = ffi::shape(out);
+    let y = gr.output_f32(out);
+    let (n, ch) = (n as usize, ch as usize);
+    let mut pcm = vec![0f32; n * ch];
+    for t in 0..n {
+        for c in 0..ch {
+            pcm[t * ch + c] = y[t + n * c];
+        }
+    }
+    Ok(pcm)
+}
+
+/// The folded-weights file for `src`, created in `cache_dir` when missing.
+pub fn folded_path(src: &Path, cache_dir: &Path) -> Result<std::path::PathBuf> {
+    let name = src
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("sound_tokenizer");
+    let dst = cache_dir.join(format!("{name}.folded.safetensors"));
+    if !dst.exists() {
+        std::fs::create_dir_all(cache_dir)?;
+        fold_weight_norm(src, &dst).with_context(|| format!("folding {}", src.display()))?;
+    }
+    Ok(dst)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fold_writes_a_readable_file() {
+        let dir = std::env::temp_dir().join(format!("llmman-fold-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let raw = |name: &str, shape: &[i64], data: &[f32]| RawTensor {
+            name: name.into(),
+            dtype: "F32".into(),
+            shape: shape.to_vec(),
+            bytes: data.iter().flat_map(|v| v.to_le_bytes()).collect(),
+        };
+        // w[i] = g[i] * v[i] / ||v[i]||
+        let src = dir.join("in.safetensors");
+        write_safetensors_raw(
+            &src,
+            &[
+                raw("a.weight_v", &[2, 3], &[3.0, 4.0, 0.0, 0.0, 0.0, 2.0]),
+                raw("a.weight_g", &[2, 1], &[10.0, 1.0]),
+                raw("b.alpha", &[1, 2, 1], &[0.5, 0.25]),
+            ],
+            "test",
+        )
+        .unwrap();
+        let dst = dir.join("out.safetensors");
+        fold_weight_norm(&src, &dst).unwrap();
+        let out = read_safetensors_raw(&dst).unwrap();
+        let names: Vec<&str> = out.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(names, ["a.weight", "b.alpha"]);
+        assert_eq!(out[0].f32s().unwrap(), [6.0, 8.0, 0.0, 0.0, 0.0, 1.0]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/mediagen/cosmos3/dit.rs
+++ b/src/mediagen/cosmos3/dit.rs
@@ -1,0 +1,650 @@
+//! The Cosmos3 omni transformer (diffusers `Cosmos3OmniTransformer`): two token
+//! streams per layer that share nothing but attention. The understanding stream
+//! (prompt tokens, causal decoder) never sees the generation stream (latents),
+//! so it runs once per prompt ([`und_forward`]) and its keys/values feed every
+//! denoising step ([`gen_forward`]).
+
+use anyhow::{bail, Result};
+
+use super::Hparams;
+use crate::mediagen::backend::{Backend, Ctx, Graph};
+use crate::mediagen::ffi::{self, Tensor};
+use crate::mediagen::ltx::rms;
+use crate::mediagen::weights::Weights;
+
+/// The causal mask is `n x n`; the checkpoints are trained on far shorter prompts.
+pub const MAX_PROMPT_TOKENS: i64 = 4096;
+
+/// Per-layer keys (normed, roped) and values of the understanding stream, `[head_dim * n_kv_heads, n_tokens]`.
+pub struct UndCache {
+    pub n_tokens: i64,
+    pub k: Vec<Vec<f32>>,
+    pub v: Vec<Vec<f32>>,
+}
+
+/// Interleaved 3-D mRoPE cos/sin tables `[n_tokens][head_dim/2]` for `(t, h, w)` positions.
+pub fn mrope_tables(hp: &Hparams, positions: &[[f64; 3]]) -> (Vec<f32>, Vec<f32>) {
+    let half = (hp.head_dim / 2) as usize;
+    let sect = hp.mrope_section;
+    let mut cos = Vec::with_capacity(positions.len() * half);
+    let mut sin = Vec::with_capacity(positions.len() * half);
+    for p in positions {
+        for j in 0..half {
+            let inv = 1.0 / hp.rope_theta.powf(2.0 * j as f64 / hp.head_dim as f64);
+            // [T H W T H W ... T T]: H takes 1, 4, 7, ... and W 2, 5, 8, ... below 3*section
+            let axis = if j < 3 * sect[1] as usize && j % 3 == 1 {
+                1
+            } else if j < 3 * sect[2] as usize && j % 3 == 2 {
+                2
+            } else {
+                0
+            };
+            let angle = p[axis] * inv;
+            cos.push(angle.cos() as f32);
+            sin.push(angle.sin() as f32);
+        }
+    }
+    (cos, sin)
+}
+
+/// Positions of the prompt tokens: the same index on all three axes.
+pub fn text_positions(n: i64) -> Vec<[f64; 3]> {
+    (0..n).map(|i| [i as f64; 3]).collect()
+}
+
+/// Vision token positions (`get_3d_mrope_ids_vae_tokens`): a `[t][h][w]` grid `temporal_margin` after the text.
+pub fn vision_positions(hp: &Hparams, n_text: i64, grid: [i64; 3], fps: f32) -> Vec<[f64; 3]> {
+    let offset = (n_text + hp.temporal_margin) as f64;
+    let [gt, gh, gw] = grid;
+    let modulated = hp.enable_fps_modulation && gt > 1;
+    let mut out = Vec::with_capacity((gt * gh * gw) as usize);
+    for t in 0..gt {
+        let tp = if modulated {
+            let tps = fps as f64 / hp.vae_scale_t as f64;
+            let base_tps = hp.base_fps as f64 / hp.vae_scale_t as f64;
+            t as f64 / tps * base_tps + offset
+        } else {
+            t as f64 + offset
+        };
+        for h in 0..gh {
+            for w in 0..gw {
+                out.push([tp, h as f64, w as f64]);
+            }
+        }
+    }
+    out
+}
+
+/// Sound token positions: one per latent frame at `sound_fps`, same temporal offset as vision.
+pub fn sound_positions(hp: &Hparams, n_text: i64, n: i64, sound_fps: f32) -> Vec<[f64; 3]> {
+    let offset = (n_text + hp.temporal_margin) as f64;
+    (0..n)
+        .map(|f| {
+            let t = if hp.enable_fps_modulation && n > 1 {
+                f as f64 / sound_fps as f64 * hp.base_fps as f64 + offset
+            } else {
+                f as f64 + offset
+            };
+            [t, 0.0, 0.0]
+        })
+        .collect()
+}
+
+/// Action token positions: transition `f` sits at video frame `f + 1`.
+pub fn action_positions(hp: &Hparams, n_text: i64, n: i64, fps: f32) -> Vec<[f64; 3]> {
+    let offset = (n_text + hp.temporal_margin) as f64;
+    let base_tps = hp.base_fps as f64 / hp.vae_scale_t as f64;
+    (0..n)
+        .map(|f| {
+            let t = if hp.enable_fps_modulation && n > 1 {
+                (f + 1) as f64 / fps as f64 * base_tps + offset
+            } else {
+                (f + 1) as f64 + offset
+            };
+            [t, 0.0, 0.0]
+        })
+        .collect()
+}
+
+/// A (cos, sin) pair of mRoPE tables.
+pub type Tables = (Vec<f32>, Vec<f32>);
+
+/// diffusers' `Timesteps(256, flip_sin_to_cos=True)`: 128 cosines then 128 sines.
+pub fn timestep_embedding(t: f32) -> Vec<f32> {
+    let half = 128;
+    let mut e = vec![0f32; 256];
+    for j in 0..half {
+        let freq = (-(10000f32).ln() * j as f32 / half as f32).exp();
+        let arg = t * freq;
+        e[j] = arg.cos();
+        e[half + j] = arg.sin();
+    }
+    e
+}
+
+/// Rotate-half RoPE on `x: [n_heads * hd, T]` with a `[hd/2, T]` table shared by all heads.
+fn rope(g: &Ctx, x: Tensor, cos: Tensor, sin: Tensor, n_heads: i64) -> Tensor {
+    let [dim, t, ..] = ffi::shape(x);
+    let hd = dim / n_heads;
+    let x4 = g.reshape_4d(g.cont(x), hd / 2, 2, n_heads, t);
+    let nb = ffi::strides(x4);
+    let x1 = g.cont(g.view_4d(x4, hd / 2, 1, n_heads, t, nb[1], nb[2], nb[3], 0));
+    let x2 = g.cont(g.view_4d(x4, hd / 2, 1, n_heads, t, nb[1], nb[2], nb[3], nb[1]));
+    let c = g.reshape_4d(cos, hd / 2, 1, 1, t);
+    let s = g.reshape_4d(sin, hd / 2, 1, 1, t);
+    let o1 = g.sub(g.mul(x1, c), g.mul(x2, s));
+    let o2 = g.add(g.mul(x1, s), g.mul(x2, c));
+    g.reshape_2d(g.concat(o1, o2, 1), dim, t)
+}
+
+/// RMSNorm over each head of `x: [n_heads * head_dim, T]` with a `[head_dim]` weight.
+fn head_rms(g: &Ctx, x: Tensor, hd: i64, eps: f32, w: Option<Tensor>) -> Tensor {
+    let [dim, t, ..] = ffi::shape(x);
+    let x3 = g.reshape_3d(g.cont(x), hd, dim / hd, t);
+    let y = rms(g, x3, eps, w);
+    g.reshape_2d(y, dim, t)
+}
+
+/// Grouped-query attention: q `[n_heads*hd, Tq]`, k/v `[n_kv*hd, Tk]` -> `[n_heads*hd, Tq]`.
+fn sdpa_gqa(
+    g: &Ctx,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    n_heads: i64,
+    n_kv: i64,
+    mask: Option<Tensor>,
+    flash: bool,
+) -> Tensor {
+    let tq = ffi::shape(q)[1];
+    let tk = ffi::shape(k)[1];
+    let hd = ffi::shape(q)[0] / n_heads;
+    let scale = 1.0 / (hd as f32).sqrt();
+    let q3 = g.permute(g.reshape_3d(g.cont(q), hd, n_heads, tq), 0, 2, 1, 3);
+    let k3 = g.permute(g.reshape_3d(g.cont(k), hd, n_kv, tk), 0, 2, 1, 3);
+    if flash && mask.is_none() {
+        let v3 = g.permute(g.reshape_3d(g.cont(v), hd, n_kv, tk), 0, 2, 1, 3);
+        let k3 = g.cast(k3, ffi::ty::F16);
+        let v3 = g.cast(v3, ffi::ty::F16);
+        let cur = g.flash_attn_ext(q3, k3, v3, std::ptr::null_mut(), scale, 0.0, 0.0);
+        unsafe { (g.api.ggml_flash_attn_ext_set_prec)(cur, ffi::GGML_PREC_F32) };
+        g.reshape_2d(cur, hd * n_heads, tq)
+    } else {
+        let v3 = g.cont(g.permute(g.reshape_3d(g.cont(v), hd, n_kv, tk), 1, 2, 0, 3));
+        let kq = g.mul_mat(k3, q3);
+        let kq = g.soft_max_ext(kq, mask.unwrap_or(std::ptr::null_mut()), scale, 0.0);
+        let kqv = g.mul_mat(v3, kq);
+        g.cont_2d(g.permute(kqv, 0, 2, 1, 3), hd * n_heads, tq)
+    }
+}
+
+/// `Cosmos3VLTextMLP`: `down(silu(gate) * up)` or `down(relu(up)^2)`.
+fn mlp(g: &Ctx, w: &Weights, prefix: &str, x: Tensor, relu2: bool) -> Result<Tensor> {
+    let up = g.linear(x, w.get(&format!("{prefix}.up_proj.weight"))?, None);
+    let h = if relu2 {
+        g.sqr(g.clamp(up, 0.0, f32::INFINITY))
+    } else {
+        let gate = g.linear(x, w.get(&format!("{prefix}.gate_proj.weight"))?, None);
+        g.mul(g.silu(gate), up)
+    };
+    Ok(g.linear(h, w.get(&format!("{prefix}.down_proj.weight"))?, None))
+}
+
+/// The understanding stream over the prompt tokens.
+pub fn und_forward(hp: &Hparams, w: &Weights, be: &Backend, ids: &[u32]) -> Result<UndCache> {
+    let n = ids.len() as i64;
+    if n == 0 || n > MAX_PROMPT_TOKENS {
+        bail!("the prompt must be 1 to {MAX_PROMPT_TOKENS} tokens, got {n}");
+    }
+    let mut gr = Graph::new(be.api, 4 * 1024 + hp.n_layers as usize * 96)?;
+    let ids_i32: Vec<i32> = ids.iter().map(|&i| i as i32).collect();
+    let ids_t = gr.input_i32(&[n], &ids_i32, "ids");
+    let (cos, sin) = mrope_tables(hp, &text_positions(n));
+    let half = hp.head_dim / 2;
+    let cos_t = gr.input_f32(&[half, n], &cos, "cos");
+    let sin_t = gr.input_f32(&[half, n], &sin, "sin");
+    // causal mask [Tk, Tq]: -inf where the key follows the query
+    let mut mask = vec![0f32; (n * n) as usize];
+    for q in 0..n as usize {
+        for k in q + 1..n as usize {
+            mask[q * n as usize + k] = f32::NEG_INFINITY;
+        }
+    }
+    let mask_t = gr.input_f32(&[n, n], &mask, "mask");
+
+    let g = &gr.ctx;
+    let eps = hp.rms_eps;
+    let hd = hp.head_dim;
+    let mut x = g.get_rows(w.get("embed_tokens.weight")?, ids_t);
+    let mut ks = Vec::with_capacity(hp.n_layers as usize);
+    let mut vs = Vec::with_capacity(hp.n_layers as usize);
+    for l in 0..hp.n_layers {
+        let p = format!("layers.{l}");
+        let h = rms(
+            g,
+            x,
+            eps,
+            Some(w.get(&format!("{p}.input_layernorm.weight"))?),
+        );
+        let mut q = g.linear(h, w.get(&format!("{p}.self_attn.to_q.weight"))?, None);
+        let mut k = g.linear(h, w.get(&format!("{p}.self_attn.to_k.weight"))?, None);
+        let v = g.linear(h, w.get(&format!("{p}.self_attn.to_v.weight"))?, None);
+        if hp.qk_norm_for_text {
+            q = head_rms(
+                g,
+                q,
+                hd,
+                eps,
+                Some(w.get(&format!("{p}.self_attn.norm_q.weight"))?),
+            );
+            k = head_rms(
+                g,
+                k,
+                hd,
+                eps,
+                Some(w.get(&format!("{p}.self_attn.norm_k.weight"))?),
+            );
+        }
+        let mut k_gen = match w.opt(&format!("{p}.self_attn.k_norm_und_for_gen.weight")) {
+            Some(nw) => head_rms(g, k, hd, eps, Some(nw)),
+            None => k,
+        };
+        q = rope(g, q, cos_t, sin_t, hp.n_heads);
+        k = rope(g, k, cos_t, sin_t, hp.n_kv_heads);
+        k_gen = rope(g, k_gen, cos_t, sin_t, hp.n_kv_heads);
+        let attn = sdpa_gqa(g, q, k, v, hp.n_heads, hp.n_kv_heads, Some(mask_t), false);
+        x = g.add(
+            x,
+            g.linear(attn, w.get(&format!("{p}.self_attn.to_out.weight"))?, None),
+        );
+        let h2 = rms(
+            g,
+            x,
+            eps,
+            Some(w.get(&format!("{p}.post_attention_layernorm.weight"))?),
+        );
+        x = g.add(x, mlp(g, w, &format!("{p}.mlp"), h2, hp.relu2)?);
+        let k_out = g.cont(k_gen);
+        let v_out = g.cont(v);
+        gr.mark_output(k_out);
+        gr.mark_output(v_out);
+        ks.push(k_out);
+        vs.push(v_out);
+    }
+    gr.compute(be)?;
+    Ok(UndCache {
+        n_tokens: n,
+        k: ks.iter().map(|&t| gr.output_f32(t)).collect(),
+        v: vs.iter().map(|&t| gr.output_f32(t)).collect(),
+    })
+}
+
+/// One modality's tokens of the generation stream for a denoising step.
+pub struct Segment<'a> {
+    /// `[n][dim]`: patchified latents (vision), sound latents, or action vectors.
+    pub tokens: &'a [f32],
+    pub n: i64,
+    /// mRoPE tables `[n][head_dim/2]`.
+    pub cos: &'a [f32],
+    pub sin: &'a [f32],
+    /// `1` for noisy tokens, `0` for conditioning tokens; `None` when all are noisy.
+    pub noisy: Option<&'a [f32]>,
+}
+
+/// One denoising evaluation of the generation stream.
+pub struct GenInputs<'a> {
+    pub vision: Segment<'a>,
+    pub sound: Option<Segment<'a>>,
+    /// Action tokens and the embodiment domain selecting the projection weights.
+    pub action: Option<(Segment<'a>, i64)>,
+    /// Already scaled by `timestep_scale` (0.995 for t = 995).
+    pub timestep: f32,
+    pub und: &'a UndCache,
+    pub flash: bool,
+}
+
+/// Velocity predictions per modality, `[n][dim]` each (empty when absent).
+pub struct GenOutputs {
+    pub vision: Vec<f32>,
+    pub sound: Vec<f32>,
+    pub action: Vec<f32>,
+}
+
+/// `DomainAwareLinear`: one domain's weight `[in, out]` and bias `[out]` from the embedding tables.
+fn domain_linear(
+    g: &Ctx,
+    w: &Weights,
+    prefix: &str,
+    domain: Tensor,
+    n_in: i64,
+    n_out: i64,
+) -> Result<(Tensor, Tensor)> {
+    let row = g.get_rows(w.get(&format!("{prefix}.fc.weight"))?, domain); // [in*out, 1]
+                                                                          // the row is `[in][out]` (out fastest); mul_mat wants `[in, out]` in ggml order
+    let wt = g.cont(g.transpose(g.reshape_2d(row, n_out, n_in)));
+    let b = g.get_rows(w.get(&format!("{prefix}.bias.weight"))?, domain); // [out, 1]
+    Ok((wt, g.reshape_2d(b, n_out, 1)))
+}
+
+/// The velocity predictions for every generation token.
+pub fn gen_forward(hp: &Hparams, w: &Weights, be: &Backend, inp: &GenInputs) -> Result<GenOutputs> {
+    let nt = inp.und.n_tokens;
+    let nv = inp.vision.n;
+    let ns = inp.sound.as_ref().map_or(0, |s| s.n);
+    let na = inp.action.as_ref().map_or(0, |(s, _)| s.n);
+    let n = nv + ns + na;
+    let mut gr = Graph::new(be.api, 4 * 1024 + hp.n_layers as usize * 128)?;
+    let half = hp.head_dim / 2;
+    let v_tok = gr.input_f32(&[hp.patch_dim, nv], inp.vision.tokens, "vision");
+    let s_tok = inp
+        .sound
+        .as_ref()
+        .map(|s| gr.input_f32(&[hp.sound_dim, s.n], s.tokens, "sound"));
+    let a_tok = inp
+        .action
+        .as_ref()
+        .map(|(s, _)| gr.input_f32(&[hp.action_dim, s.n], s.tokens, "action"));
+    let domain = inp
+        .action
+        .as_ref()
+        .map(|(_, d)| gr.input_i32(&[1], &[*d as i32], "domain"));
+    // rope tables and the noisy mask over the concatenated tokens
+    let mut cos = inp.vision.cos.to_vec();
+    let mut sin = inp.vision.sin.to_vec();
+    let mut noisy: Vec<f32> = match inp.vision.noisy {
+        Some(m) => m.to_vec(),
+        None => vec![1.0; nv as usize],
+    };
+    let mut any_cond = inp.vision.noisy.is_some();
+    for seg in inp.sound.iter().chain(inp.action.iter().map(|(s, _)| s)) {
+        cos.extend_from_slice(seg.cos);
+        sin.extend_from_slice(seg.sin);
+        match seg.noisy {
+            Some(m) => {
+                noisy.extend_from_slice(m);
+                any_cond = true;
+            }
+            None => noisy.extend(std::iter::repeat_n(1.0, seg.n as usize)),
+        }
+    }
+    let cos_t = gr.input_f32(&[half, n], &cos, "cos");
+    let sin_t = gr.input_f32(&[half, n], &sin, "sin");
+    let noisy_t = any_cond.then(|| gr.input_f32(&[1, n], &noisy, "noisy"));
+    let temb_in = gr.input_f32(&[256], &timestep_embedding(inp.timestep), "temb");
+    let kv_dim = hp.head_dim * hp.n_kv_heads;
+    let und_k: Vec<Tensor> = (0..hp.n_layers as usize)
+        .map(|l| gr.input_f32(&[kv_dim, nt], &inp.und.k[l], &format!("und_k{l}")))
+        .collect();
+    let und_v: Vec<Tensor> = (0..hp.n_layers as usize)
+        .map(|l| gr.input_f32(&[kv_dim, nt], &inp.und.v[l], &format!("und_v{l}")))
+        .collect();
+
+    let g = &gr.ctx;
+    let eps = hp.rms_eps;
+    let hd = hp.head_dim;
+    // embed every modality, then pack them in order: vision, sound, action
+    let mut x = g.linear(
+        v_tok,
+        w.get("proj_in.weight")?,
+        Some(w.get("proj_in.bias")?),
+    );
+    if let Some(st) = s_tok {
+        let e = g.linear(
+            st,
+            w.get("audio_proj_in.weight")?,
+            Some(w.get("audio_proj_in.bias")?),
+        );
+        let e = g.add(
+            e,
+            g.reshape_2d(w.get("audio_modality_embed")?, hp.hidden, 1),
+        );
+        x = g.concat(x, e, 1);
+    }
+    let mut action_out_w = None;
+    if let (Some(at), Some(d)) = (a_tok, domain) {
+        let (wi, bi) = domain_linear(g, w, "action_proj_in", d, hp.action_dim, hp.hidden)?;
+        let e = g.add(g.mul_mat(wi, at), bi);
+        let e = g.add(
+            e,
+            g.reshape_2d(w.get("action_modality_embed")?, hp.hidden, 1),
+        );
+        x = g.concat(x, e, 1);
+        action_out_w = Some(domain_linear(
+            g,
+            w,
+            "action_proj_out",
+            d,
+            hp.hidden,
+            hp.action_dim,
+        )?);
+    }
+    // timestep embedding, added to the noisy tokens
+    let te = g.linear(
+        g.reshape_2d(temb_in, 256, 1),
+        w.get("time_embedder.linear_1.weight")?,
+        Some(w.get("time_embedder.linear_1.bias")?),
+    );
+    let te = g.linear(
+        g.silu(te),
+        w.get("time_embedder.linear_2.weight")?,
+        Some(w.get("time_embedder.linear_2.bias")?),
+    );
+    x = match noisy_t {
+        None => g.add(x, te),
+        Some(m) => g.add(x, g.mul(g.repeat(te, x), m)),
+    };
+
+    for l in 0..hp.n_layers {
+        let p = format!("layers.{l}");
+        let h = rms(
+            g,
+            x,
+            eps,
+            Some(w.get(&format!("{p}.input_layernorm_moe_gen.weight"))?),
+        );
+        let q = g.linear(h, w.get(&format!("{p}.self_attn.add_q_proj.weight"))?, None);
+        let k = g.linear(h, w.get(&format!("{p}.self_attn.add_k_proj.weight"))?, None);
+        let v = g.linear(h, w.get(&format!("{p}.self_attn.add_v_proj.weight"))?, None);
+        let q = head_rms(
+            g,
+            q,
+            hd,
+            eps,
+            Some(w.get(&format!("{p}.self_attn.norm_added_q.weight"))?),
+        );
+        let k = head_rms(
+            g,
+            k,
+            hd,
+            eps,
+            Some(w.get(&format!("{p}.self_attn.norm_added_k.weight"))?),
+        );
+        let q = rope(g, q, cos_t, sin_t, hp.n_heads);
+        let k = rope(g, k, cos_t, sin_t, hp.n_kv_heads);
+        let kk = g.concat(und_k[l as usize], g.cont(k), 1);
+        let vv = g.concat(und_v[l as usize], g.cont(v), 1);
+        let attn = sdpa_gqa(g, q, kk, vv, hp.n_heads, hp.n_kv_heads, None, inp.flash);
+        x = g.add(
+            x,
+            g.linear(
+                attn,
+                w.get(&format!("{p}.self_attn.to_add_out.weight"))?,
+                None,
+            ),
+        );
+        let h2 = rms(
+            g,
+            x,
+            eps,
+            Some(w.get(&format!("{p}.post_attention_layernorm_moe_gen.weight"))?),
+        );
+        x = g.add(x, mlp(g, w, &format!("{p}.mlp_moe_gen"), h2, hp.relu2)?);
+    }
+    let out = g.cont(rms(g, x, eps, Some(w.get("norm_moe_gen.weight")?)));
+    let nb = ffi::strides(out);
+    let part = |off: i64, len: i64| g.view_2d(out, hp.hidden, len, nb[1], (off as usize) * nb[1]);
+    let v_out = g.cont(g.linear(
+        part(0, nv),
+        w.get("proj_out.weight")?,
+        Some(w.get("proj_out.bias")?),
+    ));
+    gr.mark_output(v_out);
+    let s_out = (ns > 0)
+        .then(|| -> Result<Tensor> {
+            let t = g.cont(g.linear(
+                part(nv, ns),
+                w.get("audio_proj_out.weight")?,
+                Some(w.get("audio_proj_out.bias")?),
+            ));
+            gr.mark_output(t);
+            Ok(t)
+        })
+        .transpose()?;
+    let a_out = match action_out_w {
+        Some((wo, bo)) if na > 0 => {
+            let t = g.cont(g.add(g.mul_mat(wo, part(nv + ns, na)), bo));
+            gr.mark_output(t);
+            Some(t)
+        }
+        _ => None,
+    };
+    gr.compute(be)?;
+    Ok(GenOutputs {
+        vision: gr.output_f32(v_out),
+        sound: s_out.map(|t| gr.output_f32(t)).unwrap_or_default(),
+        action: a_out.map(|t| gr.output_f32(t)).unwrap_or_default(),
+    })
+}
+
+/// Latents `[C][T][H][W]` -> tokens `[t][h][w][(p*P + q)*C + c]` (`_patchify_and_pack_latents`).
+pub fn patchify(hp: &Hparams, lat: &[f32], t: i64, h: i64, w: i64) -> Vec<f32> {
+    let (c, p) = (hp.latent_channels, hp.patch);
+    // odd latent sizes are zero-padded to whole patches
+    let (hp_, wp) = ((h + p - 1) / p, (w + p - 1) / p);
+    let mut out = vec![0f32; (t * hp_ * wp * hp.patch_dim) as usize];
+    let idx = |ci: i64, ti: i64, hi: i64, wi: i64| (((ci * t + ti) * h + hi) * w + wi) as usize;
+    let mut n = 0usize;
+    for ti in 0..t {
+        for hh in 0..hp_ {
+            for ww in 0..wp {
+                let base = n * hp.patch_dim as usize;
+                for pp in 0..p {
+                    for q in 0..p {
+                        let (hi, wi) = (hh * p + pp, ww * p + q);
+                        if hi >= h || wi >= w {
+                            continue;
+                        }
+                        for ci in 0..c {
+                            out[base + ((pp * p + q) * c + ci) as usize] = lat[idx(ci, ti, hi, wi)];
+                        }
+                    }
+                }
+                n += 1;
+            }
+        }
+    }
+    out
+}
+
+/// The inverse of [`patchify`].
+pub fn unpatchify(hp: &Hparams, tokens: &[f32], t: i64, h: i64, w: i64) -> Vec<f32> {
+    let (c, p) = (hp.latent_channels, hp.patch);
+    let (hp_, wp) = ((h + p - 1) / p, (w + p - 1) / p);
+    let mut out = vec![0f32; (c * t * h * w) as usize];
+    let idx = |ci: i64, ti: i64, hi: i64, wi: i64| (((ci * t + ti) * h + hi) * w + wi) as usize;
+    let mut n = 0usize;
+    for ti in 0..t {
+        for hh in 0..hp_ {
+            for ww in 0..wp {
+                let base = n * hp.patch_dim as usize;
+                for pp in 0..p {
+                    for q in 0..p {
+                        let (hi, wi) = (hh * p + pp, ww * p + q);
+                        if hi >= h || wi >= w {
+                            continue;
+                        }
+                        for ci in 0..c {
+                            out[idx(ci, ti, hi, wi)] =
+                                tokens[base + ((pp * p + q) * c + ci) as usize];
+                        }
+                    }
+                }
+                n += 1;
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn patchify_roundtrip() {
+        let hp = Hparams::test_default();
+        let (t, h, w) = (2, 4, 6);
+        let lat: Vec<f32> = (0..(hp.latent_channels * t * h * w))
+            .map(|i| i as f32)
+            .collect();
+        let tok = patchify(&hp, &lat, t, h, w);
+        assert_eq!(tok.len(), (t * (h / 2) * (w / 2) * hp.patch_dim) as usize);
+        // first token: (t=0,h=0..2,w=0..2), entries ordered p, q, c
+        assert_eq!(tok[0], lat[0]); // c0, p0, q0
+        assert_eq!(tok[hp.latent_channels as usize], lat[1]); // p0, q1 -> w=1
+        assert_eq!(tok[2 * hp.latent_channels as usize], lat[w as usize]); // p1 -> h=1
+        assert_eq!(unpatchify(&hp, &tok, t, h, w), lat);
+        // odd sizes pad to whole patches and crop back
+        let (h, w) = (3, 5);
+        let lat: Vec<f32> = (0..(hp.latent_channels * t * h * w))
+            .map(|i| i as f32)
+            .collect();
+        let tok = patchify(&hp, &lat, t, h, w);
+        assert_eq!(tok.len(), (t * 2 * 3 * hp.patch_dim) as usize);
+        assert_eq!(unpatchify(&hp, &tok, t, h, w), lat);
+    }
+
+    #[test]
+    fn mrope_axes() {
+        let hp = Hparams::test_default();
+        // only the H axis differs: frequencies 1,4,7,..,58 change (sin: cos of a
+        // tiny angle rounds to 1 in f32)
+        let (_, s0) = mrope_tables(&hp, &[[3.0, 0.0, 0.0]]);
+        let (_, s1) = mrope_tables(&hp, &[[3.0, 5.0, 0.0]]);
+        for j in 0..64 {
+            let h_axis = j < 60 && j % 3 == 1;
+            assert_eq!(s0[j] != s1[j], h_axis, "j={j}");
+        }
+        let (_, s2) = mrope_tables(&hp, &[[3.0, 0.0, 5.0]]);
+        for j in 0..64 {
+            let w_axis = j < 60 && j % 3 == 2;
+            assert_eq!(s0[j] != s2[j], w_axis, "j={j}");
+        }
+    }
+
+    #[test]
+    fn timestep_embedding_layout() {
+        let e = timestep_embedding(0.995);
+        assert_eq!(e.len(), 256);
+        assert!((e[0] - 0.995f32.cos()).abs() < 1e-6);
+        assert!((e[128] - 0.995f32.sin()).abs() < 1e-6);
+        // last frequency 10000^(-127/128)
+        let f = (-(10000f32).ln() * 127.0 / 128.0).exp();
+        assert!((e[127] - (0.995 * f).cos()).abs() < 1e-6);
+    }
+
+    #[test]
+    fn vision_positions_layout() {
+        let hp = Hparams::test_default();
+        let pos = vision_positions(&hp, 10, [3, 2, 2], 24.0);
+        assert_eq!(pos.len(), 12);
+        assert_eq!(pos[0], [15010.0, 0.0, 0.0]);
+        assert_eq!(pos[3], [15010.0, 1.0, 1.0]);
+        assert_eq!(pos[4], [15011.0, 0.0, 0.0]);
+        // 12 fps: latent frames are 2 base-fps latent frames apart
+        let pos12 = vision_positions(&hp, 10, [3, 2, 2], 12.0);
+        assert_eq!(pos12[4][0], 15012.0);
+        // a single frame is not fps-modulated
+        assert_eq!(vision_positions(&hp, 10, [1, 2, 2], 12.0)[0][0], 15010.0);
+    }
+}

--- a/src/mediagen/cosmos3/mod.rs
+++ b/src/mediagen/cosmos3/mod.rs
@@ -1,0 +1,1122 @@
+//! NVIDIA Cosmos3 (Edge / Nano / Super) text-to-image and text-to-video on
+//! ggml: the omni transformer GGUF published as `ai/cosmos3-*` plus its Wan
+//! 2.2 VAE and tokenizer sidecars. See `dit` for the model, `vae` for the
+//! decoder, `sched` for the UniPC sampler and `tokenizer` for the prompt.
+
+pub mod audio;
+pub mod dit;
+pub mod sched;
+pub mod tokenizer;
+pub mod vae;
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use anyhow::{anyhow, bail, Context as _, Result};
+use serde_json::Value;
+
+use super::backend::Backend;
+use super::ffi::Api;
+use super::weights::{Index, LoadOpts, Weights};
+use super::{dump, ActionMode, Frames, GenParams, Mt19937, Output};
+use dit::UndCache;
+use tokenizer::{PromptSpec, Template, Tokenizer};
+
+/// `Cosmos3OmniPipeline.__call__` defaults.
+pub const DEFAULT_STEPS: i32 = 35;
+pub const DEFAULT_CFG: f32 = 6.0;
+
+/// `Cosmos3OmniTransformer` config, from the GGUF's `cosmos3.*` keys.
+#[derive(Clone, Debug)]
+pub struct Hparams {
+    pub hidden: i64,
+    pub n_layers: i64,
+    pub n_heads: i64,
+    pub n_kv_heads: i64,
+    pub head_dim: i64,
+    pub rms_eps: f32,
+    pub rope_theta: f64,
+    pub mrope_section: [i64; 3],
+    /// `hidden_act == "relu2"` (Nemotron backbone) instead of SwiGLU.
+    pub relu2: bool,
+    pub qk_norm_for_text: bool,
+    pub latent_channels: i64,
+    pub patch: i64,
+    pub patch_dim: i64,
+    pub base_fps: f32,
+    pub enable_fps_modulation: bool,
+    pub temporal_margin: i64,
+    pub timestep_scale: f32,
+    pub sound_gen: bool,
+    pub sound_dim: i64,
+    pub sound_latent_fps: f32,
+    pub action_gen: bool,
+    pub action_dim: i64,
+    pub vae_scale_t: i64,
+    pub vae_scale_s: i64,
+}
+
+impl Hparams {
+    pub fn from_metadata(meta: &std::collections::HashMap<String, String>) -> Result<Hparams> {
+        let cfg: Value = serde_json::from_str(
+            meta.get("cosmos3.transformer_config_json")
+                .ok_or_else(|| anyhow!("GGUF has no cosmos3.transformer_config_json"))?,
+        )
+        .context("cosmos3.transformer_config_json")?;
+        let i = |k: &str, d: i64| cfg.get(k).and_then(Value::as_i64).unwrap_or(d);
+        let f = |k: &str, d: f64| cfg.get(k).and_then(Value::as_f64).unwrap_or(d);
+        let b = |k: &str, d: bool| cfg.get(k).and_then(Value::as_bool).unwrap_or(d);
+        let sect: Vec<i64> = cfg
+            .get("rope_axes_dim")
+            .or_else(|| cfg.get("rope_scaling").and_then(|r| r.get("mrope_section")))
+            .and_then(Value::as_array)
+            .map(|a| a.iter().filter_map(Value::as_i64).collect())
+            .unwrap_or_else(|| vec![24, 20, 20]);
+        let head_dim = i("head_dim", 128);
+        if sect.len() != 3 || sect.iter().sum::<i64>() != head_dim / 2 {
+            bail!("mrope_section {sect:?} does not cover head_dim {head_dim} / 2");
+        }
+        let patch = i("latent_patch_size", 2);
+        let channels = i("latent_channel", 48);
+        Ok(Hparams {
+            hidden: i("hidden_size", 4096),
+            n_layers: i("num_hidden_layers", 36),
+            n_heads: i("num_attention_heads", 32),
+            n_kv_heads: i("num_key_value_heads", 8),
+            head_dim,
+            rms_eps: f("rms_norm_eps", 1e-6) as f32,
+            rope_theta: f("rope_theta", 5_000_000.0),
+            mrope_section: [sect[0], sect[1], sect[2]],
+            relu2: cfg.get("hidden_act").and_then(Value::as_str) == Some("relu2"),
+            qk_norm_for_text: b("qk_norm_for_text", true),
+            latent_channels: channels,
+            patch,
+            patch_dim: i("patch_latent_dim", patch * patch * channels),
+            base_fps: f("base_fps", 24.0) as f32,
+            enable_fps_modulation: b("enable_fps_modulation", true),
+            temporal_margin: i("unified_3d_mrope_temporal_modality_margin", 15000),
+            timestep_scale: f("timestep_scale", 0.001) as f32,
+            sound_gen: b("sound_gen", false),
+            sound_dim: i("sound_dim", 64),
+            sound_latent_fps: f("sound_latent_fps", 25.0) as f32,
+            action_gen: b("action_gen", false),
+            action_dim: i("action_dim", 64),
+            vae_scale_t: 4,
+            vae_scale_s: 16,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn test_default() -> Hparams {
+        Hparams {
+            hidden: 4096,
+            n_layers: 36,
+            n_heads: 32,
+            n_kv_heads: 8,
+            head_dim: 128,
+            rms_eps: 1e-6,
+            rope_theta: 5_000_000.0,
+            mrope_section: [24, 20, 20],
+            relu2: false,
+            qk_norm_for_text: true,
+            latent_channels: 48,
+            patch: 2,
+            patch_dim: 192,
+            base_fps: 24.0,
+            enable_fps_modulation: true,
+            temporal_margin: 15000,
+            timestep_scale: 0.001,
+            sound_gen: false,
+            sound_dim: 64,
+            sound_latent_fps: 25.0,
+            action_gen: false,
+            action_dim: 64,
+            vae_scale_t: 4,
+            vae_scale_s: 16,
+        }
+    }
+}
+
+pub fn is_cosmos3(arch: &str) -> bool {
+    arch == "cosmos3"
+}
+
+/// Everything loaded for one Cosmos3 model.
+pub struct Model {
+    pub hp: Hparams,
+    pub dit: Weights,
+    pub vae: Weights,
+    /// The sound tokenizer's decoder (Nano, Super).
+    pub sound: Option<Weights>,
+    tok: Tokenizer,
+    /// `use_native_flow_schedule` of the pipeline (Edge).
+    native_flow_schedule: bool,
+    latents_mean: Vec<f32>,
+    latents_std: Vec<f32>,
+    flash: bool,
+    /// Understanding-stream caches of the last positive / negative prompt.
+    cond: Option<(Vec<u32>, UndCache)>,
+    ncond: Option<(Vec<u32>, UndCache)>,
+}
+
+fn read_json(path: &Path) -> Result<Value> {
+    serde_json::from_slice(&std::fs::read(path)?).with_context(|| path.display().to_string())
+}
+
+impl Model {
+    pub fn load(
+        api: &'static Api,
+        be: &Backend,
+        idx: &Index,
+        model: &Path,
+        vae: Option<&Path>,
+        files: &BTreeMap<String, PathBuf>,
+        flash: bool,
+    ) -> Result<Model> {
+        let mut hp = Hparams::from_metadata(&idx.metadata)?;
+        let vae_path = vae.ok_or_else(|| anyhow!("the model pack has no VAE (role \"vae\")"))?;
+        let tok_path = files
+            .get("text_tokenizer/tokenizer.json")
+            .or_else(|| files.get("tokenizer.json"))
+            .ok_or_else(|| anyhow!("the model pack has no tokenizer.json"))?;
+        let template = if hp.relu2 {
+            Template::Nemotron
+        } else {
+            Template::Qwen
+        };
+        let model_index = files
+            .get("model_index.json")
+            .and_then(|p| read_json(p).ok());
+        let use_system_prompt = model_index
+            .as_ref()
+            .and_then(|v| v.get("default_use_system_prompt")?.as_bool())
+            .unwrap_or(true);
+        let native_flow_schedule = model_index
+            .as_ref()
+            .and_then(|v| v.get("use_native_flow_schedule")?.as_bool())
+            .unwrap_or(false);
+        let tok = Tokenizer::load(tok_path, template, use_system_prompt)?;
+
+        let (mut latents_mean, mut latents_std) = (vec![0f32; 48], vec![1f32; 48]);
+        match files.get("vae/config.json").map(|p| read_json(p)) {
+            Some(Ok(v)) => {
+                let arr = |k: &str| -> Option<Vec<f32>> {
+                    Some(
+                        v.get(k)?
+                            .as_array()?
+                            .iter()
+                            .filter_map(|x| x.as_f64().map(|x| x as f32))
+                            .collect(),
+                    )
+                };
+                if let (Some(m), Some(s)) = (arr("latents_mean"), arr("latents_std")) {
+                    latents_mean = m;
+                    latents_std = s;
+                }
+                if let Some(t) = v.get("scale_factor_temporal").and_then(Value::as_i64) {
+                    hp.vae_scale_t = t;
+                }
+                if let Some(s) = v.get("scale_factor_spatial").and_then(Value::as_i64) {
+                    hp.vae_scale_s = s;
+                }
+            }
+            Some(Err(e)) => eprintln!("[llmman] mediagen: vae/config.json unreadable ({e}), using defaults"),
+            None => eprintln!("[llmman] mediagen: no vae/config.json in the model pack, using default latent statistics"),
+        }
+        let nch = hp.latent_channels as usize;
+        if latents_mean.len() != nch
+            || latents_std.len() != nch
+            || latents_std.iter().any(|&s| s <= 0.0)
+        {
+            bail!("vae/config.json: latents_mean/latents_std must each hold {nch} positive-std entries");
+        }
+        // the decoder graph is fixed to Wan 2.2's 4x temporal, 16x spatial factors
+        if (hp.vae_scale_t, hp.vae_scale_s) != (4, 16) {
+            bail!(
+                "unsupported VAE scale factors ({}, {}), expected (4, 16)",
+                hp.vae_scale_t,
+                hp.vae_scale_s
+            );
+        }
+
+        let buft = be.weight_buft();
+        let t0 = Instant::now();
+        let dit = Weights::load(api, model, buft, &LoadOpts::default())?;
+        let vae_merged = vae::merged_path(
+            vae_path,
+            &vae_path.parent().map(Path::to_path_buf).unwrap_or_default(),
+        )?;
+        let vae = Weights::load(
+            api,
+            &vae_merged,
+            buft,
+            &LoadOpts {
+                rename: Some(Box::new(|n| {
+                    (n.starts_with("decoder.")
+                        || n.starts_with("post_quant_conv.")
+                        || n.starts_with("encoder.")
+                        || n.starts_with("quant_conv."))
+                    .then(|| n.to_string())
+                })),
+                transform: None,
+            },
+        )?;
+        if !vae.has("decoder.conv_in.weight") {
+            bail!("the VAE is not a Wan decoder (decoder.conv_in.weight missing)");
+        }
+        // the sound tokenizer: weight-norm folded once, next to the VAE's link
+        let sound = match (
+            hp.sound_gen,
+            files.get("sound_tokenizer/diffusion_pytorch_model.safetensors"),
+        ) {
+            (true, Some(path)) => {
+                let cache_dir = path.parent().map(Path::to_path_buf).unwrap_or_default();
+                let folded = audio::folded_path(path, &cache_dir)?;
+                Some(Weights::load(
+                    api,
+                    &folded,
+                    buft,
+                    &LoadOpts {
+                        rename: Some(Box::new(|n| {
+                            n.starts_with("decoder.").then(|| n.to_string())
+                        })),
+                        transform: Some(Box::new(audio::transform)),
+                    },
+                )?)
+            }
+            _ => None,
+        };
+        eprintln!(
+            "[llmman] mediagen: cosmos3 model loaded in {:.1} s ({} layers, hidden {}, {} template, system prompt {use_system_prompt}, sound {}, actions {})",
+            t0.elapsed().as_secs_f64(),
+            hp.n_layers,
+            hp.hidden,
+            match template {
+                Template::Qwen => "qwen",
+                Template::Nemotron => "nemotron",
+            },
+            sound.is_some(),
+            hp.action_gen
+        );
+        Ok(Model {
+            hp,
+            dit,
+            vae,
+            sound,
+            tok,
+            native_flow_schedule,
+            latents_mean,
+            latents_std,
+            flash,
+            cond: None,
+            ncond: None,
+        })
+    }
+
+    fn und(&mut self, be: &Backend, ids: Vec<u32>, negative: bool) -> Result<()> {
+        let slot = if negative {
+            &mut self.ncond
+        } else {
+            &mut self.cond
+        };
+        if matches!(slot, Some((cached, _)) if *cached == ids) {
+            return Ok(());
+        }
+        let t0 = Instant::now();
+        let cache = dit::und_forward(&self.hp, &self.dit, be, &ids)?;
+        eprintln!(
+            "[llmman] mediagen: encoded {} prompt ({} tokens) in {:.2} s",
+            if negative { "negative" } else { "positive" },
+            ids.len(),
+            t0.elapsed().as_secs_f64()
+        );
+        *slot = Some((ids, cache));
+        Ok(())
+    }
+
+    /// Runs one generation; `progress(step, n_steps)` returning `false` cancels.
+    pub fn generate(
+        &mut self,
+        be: &mut Backend,
+        p: &GenParams,
+        mut progress: impl FnMut(i32, i32) -> bool,
+    ) -> Result<Output> {
+        let hp = self.hp.clone();
+        let unit = hp.vae_scale_s * hp.patch;
+        let action = p.action.as_ref();
+        if let Some(a) = action {
+            if !hp.action_gen {
+                bail!("this model has no action generation");
+            }
+            if a.chunk_size < 1 {
+                bail!("action chunk_size must be at least 1");
+            }
+        }
+        let gen_audio = p.gen_audio && self.sound.is_some() && p.n_frames > 1;
+
+        // ── the conditioning frames, the canvas and the frame count ──
+        let mut n_frames;
+        let (w, h);
+        let mut cond_rgb: Option<(Vec<f32>, i64)> = None; // [f][h][w][3] in [-1, 1], frame count
+        let mut cond_latent_frames: Vec<i64> = Vec::new();
+        let mut content = None; // action canvas: (content_h, content_w)
+        if let Some(a) = action {
+            n_frames = a.chunk_size + 1;
+            let src = p
+                .image
+                .as_ref()
+                .or(p.video.as_ref())
+                .ok_or_else(|| anyhow!("an action run needs a conditioning image or video"))?;
+            let (frames, ch, cw, th, tw) = action_frames(src, a.resolution_tier, n_frames)?;
+            (h, w) = (th, tw);
+            content = Some((ch, cw));
+            cond_rgb = Some((frames, n_frames));
+            let lt = (n_frames - 1) / hp.vae_scale_t + 1;
+            cond_latent_frames = match a.mode {
+                ActionMode::InverseDynamics => (0..lt).collect(),
+                _ => vec![0],
+            };
+        } else {
+            (w, h) = (p.width, p.height);
+            if w <= 0 || h <= 0 || w % unit != 0 || h % unit != 0 {
+                bail!("width and height must be positive multiples of {unit}");
+            }
+            n_frames = p.n_frames.max(1);
+            if (n_frames - 1) % hp.vae_scale_t != 0 {
+                n_frames = (n_frames - 1) / hp.vae_scale_t * hp.vae_scale_t + 1;
+                eprintln!(
+                    "[llmman] mediagen: n_frames must be {}k+1, using {n_frames}",
+                    hp.vae_scale_t
+                );
+            }
+            let lt = (n_frames - 1) / hp.vae_scale_t + 1;
+            if let (Some(vid), true) = (&p.video, n_frames > 1) {
+                // video-to-video: the clip's leading frames stay clean at the given latent
+                // indexes; the causal encoder needs the pixel frames up to the last of them
+                let mut idx: Vec<i64> = p
+                    .condition_frames
+                    .iter()
+                    .copied()
+                    .filter(|&i| i >= 0 && i < lt)
+                    .collect();
+                idx.sort_unstable();
+                idx.dedup();
+                if idx.is_empty() {
+                    bail!("condition_frames has no latent frame below {lt}");
+                }
+                let n_px = idx[idx.len() - 1] * hp.vae_scale_t + 1;
+                cond_rgb = Some((clip_frames(vid, w, h, n_px, p.condition_keep_last)?, n_px));
+                cond_latent_frames = idx;
+            } else if let (Some(img), true) = (&p.image, n_frames > 1) {
+                // image-to-video: frame 0 is the image, the rest is generated; the
+                // causal encoder's first latent frame only sees the first pixel frame
+                cond_rgb = Some((cover_crop(img, w, h)?, 1));
+                cond_latent_frames = vec![0];
+            }
+        }
+        if (n_frames - 1) % hp.vae_scale_t != 0 {
+            bail!(
+                "the clip must have {}k+1 frames, got {n_frames}",
+                hp.vae_scale_t
+            );
+        }
+        let n_steps = if p.n_steps > 0 {
+            p.n_steps
+        } else {
+            DEFAULT_STEPS
+        };
+        let cfg = if p.cfg_scale > 0.0 {
+            p.cfg_scale
+        } else if action.is_some() {
+            1.0
+        } else {
+            DEFAULT_CFG
+        };
+        let use_cfg = cfg != 1.0;
+        if !(p.fps.is_finite() && p.fps > 0.0) {
+            bail!("fps must be positive");
+        }
+        let flow_shift = p.flow_shift.or(action.map(|_| ACTION_FLOW_SHIFT));
+        if flow_shift.is_some_and(|f| !(f.is_finite() && f > 0.0)) {
+            bail!("flow_shift must be positive");
+        }
+
+        // ── prompts ──
+        let (cond_ids, uncond_ids) = match action {
+            Some(a) => {
+                let text = action_prompt(&p.prompt, &a.view_point, n_frames, p.fps, h, w);
+                (
+                    self.tok.encode_chat(&text, None)?,
+                    self.tok.encode_chat(&p.negative_prompt, None)?,
+                )
+            }
+            None => {
+                let spec = |prompt: &str, negative: bool| PromptSpec {
+                    prompt: prompt.to_string(),
+                    negative,
+                    n_frames,
+                    fps: p.fps,
+                    width: w,
+                    height: h,
+                };
+                (
+                    self.tok.encode(&spec(&p.prompt, false))?,
+                    self.tok.encode(&spec(&p.negative_prompt, true))?,
+                )
+            }
+        };
+        self.und(be, cond_ids, false)?;
+        if use_cfg {
+            self.und(be, uncond_ids, true)?;
+        }
+
+        // ── latents ──
+        let lt = (n_frames - 1) / hp.vae_scale_t + 1;
+        let (mut lh, mut lw) = (h / hp.vae_scale_s, w / hp.vae_scale_s);
+        let c = hp.latent_channels as usize;
+        let seed = p.seed.unwrap_or_else(super::rand_seed);
+        let mut rng = Mt19937::new(seed);
+        // conditioning latents: the encoded frames, normalized
+        let x0 = match &cond_rgb {
+            Some((rgb, nf)) => {
+                let t0 = Instant::now();
+                let frames = vae::encode(&self.vae, be, rgb, *nf, h, w)?;
+                be.release_compute()?;
+                eprintln!(
+                    "[llmman] mediagen: encoded {nf} conditioning frame(s) in {:.2} s",
+                    t0.elapsed().as_secs_f64()
+                );
+                Some(frames)
+            }
+            None => None,
+        };
+        if let Some((ch, cw)) = content {
+            // the action canvas is padded; the model works on the content region
+            lh = (ch / hp.vae_scale_s).max(1);
+            lw = (cw / hp.vae_scale_s).max(1);
+        }
+        let n_lat = c * (lt * lh * lw) as usize;
+        let mut x = vec![0f32; n_lat];
+        if !noise_from_env("MEDIAGEN_NOISE", &mut x)? {
+            for v in x.iter_mut() {
+                *v = rng.normal();
+            }
+        }
+        dump("noise_video", &x);
+        let hw = (lh * lw) as usize;
+        let lat_idx = |ci: usize, t: usize, hwi: usize| (ci * lt as usize + t) * hw + hwi;
+        if let Some(frames) = &x0 {
+            // frames[t] is [C][H_full][W_full] in VAE space; crop to the content and normalize
+            let (fh, fw) = ((h / hp.vae_scale_s) as usize, (w / hp.vae_scale_s) as usize);
+            for &t in &cond_latent_frames {
+                let f = &frames[t as usize];
+                for ci in 0..c {
+                    let (m, sd) = (self.latents_mean[ci], self.latents_std[ci]);
+                    for y in 0..lh as usize {
+                        for xx in 0..lw as usize {
+                            x[lat_idx(ci, t as usize, y * lw as usize + xx)] =
+                                (f[(ci * fh + y) * fw + xx] - m) / sd;
+                        }
+                    }
+                }
+            }
+            dump("cond_latent", &x);
+        }
+        let grid = [
+            lt,
+            (lh + hp.patch - 1) / hp.patch,
+            (lw + hp.patch - 1) / hp.patch,
+        ];
+        let n_vis = grid.iter().product::<i64>();
+        let frame_tokens = (grid[1] * grid[2]) as usize;
+        let vis_noisy: Option<Vec<f32>> = (!cond_latent_frames.is_empty()).then(|| {
+            let mut m = vec![1f32; n_vis as usize];
+            for &t in &cond_latent_frames {
+                m[t as usize * frame_tokens..(t as usize + 1) * frame_tokens].fill(0.0);
+            }
+            m
+        });
+
+        // sound latents: all noisy
+        let n_sound = if gen_audio {
+            let samples = (n_frames as f64 / p.fps as f64 * audio::SAMPLE_RATE as f64) as i64;
+            (samples + audio::HOP - 1) / audio::HOP
+        } else {
+            0
+        };
+        let mut sound = vec![0f32; (n_sound * hp.sound_dim) as usize];
+        if !noise_from_env("MEDIAGEN_NOISE_SOUND", &mut sound)? {
+            for v in sound.iter_mut() {
+                *v = rng.normal();
+            }
+        }
+
+        // action latents: forward dynamics conditions on the given actions, the
+        // other modes denoise them; channels past the domain's width stay 0
+        let (domain_id, raw_dim) = match action {
+            Some(a) => (
+                domain_id(&a.domain)
+                    .ok_or_else(|| anyhow!("unknown action domain {:?}", a.domain))?,
+                raw_action_dim(&a.domain).ok_or_else(|| {
+                    anyhow!("action domain {:?} has no canonical action width", a.domain)
+                })?,
+            ),
+            None => (0, 0),
+        };
+        let n_act = action.map_or(0, |a| a.chunk_size);
+        if action.is_some() && hp.action_dim < raw_dim {
+            bail!(
+                "the model's action_dim {} is below the domain's width {raw_dim}",
+                hp.action_dim
+            );
+        }
+        let ad = hp.action_dim as usize;
+        let mut act = vec![0f32; (n_act as usize) * ad];
+        let act_noisy: Option<Vec<f32>> = match action {
+            Some(a) if a.mode == ActionMode::ForwardDynamics => {
+                if a.actions.is_empty() {
+                    bail!("forward dynamics needs the actions");
+                }
+                for t in 0..n_act as usize {
+                    let row = &a.actions[t.min(a.actions.len() - 1)];
+                    if row.len() != raw_dim as usize {
+                        bail!(
+                            "action {t} has {} values, domain {:?} takes {raw_dim}",
+                            row.len(),
+                            a.domain
+                        );
+                    }
+                    act[t * ad..t * ad + row.len()].copy_from_slice(row);
+                }
+                Some(vec![0.0; n_act as usize])
+            }
+            Some(_) => {
+                if noise_from_env("MEDIAGEN_NOISE_ACTION", &mut act)? {
+                    for t in 0..n_act as usize {
+                        act[t * ad + raw_dim as usize..(t + 1) * ad].fill(0.0);
+                    }
+                } else {
+                    for t in 0..n_act as usize {
+                        for d in 0..raw_dim as usize {
+                            act[t * ad + d] = rng.normal();
+                        }
+                    }
+                }
+                None
+            }
+            None => None,
+        };
+
+        // ── positions ──
+        let n_text = |negative: bool| -> i64 {
+            let slot = if negative { &self.ncond } else { &self.cond };
+            slot.as_ref().map_or(0, |(ids, _)| ids.len() as i64)
+        };
+        let tables = |negative: bool| {
+            let nt = n_text(negative);
+            let vis = dit::mrope_tables(&hp, &dit::vision_positions(&hp, nt, grid, p.fps));
+            let snd = dit::mrope_tables(
+                &hp,
+                &dit::sound_positions(&hp, nt, n_sound, hp.sound_latent_fps),
+            );
+            let act = dit::mrope_tables(&hp, &dit::action_positions(&hp, nt, n_act, p.fps));
+            (vis, snd, act)
+        };
+        let cond_tables = tables(false);
+        let uncond_tables = use_cfg.then(|| tables(true));
+
+        // ── sampling ──
+        let (sigmas, timesteps) = match flow_shift {
+            Some(shift) => sched::schedule_flow(n_steps as usize, shift, self.native_flow_schedule),
+            None => sched::schedule(n_steps as usize),
+        };
+        let mut solver_v = sched::UniPC::new(sigmas.clone());
+        let mut solver_s = sched::UniPC::new(sigmas.clone());
+        let mut solver_a = sched::UniPC::new(sigmas);
+        eprintln!(
+            "[llmman] mediagen: generating {}x{}, {n_frames} frame(s), {n_vis} vision tokens{}{}, {n_steps} steps, cfg {cfg:.1}, seed {seed}{}",
+            lw * hp.vae_scale_s,
+            lh * hp.vae_scale_s,
+            if n_sound > 0 { format!(", {n_sound} sound tokens") } else { String::new() },
+            if n_act > 0 { format!(", {n_act} action tokens ({})", action.unwrap().mode.name()) } else { String::new() },
+            flow_shift.map_or(String::new(), |s| format!(", flow shift {s}"))
+        );
+        let cond = &self.cond.as_ref().expect("positive prompt encoded").1;
+        let ncond = use_cfg.then(|| &self.ncond.as_ref().expect("negative prompt encoded").1);
+        let action_noisy = act_noisy.as_deref();
+        let has_noisy_action = n_act > 0 && action_noisy.is_none();
+        for (i, &t) in timesteps.iter().enumerate() {
+            let t0 = Instant::now();
+            let tokens = dit::patchify(&hp, &x, lt, lh, lw);
+            let timestep = t as f32 * hp.timestep_scale;
+            let run = |und: &UndCache, tb: &(dit::Tables, dit::Tables, dit::Tables)| {
+                let inp = dit::GenInputs {
+                    vision: dit::Segment {
+                        tokens: &tokens,
+                        n: n_vis,
+                        cos: &tb.0 .0,
+                        sin: &tb.0 .1,
+                        noisy: vis_noisy.as_deref(),
+                    },
+                    sound: (n_sound > 0).then(|| dit::Segment {
+                        tokens: &sound,
+                        n: n_sound,
+                        cos: &tb.1 .0,
+                        sin: &tb.1 .1,
+                        noisy: None,
+                    }),
+                    action: (n_act > 0).then(|| {
+                        (
+                            dit::Segment {
+                                tokens: &act,
+                                n: n_act,
+                                cos: &tb.2 .0,
+                                sin: &tb.2 .1,
+                                noisy: action_noisy,
+                            },
+                            domain_id,
+                        )
+                    }),
+                    timestep,
+                    und,
+                    flash: self.flash,
+                };
+                dit::gen_forward(&hp, &self.dit, be, &inp)
+            };
+            let mut out = run(cond, &cond_tables)?;
+            if let (Some(nc), Some(tb)) = (ncond, &uncond_tables) {
+                let u = run(nc, tb)?;
+                for (o, u) in out.vision.iter_mut().zip(&u.vision) {
+                    *o = u + cfg * (*o - u);
+                }
+                for (o, u) in out.sound.iter_mut().zip(&u.sound) {
+                    *o = u + cfg * (*o - u);
+                }
+                for (o, u) in out.action.iter_mut().zip(&u.action) {
+                    *o = u + cfg * (*o - u);
+                }
+            }
+            let mut v = dit::unpatchify(&hp, &out.vision, lt, lh, lw);
+            // conditioning frames keep their velocity at zero, so the solver leaves them
+            for &tf in &cond_latent_frames {
+                for ci in 0..c {
+                    v[lat_idx(ci, tf as usize, 0)..lat_idx(ci, tf as usize, 0) + hw].fill(0.0);
+                }
+            }
+            if i == 0 {
+                dump("pred0_video", &v);
+                dump("pred0_sound", &out.sound);
+                dump("pred0_action", &out.action);
+            }
+            x = solver_v.step(&v, &x);
+            if n_sound > 0 {
+                sound = solver_s.step(&out.sound, &sound);
+            }
+            if has_noisy_action {
+                let mut va = out.action;
+                for t in 0..n_act as usize {
+                    va[t * ad + raw_dim as usize..(t + 1) * ad].fill(0.0);
+                }
+                act = solver_a.step(&va, &act);
+                for t in 0..n_act as usize {
+                    act[t * ad + raw_dim as usize..(t + 1) * ad].fill(0.0);
+                }
+            }
+            eprintln!(
+                "[llmman] mediagen: step {}/{n_steps} t {t} sigma {:.4} -> {:.4} ({:.2} s)",
+                i + 1,
+                solver_v.sigma(i),
+                solver_v.sigma(i + 1),
+                t0.elapsed().as_secs_f64()
+            );
+            if !progress(i as i32 + 1, n_steps) {
+                bail!("cancelled");
+            }
+        }
+        dump("latents", &x);
+        // debugging aids: decode given latents instead of the sampled ones
+        noise_from_env("MEDIAGEN_LATENTS", &mut x)?;
+        noise_from_env("MEDIAGEN_LATENTS_SOUND", &mut sound)?;
+        dump("latents_sound", &sound);
+        be.release_compute()?;
+
+        // ── decode ──
+        let t0 = Instant::now();
+        let frames: Vec<Vec<f32>> = (0..lt as usize)
+            .map(|t| {
+                let mut f = vec![0f32; c * hw];
+                for ci in 0..c {
+                    let (m, sd) = (self.latents_mean[ci], self.latents_std[ci]);
+                    for hwi in 0..hw {
+                        f[ci * hw + hwi] = x[lat_idx(ci, t, hwi)] * sd + m;
+                    }
+                }
+                f
+            })
+            .collect();
+        let dec = vae::decode(&self.vae, be, &frames, hp.latent_channels, lh, lw);
+        be.release_compute()?;
+        let dec = dec?;
+        eprintln!(
+            "[llmman] mediagen: decoded {} frame(s) of {}x{} in {:.2} s",
+            dec.frames,
+            dec.width,
+            dec.height,
+            t0.elapsed().as_secs_f64()
+        );
+        let nf = dec.frames.min(n_frames);
+        let mut out = Output {
+            width: dec.width,
+            height: dec.height,
+            n_frames: nf,
+            fps: p.fps,
+            rgb: dec.rgb[..(dec.width * dec.height * 3 * nf) as usize]
+                .iter()
+                .map(|v| (((v + 1.0) * 0.5).clamp(0.0, 1.0) * 255.0).round() as u8)
+                .collect(),
+            revised_prompt: p.prompt.clone(),
+            seed,
+            ..Default::default()
+        };
+        if n_sound > 0 {
+            let t0 = Instant::now();
+            let snd = self.sound.as_ref().expect("sound tokenizer");
+            let pcm = audio::decode(snd, be, &sound, n_sound);
+            be.release_compute()?;
+            match pcm {
+                Ok(pcm) => {
+                    let want = (n_frames as f64 / p.fps as f64 * audio::SAMPLE_RATE as f64).round()
+                        as usize;
+                    let n = (pcm.len() / 2).min(want);
+                    out.sample_rate = audio::SAMPLE_RATE;
+                    out.n_channels = 2;
+                    out.pcm = pcm[..n * 2].to_vec();
+                    eprintln!(
+                        "[llmman] mediagen: decoded {:.2} s of audio in {:.2} s",
+                        n as f64 / audio::SAMPLE_RATE as f64,
+                        t0.elapsed().as_secs_f64()
+                    );
+                }
+                Err(e) => eprintln!(
+                    "[llmman] mediagen: sound decoding failed ({e}), returning video only"
+                ),
+            }
+        }
+        if has_noisy_action {
+            out.actions = (0..n_act as usize)
+                .map(|t| act[t * ad..t * ad + raw_dim as usize].to_vec())
+                .collect();
+        }
+        Ok(out)
+    }
+}
+
+/// Debugging aid: fills `out` from the raw f32 file named by `var` (shared noise with a reference run).
+fn noise_from_env(var: &str, out: &mut [f32]) -> Result<bool> {
+    let Ok(path) = std::env::var(var) else {
+        return Ok(false);
+    };
+    let bytes = std::fs::read(&path).with_context(|| path.clone())?;
+    if bytes.len() != out.len() * 4 {
+        bail!("{var} must hold {} little-endian f32 values", out.len());
+    }
+    for (v, c) in out.iter_mut().zip(bytes.as_chunks::<4>().0) {
+        *v = f32::from_le_bytes(*c);
+    }
+    eprintln!("[llmman] mediagen: using the noise from {var}");
+    Ok(true)
+}
+
+/// The scheduler shift the reference action examples run with (`--flow-shift 10`).
+pub const ACTION_FLOW_SHIFT: f32 = 10.0;
+
+// ── embodiment tables (`_EMBODIMENT_TO_DOMAIN_ID`, `_EMBODIMENT_TO_RAW_ACTION_DIM`) ──
+
+pub fn domain_id(name: &str) -> Option<i64> {
+    Some(match name {
+        "no_action" => 0,
+        "av" => 1,
+        "camera_pose" => 2,
+        "hand_pose" => 3,
+        "pusht" => 4,
+        "libero" => 5,
+        "umi" => 6,
+        "bridge_orig_lerobot" => 7,
+        "droid_lerobot" | "robomind-franka" => 8,
+        "galbot" => 9,
+        "robomind-franka-dual" => 12,
+        "robomind-ur" => 13,
+        "agibotworld" | "agibot_gear_gripper" | "agibot_gear_gripper_ext" => 15,
+        "fractal" => 20,
+        _ => return None,
+    })
+}
+
+pub fn raw_action_dim(name: &str) -> Option<i64> {
+    Some(match name {
+        "av" | "camera_pose" => 9,
+        "pusht" => 2,
+        "umi"
+        | "bridge_orig_lerobot"
+        | "droid_lerobot"
+        | "robomind-franka"
+        | "robomind-ur"
+        | "fractal" => 10,
+        "robomind-franka-dual" => 20,
+        "galbot" => 30,
+        "agibotworld" | "agibot_gear_gripper" | "agibot_gear_gripper_ext" => 29,
+        "hand_pose" => 57,
+        _ => return None,
+    })
+}
+
+/// `_ACTION_RESOLUTION_BINS[tier]`: (aspect h/w, (height, width)).
+fn resolution_bins(tier: i64) -> Option<&'static [(f64, i64, i64)]> {
+    Some(match tier {
+        256 => &[
+            (1.0, 256, 256),
+            (0.8, 256, 320),
+            (1.25, 320, 256),
+            (0.6, 192, 320),
+            (1.6666666666666667, 320, 192),
+        ],
+        480 => &[
+            (1.0, 640, 640),
+            (0.7391304347826086, 544, 736),
+            (1.3529411764705883, 736, 544),
+            (0.5769230769230769, 480, 832),
+            (1.7333333333333334, 832, 480),
+        ],
+        704 => &[
+            (1.0, 960, 960),
+            (0.7647058823529411, 832, 1088),
+            (1.3076923076923077, 1088, 832),
+            (0.55, 704, 1280),
+            (1.8181818181818181, 1280, 704),
+        ],
+        720 => &[
+            (1.0, 960, 960),
+            (0.7536231884057971, 832, 1104),
+            (1.3269230769230769, 1104, 832),
+            (0.5625, 720, 1280),
+            (1.7777777777777777, 1280, 720),
+        ],
+        _ => return None,
+    })
+}
+
+/// `_build_action_json_prompt`
+pub fn action_prompt(
+    description: &str,
+    view_point: &str,
+    n_frames: i64,
+    fps: f32,
+    height: i64,
+    width: i64,
+) -> String {
+    let secs = if fps > 0.0 {
+        n_frames as f64 / fps as f64
+    } else {
+        0.0
+    };
+    let duration = secs as i64;
+    let end = secs.round() as i64;
+    let (minutes, seconds) = (end / 60, end % 60);
+    let mut desc = description.trim().to_string();
+    if !desc.is_empty() && !desc.ends_with(['.', '!', '?']) {
+        desc.push('.');
+    }
+    let framing = match view_point {
+        "ego_view" => Some("This video is captured from a first-person perspective looking at the scene."),
+        "third_person_view" => Some("This video is captured from a third-person perspective looking towards the agent from the front."),
+        "wrist_view" => Some("This video is captured from a wrist-mounted camera."),
+        "concat_view" => Some("This video contains concatenated views from multiple camera perspectives."),
+        _ => None,
+    };
+    let ratio = if height > 0 {
+        width as f64 / height as f64
+    } else {
+        1.0
+    };
+    let aspect = ["1,1", "4,3", "3,4", "16,9", "9,16"]
+        .into_iter()
+        .min_by(|a, b| {
+            let r = |s: &str| {
+                let (x, y) = s.split_once(',').unwrap();
+                x.parse::<f64>().unwrap() / y.parse::<f64>().unwrap()
+            };
+            (r(a) - ratio).abs().total_cmp(&(r(b) - ratio).abs())
+        })
+        .unwrap();
+    // json.dumps key order: cinematography (if any), actions, duration, fps, resolution, aspect_ratio
+    let mut obj = serde_json::Map::new();
+    if let Some(f) = framing {
+        obj.insert("cinematography".into(), serde_json::json!({"framing": f}));
+    }
+    obj.insert(
+        "actions".into(),
+        serde_json::json!([{"time": format!("0:00-{minutes}:{seconds:02}"), "description": desc}]),
+    );
+    obj.insert("duration".into(), Value::String(format!("{duration}s")));
+    obj.insert("fps".into(), Value::from(fps as f64));
+    obj.insert(
+        "resolution".into(),
+        serde_json::json!({"H": height, "W": width}),
+    );
+    obj.insert("aspect_ratio".into(), Value::String(aspect.into()));
+    python_json(&Value::Object(obj))
+}
+
+/// `json.dumps` with its default separators (`", "` and `": "`) and float formatting.
+fn python_json(v: &Value) -> String {
+    match v {
+        Value::Object(m) => format!(
+            "{{{}}}",
+            m.iter()
+                .map(|(k, v)| format!("{}: {}", Value::String(k.clone()), python_json(v)))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        Value::Array(a) => format!(
+            "[{}]",
+            a.iter().map(python_json).collect::<Vec<_>>().join(", ")
+        ),
+        Value::Number(n) if n.is_f64() => {
+            let f = n.as_f64().unwrap();
+            if f.fract() == 0.0 && f.abs() < 1e16 {
+                format!("{f:.1}")
+            } else {
+                format!("{f}")
+            }
+        }
+        other => other.to_string(),
+    }
+}
+
+/// `_preprocess_conditioning_image`: cover-scale, center-crop to `w x h`, `[-1, 1]`.
+fn cover_crop(img: &Frames, w: i64, h: i64) -> Result<Vec<f32>> {
+    if img.n_frames < 1 {
+        bail!("no conditioning image");
+    }
+    let (sw, sh) = (img.width as f64, img.height as f64);
+    let scale = (w as f64 / sw).max(h as f64 / sh);
+    let (rw, rh) = ((scale * sw).ceil() as i64, (scale * sh).ceil() as i64);
+    let resized = resize_rgb(
+        &img.rgb[..(img.width * img.height * 3) as usize],
+        img.width,
+        img.height,
+        rw,
+        rh,
+        false,
+    );
+    let top = ((rh - h) as f64 / 2.0).round() as i64;
+    let left = ((rw - w) as f64 / 2.0).round() as i64;
+    let mut out = vec![0f32; (w * h * 3) as usize];
+    for y in 0..h {
+        for x in 0..w {
+            for ch in 0..3 {
+                let v = resized[(((y + top) * rw + x + left) * 3 + ch) as usize];
+                out[((y * w + x) * 3 + ch) as usize] = v.round().clamp(0.0, 255.0) / 127.5 - 1.0;
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// `VideoProcessor.preprocess_video`: the clip's first (or last) `max_frames`
+/// frames resized straight to `w x h`, the last repeated when it is shorter.
+fn clip_frames(vid: &Frames, w: i64, h: i64, max_frames: i64, keep_last: bool) -> Result<Vec<f32>> {
+    if vid.n_frames < 1 {
+        bail!("no conditioning frames");
+    }
+    let n = vid.n_frames.min(max_frames);
+    let first = if keep_last { vid.n_frames - n } else { 0 };
+    let frame_px = (vid.width * vid.height * 3) as usize;
+    let mut out = Vec::with_capacity((max_frames * w * h * 3) as usize);
+    let mut last = Vec::new();
+    for f in 0..max_frames {
+        if f < n {
+            let fi = (first + f) as usize;
+            let frame = &vid.rgb[fi * frame_px..(fi + 1) * frame_px];
+            let resized = if (vid.width, vid.height) != (w, h) {
+                resize_rgb(frame, vid.width, vid.height, w, h, false)
+            } else {
+                frame.iter().map(|&v| v as f32).collect()
+            };
+            last = resized
+                .iter()
+                .map(|v| v.round().clamp(0.0, 255.0) / 127.5 - 1.0)
+                .collect();
+        }
+        out.extend_from_slice(&last);
+    }
+    Ok(out)
+}
+
+/// `_prepare_action_video_conditioning`: the clip downscaled into the tier's
+/// canvas and padded right/bottom; returns frames, content size, canvas size.
+fn action_frames(src: &Frames, tier: i64, n_frames: i64) -> Result<(Vec<f32>, i64, i64, i64, i64)> {
+    let bins = resolution_bins(tier)
+        .ok_or_else(|| anyhow!("action resolution tier must be 256, 480, 704 or 720"))?;
+    if src.n_frames < 1 {
+        bail!("no conditioning frames");
+    }
+    let (fw, fh) = (src.width, src.height);
+    let ar = fh as f64 / fw as f64;
+    let &(_, th, tw) = bins
+        .iter()
+        .min_by(|a, b| (a.0 - ar).abs().total_cmp(&(b.0 - ar).abs()))
+        .unwrap();
+    let scale = (tw as f64 / fw as f64).min(th as f64 / fh as f64).min(1.0);
+    let ch = ((scale * fh as f64 + 0.5) as i64).max(1);
+    let cw = ((scale * fw as f64 + 0.5) as i64).max(1);
+    let (pad_r, pad_b) = (tw - cw, th - ch);
+    let reflect = !(pad_r >= cw || pad_b >= ch);
+    let frame_px = (fw * fh * 3) as usize;
+    let mut out = Vec::with_capacity((n_frames * th * tw * 3) as usize);
+    for f in 0..n_frames {
+        // shorter clips repeat their last frame
+        let fi = f.min(src.n_frames - 1) as usize;
+        let frame = &src.rgb[fi * frame_px..(fi + 1) * frame_px];
+        let content = if (ch, cw) != (fh, fw) {
+            resize_rgb(frame, fw, fh, cw, ch, true)
+        } else {
+            frame.iter().map(|&v| v as f32).collect()
+        };
+        for y in 0..th {
+            let sy = pad_index(y, ch, reflect);
+            for x in 0..tw {
+                let sx = pad_index(x, cw, reflect);
+                for c in 0..3 {
+                    let v = content[((sy * cw + sx) * 3 + c) as usize];
+                    out.push(v.round().clamp(0.0, 255.0) / 127.5 - 1.0);
+                }
+            }
+        }
+    }
+    Ok((out, ch, cw, th, tw))
+}
+
+fn pad_index(i: i64, n: i64, reflect: bool) -> i64 {
+    if i < n {
+        i
+    } else if reflect {
+        2 * n - 2 - i
+    } else {
+        n - 1
+    }
+}
+
+/// Antialiased resize of RGB8 `[h][w][3]` to f32 `[nh][nw][3]` (triangle or Catmull-Rom).
+fn resize_rgb(src: &[u8], w: i64, h: i64, nw: i64, nh: i64, bicubic: bool) -> Vec<f32> {
+    use image::imageops::FilterType;
+    let img = image::RgbImage::from_raw(w as u32, h as u32, src.to_vec()).expect("rgb buffer");
+    let filter = if bicubic {
+        FilterType::CatmullRom
+    } else {
+        FilterType::Triangle
+    };
+    let out = image::imageops::resize(&img, nw as u32, nh as u32, filter);
+    out.into_raw().into_iter().map(|v| v as f32).collect()
+}

--- a/src/mediagen/cosmos3/sched.rs
+++ b/src/mediagen/cosmos3/sched.rs
@@ -1,0 +1,254 @@
+//! diffusers' `UniPCMultistepScheduler` as Cosmos3 configures it: Karras sigmas
+//! mapped to flow sigmas, `predict_x0`, order 2, `bh2`, corrector after step 0.
+
+/// `sigmas` (n+1, last 0) and the integer `timesteps` (n) the transformer is conditioned on.
+pub fn schedule(n_steps: usize) -> (Vec<f32>, Vec<i64>) {
+    let n = n_steps.max(1);
+    let (smin, smax, rho) = (0.147f64, 200.0f64, 7.0f64);
+    let (a, b) = (smax.powf(1.0 / rho), smin.powf(1.0 / rho));
+    let mut sigmas = Vec::with_capacity(n + 1);
+    let mut timesteps = Vec::with_capacity(n);
+    for i in 0..n {
+        let ramp = if n > 1 {
+            i as f64 / (n - 1) as f64
+        } else {
+            0.0
+        };
+        let k = (a + ramp * (b - a)).powf(rho);
+        let s = k / (k + 1.0);
+        sigmas.push(s as f32);
+        timesteps.push((s * 1000.0).trunc() as i64);
+    }
+    sigmas.push(0.0);
+    (sigmas, timesteps)
+}
+
+/// The `use_karras_sigmas=False` schedule the action examples run with:
+/// flow sigmas shifted by `shift` (`s' = shift*s / (1 + (shift-1)*s)`), from the
+/// pipeline's own linspace when `native` (`Cosmos3-Edge`) or the scheduler's.
+pub fn schedule_flow(n_steps: usize, shift: f32, native: bool) -> (Vec<f32>, Vec<i64>) {
+    let n = n_steps.max(1);
+    let shift = shift as f64;
+    let mut sigmas = Vec::with_capacity(n + 1);
+    let mut timesteps = Vec::with_capacity(n);
+    for i in 0..n {
+        // native: linspace(1 - 1/1000, 0, n+1)[:-1]; scheduler: linspace(1, 1/1000, n+1)[:-1]
+        let s = if native {
+            (1.0 - 1.0 / 1000.0) * (1.0 - i as f64 / n as f64)
+        } else {
+            1.0 - (1.0 - 1.0 / 1000.0) * i as f64 / n as f64
+        };
+        let mut s = shift * s / (1.0 + (shift - 1.0) * s);
+        if i == 0 && (s - 1.0).abs() < 1e-6 {
+            s -= 1e-6;
+        }
+        sigmas.push(s as f32);
+        timesteps.push((s * 1000.0).trunc() as i64);
+    }
+    sigmas.push(0.0);
+    (sigmas, timesteps)
+}
+
+/// Per-modality solver state; one per latent stream (vision, sound, action).
+pub struct UniPC {
+    sigmas: Vec<f32>,
+    step: usize,
+    /// x0 predictions of the last two steps: `[older, newest]`.
+    outputs: [Option<Vec<f32>>; 2],
+    last_sample: Option<Vec<f32>>,
+    lower_order_nums: usize,
+    this_order: usize,
+}
+
+fn lam(sigma: f32) -> f32 {
+    (1.0 - sigma).ln() - sigma.ln()
+}
+
+impl UniPC {
+    pub fn new(sigmas: Vec<f32>) -> Self {
+        UniPC {
+            sigmas,
+            step: 0,
+            outputs: [None, None],
+            last_sample: None,
+            lower_order_nums: 0,
+            this_order: 1,
+        }
+    }
+
+    pub fn n_steps(&self) -> usize {
+        self.sigmas.len() - 1
+    }
+
+    pub fn sigma(&self, i: usize) -> f32 {
+        self.sigmas[i]
+    }
+
+    /// One `scheduler.step(velocity, t, sample)`: returns the next sample.
+    pub fn step(&mut self, velocity: &[f32], sample: &[f32]) -> Vec<f32> {
+        let i = self.step;
+        let s_i = self.sigmas[i];
+        // convert_model_output: flow prediction -> x0
+        let x0: Vec<f32> = sample
+            .iter()
+            .zip(velocity)
+            .map(|(x, v)| x - s_i * v)
+            .collect();
+
+        let mut sample = sample.to_vec();
+        if i > 0 && self.last_sample.is_some() {
+            sample = self.corrector(&x0, &sample);
+        }
+
+        self.outputs[0] = self.outputs[1].take();
+        self.outputs[1] = Some(x0);
+
+        let n = self.n_steps();
+        let mut order = 2.min(n - i);
+        order = order.min(self.lower_order_nums + 1);
+        self.this_order = order.max(1);
+
+        self.last_sample = Some(sample.clone());
+        let prev = self.predictor(&sample, self.this_order);
+        if self.lower_order_nums < 2 {
+            self.lower_order_nums += 1;
+        }
+        self.step += 1;
+        prev
+    }
+
+    /// multistep_uni_p_bh_update
+    fn predictor(&self, x: &[f32], order: usize) -> Vec<f32> {
+        let i = self.step;
+        let m0 = self.outputs[1].as_ref().expect("model output");
+        let sigma_t = self.sigmas[i + 1];
+        let sigma_s0 = self.sigmas[i];
+        if sigma_t == 0.0 {
+            // lambda_t = +inf: the predictor returns the x0 estimate exactly
+            return m0.clone();
+        }
+        let alpha_t = 1.0 - sigma_t;
+        let h = lam(sigma_t) - lam(sigma_s0);
+        let hh = -h;
+        let h_phi_1 = hh.exp_m1();
+        let b_h = h_phi_1; // bh2
+        let ratio = sigma_t / sigma_s0;
+        let mut out: Vec<f32> = x
+            .iter()
+            .zip(m0)
+            .map(|(x, m)| ratio * x - alpha_t * h_phi_1 * m)
+            .collect();
+        if order == 2 {
+            let m1 = self.outputs[0].as_ref().expect("previous model output");
+            let rk = (lam(self.sigmas[i - 1]) - lam(sigma_s0)) / h;
+            // D1 = (m1 - m0) / rk; pred_res = 0.5 * D1
+            for ((o, a), b) in out.iter_mut().zip(m1).zip(m0) {
+                let d1 = (a - b) / rk;
+                *o -= alpha_t * b_h * 0.5 * d1;
+            }
+        }
+        out
+    }
+
+    /// multistep_uni_c_bh_update with `this_model_output = x0` of the current step
+    fn corrector(&self, model_t: &[f32], this_sample: &[f32]) -> Vec<f32> {
+        let _ = this_sample;
+        let i = self.step;
+        let order = self.this_order;
+        let x = self.last_sample.as_ref().expect("last sample");
+        let m0 = self.outputs[1].as_ref().expect("model output");
+        let sigma_t = self.sigmas[i];
+        let sigma_s0 = self.sigmas[i - 1];
+        let alpha_t = 1.0 - sigma_t;
+        let h = lam(sigma_t) - lam(sigma_s0);
+        let hh = -h;
+        let h_phi_1 = hh.exp_m1();
+        let b_h = h_phi_1;
+        let ratio = sigma_t / sigma_s0;
+        let x_t_: Vec<f32> = x
+            .iter()
+            .zip(m0)
+            .map(|(x, m)| ratio * x - alpha_t * h_phi_1 * m)
+            .collect();
+        if order == 1 || i < 2 || self.outputs[0].is_none() {
+            // rhos_c = [0.5]
+            return x_t_
+                .iter()
+                .zip(model_t)
+                .zip(m0)
+                .map(|((xt, mt), m)| xt - alpha_t * b_h * 0.5 * (mt - m))
+                .collect();
+        }
+        let m1 = self.outputs[0].as_ref().expect("previous model output");
+        let r0 = (lam(self.sigmas[i - 2]) - lam(sigma_s0)) / h;
+        let b0 = (h_phi_1 / hh - 1.0) / b_h;
+        let b1 = 2.0 * ((h_phi_1 / hh - 1.0) / hh - 0.5) / b_h;
+        let rho0 = (b1 - b0) / (r0 - 1.0);
+        let rho1 = b0 - rho0;
+        x_t_.iter()
+            .zip(model_t)
+            .zip(m0)
+            .zip(m1)
+            .map(|(((xt, mt), m), m1)| {
+                let d1 = (m1 - m) / r0;
+                let d1_t = mt - m;
+                xt - alpha_t * b_h * (rho0 * d1 + rho1 * d1_t)
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schedule_matches_diffusers() {
+        let (s, t) = schedule(4);
+        let want = [0.99502486f32, 0.9736331, 0.7985969, 0.12816042, 0.0];
+        for (a, b) in s.iter().zip(want) {
+            assert!((a - b).abs() < 1e-6, "{a} vs {b}");
+        }
+        assert_eq!(t, vec![995, 973, 798, 128]);
+        let (s8, t8) = schedule(8);
+        assert_eq!(s8.len(), 9);
+        assert_eq!(t8, vec![995, 990, 979, 954, 890, 729, 422, 128]);
+    }
+
+    #[test]
+    fn flow_schedule_shift() {
+        let (s, t) = schedule_flow(4, 10.0, false);
+        // sigma_0 = 1 - eps; sigma_1 = 10*0.75025/(1+9*0.75025)
+        assert!((s[0] - (1.0 - 1e-6)).abs() < 1e-6);
+        let s1 = 10.0 * 0.75025 / (1.0 + 9.0 * 0.75025);
+        assert!((s[1] as f64 - s1).abs() < 1e-6, "{}", s[1]);
+        assert_eq!(s[4], 0.0);
+        assert_eq!(t[0], 999);
+        let (sn, _) = schedule_flow(4, 10.0, true);
+        assert!((sn[0] as f64 - 10.0 * 0.999 / (1.0 + 9.0 * 0.999)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn last_step_returns_x0() {
+        let (s, _) = schedule(1);
+        let mut u = UniPC::new(s);
+        let x = vec![1.0f32, -2.0];
+        let v = vec![0.5f32, 0.25];
+        let out = u.step(&v, &x);
+        let s0 = 0.99502486f32;
+        assert!((out[0] - (1.0 - s0 * 0.5)).abs() < 1e-6);
+        assert!((out[1] - (-2.0 - s0 * 0.25)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn multistep_runs_without_nan() {
+        let (s, _) = schedule(6);
+        let mut u = UniPC::new(s);
+        let mut x = vec![0.3f32, -1.1, 2.0];
+        for i in 0..6 {
+            let v: Vec<f32> = x.iter().map(|a| a * 0.1 + i as f32 * 0.01).collect();
+            x = u.step(&v, &x);
+            assert!(x.iter().all(|a| a.is_finite()), "step {i}: {x:?}");
+        }
+    }
+}

--- a/src/mediagen/cosmos3/tokenizer.rs
+++ b/src/mediagen/cosmos3/tokenizer.rs
@@ -1,0 +1,209 @@
+//! The prompt as `Cosmos3OmniPipeline.tokenize_prompt` builds it: chat template,
+//! metadata sentences, then `<|im_end|><|vision_start|>`.
+
+use std::path::Path;
+
+use anyhow::{anyhow, Context, Result};
+
+const SYSTEM_IMAGE: &str =
+    "You are a helpful assistant who will generate images from a give prompt.";
+const SYSTEM_VIDEO: &str =
+    "You are a helpful assistant who will generate videos from a give prompt.";
+
+/// Which chat template the text backbone was trained with.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Template {
+    /// Qwen3-VL (Nano, Super): ChatML, no default system block.
+    Qwen,
+    /// Nemotron (Edge): ChatML with a leading newline, an always-present
+    /// system block and a `<think>\n` generation prompt.
+    Nemotron,
+}
+
+pub struct Tokenizer {
+    tok: tokenizers::Tokenizer,
+    pub template: Template,
+    pub use_system_prompt: bool,
+    pub eos: u32,
+    pub vision_start: u32,
+}
+
+/// The prompt-side description of what is being generated.
+pub struct PromptSpec {
+    pub prompt: String,
+    pub negative: bool,
+    pub n_frames: i64,
+    pub fps: f32,
+    pub width: i64,
+    pub height: i64,
+}
+
+impl Tokenizer {
+    pub fn load(path: &Path, template: Template, use_system_prompt: bool) -> Result<Tokenizer> {
+        let tok = tokenizers::Tokenizer::from_file(path)
+            .map_err(|e| anyhow!("{}: {e}", path.display()))?;
+        let id = |s: &str| {
+            tok.token_to_id(s)
+                .ok_or_else(|| anyhow!("{}: no {s} token", path.display()))
+        };
+        Ok(Tokenizer {
+            eos: id("<|im_end|>")?,
+            vision_start: id("<|vision_start|>")?,
+            tok,
+            template,
+            use_system_prompt,
+        })
+    }
+
+    /// The augmented user text: templates appended like the pipeline does
+    /// (`_apply_templates`), inverse forms for the negative prompt.
+    pub fn user_text(spec: &PromptSpec) -> String {
+        let is_image = spec.n_frames == 1;
+        let mut text = spec.prompt.clone();
+        let mut append = |s: String| {
+            let base = text.trim_end_matches('.');
+            text = if base.is_empty() {
+                s
+            } else {
+                format!("{base}. {s}")
+            };
+        };
+        if !is_image {
+            let duration = spec.n_frames as f64 / spec.fps as f64;
+            append(if spec.negative {
+                format!(
+                    "The video is not {duration:.1} seconds long and is not of {:.0} FPS.",
+                    spec.fps
+                )
+            } else {
+                format!(
+                    "The video is {duration:.1} seconds long and is of {:.0} FPS.",
+                    spec.fps
+                )
+            });
+        }
+        let (h, w) = (spec.height, spec.width);
+        append(match (is_image, spec.negative) {
+            (true, false) => format!("This image is of {h}x{w} resolution."),
+            (true, true) => format!("This image is not of {h}x{w} resolution."),
+            (false, false) => format!("This video is of {h}x{w} resolution."),
+            (false, true) => format!("This video is not of {h}x{w} resolution."),
+        });
+        text
+    }
+
+    /// Token ids of the chat plus `[eos, <|vision_start|>]`.
+    pub fn encode(&self, spec: &PromptSpec) -> Result<Vec<u32>> {
+        let text = render(self.template, self.use_system_prompt, spec);
+        self.encode_text(&text)
+    }
+
+    /// The chat around a verbatim user message (an action run's JSON caption
+    /// or its raw negative prompt), with the given system message if any.
+    pub fn encode_chat(&self, user: &str, system: Option<&str>) -> Result<Vec<u32>> {
+        let text = render_chat(self.template, system, user);
+        self.encode_text(&text)
+    }
+
+    fn encode_text(&self, text: &str) -> Result<Vec<u32>> {
+        let enc = self
+            .tok
+            .encode(text, false)
+            .map_err(|e| anyhow!("tokenizing the prompt: {e}"))
+            .context("cosmos3 tokenizer")?;
+        let mut ids = enc.get_ids().to_vec();
+        ids.push(self.eos);
+        ids.push(self.vision_start);
+        Ok(ids)
+    }
+}
+
+/// The chat as `apply_chat_template(..., add_generation_prompt=True)` renders it
+/// for each checkpoint's template, before tokenization.
+pub fn render(template: Template, use_system_prompt: bool, spec: &PromptSpec) -> String {
+    let user = Tokenizer::user_text(spec);
+    let system = use_system_prompt.then_some(if spec.n_frames == 1 {
+        SYSTEM_IMAGE
+    } else {
+        SYSTEM_VIDEO
+    });
+    render_chat(template, system, &user)
+}
+
+fn render_chat(template: Template, system: Option<&str>, user: &str) -> String {
+    match template {
+        Template::Qwen => {
+            let mut s = String::new();
+            if let Some(sys) = system {
+                s.push_str(&format!("<|im_start|>system\n{sys}<|im_end|>\n"));
+            }
+            s.push_str(&format!(
+                "<|im_start|>user\n{user}<|im_end|>\n<|im_start|>assistant\n"
+            ));
+            s
+        }
+        // Nemotron's template starts with a blank line, always emits the
+        // system block and opens a thinking block in the generation prompt.
+        Template::Nemotron => format!(
+            "\n<|im_start|>system\n{}<|im_end|>\n<|im_start|>user\n{user}<|im_end|>\n<|im_start|>assistant\n<think>\n",
+            system.unwrap_or("")
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_text_templates() {
+        let spec = PromptSpec {
+            prompt: "A cat sits on a mat.".into(),
+            negative: false,
+            n_frames: 49,
+            fps: 24.0,
+            width: 832,
+            height: 480,
+        };
+        assert_eq!(
+            Tokenizer::user_text(&spec),
+            "A cat sits on a mat. The video is 2.0 seconds long and is of 24 FPS. This video is of 480x832 resolution."
+        );
+        let img = PromptSpec {
+            n_frames: 1,
+            negative: true,
+            prompt: String::new(),
+            ..spec
+        };
+        assert_eq!(
+            Tokenizer::user_text(&img),
+            "This image is not of 480x832 resolution."
+        );
+    }
+
+    #[test]
+    fn chat_templates() {
+        // rendered exactly as transformers' apply_chat_template does for both checkpoints
+        let spec = PromptSpec {
+            prompt: "A cat.".into(),
+            negative: false,
+            n_frames: 1,
+            fps: 24.0,
+            width: 256,
+            height: 256,
+        };
+        let user = "A cat. This image is of 256x256 resolution.";
+        assert_eq!(
+            render(Template::Qwen, true, &spec),
+            format!("<|im_start|>system\n{SYSTEM_IMAGE}<|im_end|>\n<|im_start|>user\n{user}<|im_end|>\n<|im_start|>assistant\n")
+        );
+        assert_eq!(
+            render(Template::Qwen, false, &spec),
+            format!("<|im_start|>user\n{user}<|im_end|>\n<|im_start|>assistant\n")
+        );
+        assert_eq!(
+            render(Template::Nemotron, false, &spec),
+            format!("\n<|im_start|>system\n<|im_end|>\n<|im_start|>user\n{user}<|im_end|>\n<|im_start|>assistant\n<think>\n")
+        );
+    }
+}

--- a/src/mediagen/cosmos3/vae.rs
+++ b/src/mediagen/cosmos3/vae.rs
@@ -1,0 +1,767 @@
+//! Wan 2.2 TI2V video VAE (diffusers `AutoencoderKLWan`): 48 latent channels,
+//! 16x spatial and 4x temporal compression. Runs one latent frame at a time as
+//! the reference does, with each causal conv caching the two frames before its
+//! chunk; the first latent frame is never resampled in time.
+//! Activations are `[W, H, C, T]` in ggml order.
+
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+
+use crate::mediagen::backend::{Backend, Ctx, Graph};
+use crate::mediagen::ffi::{self, Tensor};
+use crate::mediagen::weights::{read_safetensors_raw, write_safetensors_raw, Weights};
+
+/// im2col scratch per `conv_2d` call; frames are batched under this.
+const IM2COL_BUDGET: i64 = 256 << 20;
+const NORM_EPS: f32 = 1e-12;
+
+/// A frame-major decoded chunk.
+pub struct Chunk {
+    pub frames: i64,
+    pub height: i64,
+    pub width: i64,
+    /// `[f][h][w][3]`, roughly in `[-1, 1]`.
+    pub rgb: Vec<f32>,
+}
+
+/// The cached input frames of every causal conv, in traversal order, on the
+/// device: two tensors per slot, one read and one written (`ggml_cpy`) by each
+/// chunk's graph, swapped between chunks. Unfilled slots read as zeros.
+struct Caches {
+    api: &'static crate::mediagen::ffi::Api,
+    buft: crate::mediagen::ffi::GgmlBackendBuft,
+    slots: Vec<Option<CacheSlot>>,
+    /// Which of the two tensors of each slot the next chunk reads.
+    read: usize,
+    /// Slots the last chunk left holding data (vs zeros).
+    filled: Vec<bool>,
+}
+
+struct CacheSlot {
+    _ctx: Ctx,
+    buf: crate::mediagen::ffi::GgmlBackendBuffer,
+    pair: [Tensor; 2],
+    ne: [i64; 4],
+}
+
+impl Drop for CacheSlot {
+    fn drop(&mut self) {
+        unsafe { (self._ctx.api.ggml_backend_buffer_free)(self.buf) }
+    }
+}
+
+impl Caches {
+    fn new(be: &Backend) -> Caches {
+        Caches {
+            api: be.api,
+            buft: be.weight_buft(),
+            slots: Vec::new(),
+            read: 0,
+            filled: Vec::new(),
+        }
+    }
+
+    /// The tensor holding `slot`'s frames for the chunk being built, if any.
+    fn get(&self, slot: usize) -> Option<Tensor> {
+        match (self.slots.get(slot), self.filled.get(slot)) {
+            (Some(Some(s)), Some(true)) => Some(s.pair[self.read]),
+            _ => None,
+        }
+    }
+
+    /// The tensor the chunk being built writes `slot` into, allocated on first use.
+    fn target(&mut self, slot: usize, ne: [i64; 4]) -> Result<Tensor> {
+        if self.slots.len() <= slot {
+            self.slots.resize_with(slot + 1, || None);
+        }
+        if let Some(s) = &self.slots[slot] {
+            if s.ne != ne {
+                bail!("cache slot {slot}: shape {ne:?} does not match {:?}", s.ne);
+            }
+        } else {
+            let ctx = Ctx::new(self.api, 4 * 1024, true)?;
+            let pair = [
+                ctx.new_tensor(ffi::ty::F32, &ne),
+                ctx.new_tensor(ffi::ty::F32, &ne),
+            ];
+            let buf =
+                unsafe { (self.api.ggml_backend_alloc_ctx_tensors_from_buft)(ctx.raw, self.buft) };
+            if buf.is_null() {
+                bail!("cache slot {slot}: allocating {:?} failed", ne);
+            }
+            self.slots[slot] = Some(CacheSlot {
+                _ctx: ctx,
+                buf,
+                pair,
+                ne,
+            });
+        }
+        Ok(self.slots[slot].as_ref().unwrap().pair[1 - self.read])
+    }
+
+    /// After a chunk's graph ran: the written set becomes the one to read.
+    fn advance(&mut self, filled: Vec<bool>) {
+        self.filled = filled;
+        self.read = 1 - self.read;
+    }
+}
+
+struct Build<'a> {
+    gr: &'a mut Graph,
+    w: &'a Weights,
+    /// Use `ggml_conv_2d_direct` instead of im2col + matmul.
+    direct: bool,
+    caches: &'a mut Caches,
+    slot: usize,
+    /// Per slot: does this chunk leave data (vs zeros) for the next one?
+    filled: Vec<bool>,
+    first_chunk: bool,
+}
+
+impl<'a> Build<'a> {
+    fn g(&self) -> &Ctx {
+        &self.gr.ctx
+    }
+
+    fn zeros(&mut self, ne: [i64; 4], name: &str) -> Tensor {
+        let n = ne.iter().product::<i64>() as usize;
+        self.gr.input_f32(&ne, &vec![0f32; n], name)
+    }
+
+    /// The `[C]` affine weight as F32.
+    fn vec_f32(&self, t: Tensor) -> Tensor {
+        let g = self.g();
+        let n: i64 = ffi::shape(t).iter().product();
+        let t = if unsafe { (*t).type_ } == ffi::ty::F32 {
+            t
+        } else {
+            g.cast(t, ffi::ty::F32)
+        };
+        g.reshape_4d(g.cont(t), n, 1, 1, 1)
+    }
+
+    /// `WanRMS_norm`: normalize over the channels, times gamma.
+    fn norm(&self, x: Tensor, gamma: &str) -> Result<Tensor> {
+        let gm = self.vec_f32(self.w.get(gamma)?);
+        let g = self.g();
+        let p = g.cont(g.permute(x, 1, 2, 0, 3)); // [C, W, H, T]
+        let p = g.mul(g.rms_norm(p, NORM_EPS), gm);
+        Ok(g.cont(g.permute(p, 2, 0, 1, 3)))
+    }
+
+    fn bias(&self, y: Tensor, name: &str) -> Result<Tensor> {
+        let g = self.g();
+        let b = self.w.get(name)?;
+        let oc = ffi::shape(y)[2];
+        Ok(g.add(y, g.reshape_4d(b, 1, 1, oc, 1)))
+    }
+
+    /// 1x1 conv (shortcuts, quant convs, attention projections): no padding, no cache.
+    fn conv1(&self, prefix: &str, x: Tensor) -> Result<Tensor> {
+        let k = self.w.get(&format!("{prefix}.weight"))?;
+        let y = self.conv2(k, x, 1, 0);
+        self.bias(y, &format!("{prefix}.bias"))
+    }
+
+    /// 2-D 3x3 conv (`resample.1`) over every frame.
+    fn conv2d(&self, prefix: &str, x: Tensor) -> Result<Tensor> {
+        let k = self.w.get(&format!("{prefix}.weight"))?;
+        let y = self.conv_frames(k, x, 1, ffi::shape(x)[3])?;
+        self.bias(y, &format!("{prefix}.bias"))
+    }
+
+    /// A 2-D conv: direct when the backend has it, else im2col + matmul.
+    fn conv2(&self, k: Tensor, x: Tensor, s: i32, pad: i32) -> Tensor {
+        match (self.direct, self.g().api.ggml_conv_2d_direct) {
+            (true, Some(f)) => unsafe { f(self.g().raw, k, x, s, s, pad, pad, 1, 1) },
+            _ => self.g().conv_2d(k, x, s, s, pad, pad, 1, 1),
+        }
+    }
+
+    /// `conv_2d` over the first `nframes` frames, batched so im2col stays under budget.
+    fn conv_frames(&self, k: Tensor, x: Tensor, pad: i32, nframes: i64) -> Result<Tensor> {
+        let g = self.g();
+        let [w, h, c, _] = ffi::shape(x);
+        let kw = ffi::shape(k)[0];
+        let per_frame = kw * kw * c * w * h * 2;
+        let group = if self.direct {
+            nframes
+        } else {
+            (IM2COL_BUDGET / per_frame.max(1)).clamp(1, nframes)
+        };
+        let nb = ffi::strides(x);
+        let mut out: Option<Tensor> = None;
+        let mut f0 = 0;
+        while f0 < nframes {
+            let nf = group.min(nframes - f0);
+            let xv = g.view_4d(x, w, h, c, nf, nb[1], nb[2], nb[3], (f0 as usize) * nb[3]);
+            let y = self.conv2(k, xv, 1, pad);
+            out = Some(match out {
+                None => y,
+                Some(o) => g.concat(o, y, 3),
+            });
+            f0 += nf;
+        }
+        Ok(out.expect("at least one frame"))
+    }
+
+    /// Takes the next cache slot: its frames of shape `ne`, or zeros when unfilled.
+    fn take_cache(&mut self, prefix: &str, ne: [i64; 4]) -> Result<(usize, Tensor)> {
+        let slot = self.slot;
+        self.slot += 1;
+        let t = match self.caches.get(slot) {
+            Some(t) => {
+                if ffi::shape(t) != ne {
+                    bail!(
+                        "{prefix}: cache shape {:?} does not match {ne:?}",
+                        ffi::shape(t)
+                    );
+                }
+                t
+            }
+            None => self.zeros(ne, &format!("zcache{slot}")),
+        };
+        Ok((slot, t))
+    }
+
+    /// Records `t` (or zeros when `None`) as what `slot` holds for the next chunk:
+    /// a copy into the slot's write tensor, part of this chunk's graph.
+    fn keep_cache(&mut self, slot: usize, t: Option<Tensor>) -> Result<()> {
+        if self.filled.len() <= slot {
+            self.filled.resize(slot + 1, false);
+        }
+        if let Some(t) = t {
+            let dst = self.caches.target(slot, ffi::shape(t))?;
+            let node = unsafe { (self.g().api.ggml_cpy)(self.g().raw, t, dst) };
+            self.gr.mark_output(node);
+        }
+        self.filled[slot] = t.is_some();
+        Ok(())
+    }
+
+    /// The chunk's frames with the two before each stacked along the channels:
+    /// `[w, h, 3c, n]` where channel block `k` holds frame `t + k - 2` of the stream.
+    /// A 3x3x3 causal conv is then one 2-D conv with a `[3, 3, 3c, oc]` kernel.
+    fn stack_taps(&self, xx: Tensor, n: i64) -> Tensor {
+        let g = self.g();
+        let [w, h, c, _] = ffi::shape(xx);
+        let nb = ffi::strides(xx);
+        let tap = |k: usize| g.view_4d(xx, w, h, c, n, nb[1], nb[2], nb[3], k * nb[3]);
+        g.concat(g.concat(tap(0), tap(1), 2), tap(2), 2)
+    }
+
+    /// Causal 3x3x3 (or 3x1x1) conv over the chunk with the cached two frames before it.
+    fn cconv(&mut self, prefix: &str, x: Tensor, spatial_pad: i32) -> Result<Tensor> {
+        let [w, h, c, n] = ffi::shape(x);
+        let (slot, cache) = self.take_cache(prefix, [w, h, c, 2])?;
+        let g = self.g();
+        let xx = g.concat(cache, x, 3); // [w, h, c, n + 2]
+        let nb = ffi::strides(xx);
+        let keep = g.view_4d(xx, w, h, c, 2, nb[1], nb[2], nb[3], (n as usize) * nb[3]);
+        self.keep_cache(slot, Some(keep))?;
+        let stacked = self.stack_taps(xx, n);
+        let k = self.w.get(&format!("{prefix}.weight"))?; // [kw, kh, 3c, oc]
+        let y = self.conv_frames(k, stacked, spatial_pad, n)?;
+        self.bias(y, &format!("{prefix}.bias"))
+    }
+
+    /// `WanResidualBlock`
+    fn resnet(&mut self, prefix: &str, x: Tensor) -> Result<Tensor> {
+        let short = if self.w.has(&format!("{prefix}.conv_shortcut.weight")) {
+            self.conv1(&format!("{prefix}.conv_shortcut"), x)?
+        } else {
+            x
+        };
+        let h = self.norm(x, &format!("{prefix}.norm1.gamma"))?;
+        let h = self.cconv(&format!("{prefix}.conv1"), self.g().silu(h), 1)?;
+        let h = self.norm(h, &format!("{prefix}.norm2.gamma"))?;
+        let h = self.cconv(&format!("{prefix}.conv2"), self.g().silu(h), 1)?;
+        Ok(self.g().add(h, short))
+    }
+
+    /// `WanAttentionBlock`: single-head spatial attention within each frame.
+    fn attention(&mut self, prefix: &str, x: Tensor) -> Result<Tensor> {
+        let [w, h, c, n] = ffi::shape(x);
+        let hn = self.norm(x, &format!("{prefix}.norm.gamma"))?;
+        let qkv = self.conv1(&format!("{prefix}.to_qkv"), hn)?; // [w, h, 3c, n]
+        let g = self.g();
+        let hw = w * h;
+        let qkv = g.reshape_3d(qkv, hw, 3 * c, n);
+        let nb = ffi::strides(qkv);
+        let q = g.view_3d(qkv, hw, c, n, nb[1], nb[2], 0);
+        let k = g.view_3d(qkv, hw, c, n, nb[1], nb[2], (c as usize) * nb[1]);
+        let v = g.view_3d(qkv, hw, c, n, nb[1], nb[2], (2 * c as usize) * nb[1]);
+        // tokens along ne1 for q/k, along ne0 for v
+        let qc = g.cont(g.permute(q, 1, 0, 2, 3)); // [c, hw, n]
+        let kc = g.cont(g.permute(k, 1, 0, 2, 3));
+        let vc = g.cont(v); // [hw, c, n]
+        let scores = g.mul_mat(kc, qc); // [hw_k, hw_q, n]
+        let scores = g.soft_max_ext(scores, std::ptr::null_mut(), 1.0 / (c as f32).sqrt(), 0.0);
+        let o = g.mul_mat(vc, scores); // [c, hw_q, n]
+        let o = g.cont(g.permute(o, 1, 0, 2, 3)); // [hw, c, n]
+        let o = g.reshape_4d(o, w, h, c, n);
+        let o = self.conv1(&format!("{prefix}.proj"), o)?;
+        Ok(self.g().add(o, x))
+    }
+
+    /// `WanResample` upsample2d/upsample3d: optional causal time conv that
+    /// doubles the frames (never the first latent frame), then nearest 2x
+    /// spatial upsampling and a 3x3 conv.
+    fn upsample(&mut self, prefix: &str, x: Tensor, time: bool) -> Result<Tensor> {
+        let mut x = x;
+        if time {
+            let [w, h, c, n] = ffi::shape(x);
+            if self.first_chunk {
+                // `Rep`: frame 0 passes through; the next chunk starts from zero padding
+                let slot = self.slot;
+                self.slot += 1;
+                self.keep_cache(slot, None)?;
+            } else {
+                let y = self.cconv(&format!("{prefix}.time_conv"), x, 0)?; // [w, h, 2c, n]
+                                                                           // channels [0, c) are frame 2k, [c, 2c) frame 2k+1: a plain reshape interleaves
+                x = self.g().reshape_4d(y, w, h, c, 2 * n);
+            }
+        }
+        let [w, h, c, n] = ffi::shape(x);
+        let g = self.g();
+        let up = g.interpolate(x, 2 * w, 2 * h, c, n, ffi::GGML_SCALE_MODE_NEAREST);
+        self.conv2d(&format!("{prefix}.resample.1"), up)
+    }
+
+    /// `DupUp3D` with `factor_t = factor_s = 2`: nearest duplication in t, h and w
+    /// (`repeats == factor`), dropping the first frame on the first chunk.
+    fn dup_up_3d(&self, x: Tensor) -> Tensor {
+        let g = self.g();
+        let [w, h, c, n] = ffi::shape(x);
+        let up = g.interpolate(x, 2 * w, 2 * h, c, 2 * n, ffi::GGML_SCALE_MODE_NEAREST);
+        if self.first_chunk {
+            let nb = ffi::strides(up);
+            g.cont(g.view_4d(up, 2 * w, 2 * h, c, 2 * n - 1, nb[1], nb[2], nb[3], nb[3]))
+        } else {
+            up
+        }
+    }
+
+    /// `DupUp3D` with `factor_t = 1, factor_s = 2, repeats = 2`:
+    /// `out[oc, 2h + j, 2w + k] = x[2oc + j, h, w]`.
+    fn dup_up_2d(&self, x: Tensor) -> Tensor {
+        let g = self.g();
+        let [w, h, c, n] = ffi::shape(x);
+        let up = g.interpolate(x, 2 * w, h, c, n, ffi::GGML_SCALE_MODE_NEAREST);
+        // channel = j + 2*oc: split off j and move it under h
+        let s = g.reshape_4d(up, 2 * w, h, 2, (c / 2) * n);
+        let s = g.cont(g.permute(s, 0, 2, 1, 3)); // [2w, 2(j), h, ...]
+        g.reshape_4d(s, 2 * w, 2 * h, c / 2, n)
+    }
+
+    /// `[W, H, 12, F]` -> `[2W, 2H, 3, F]`: `out[c, 2h + pb, 2w + pa] = x[4c + 2pa + pb]`.
+    fn unpatchify(&self, x: Tensor) -> Result<Tensor> {
+        let g = self.g();
+        let [w, h, c12, f] = ffi::shape(x);
+        if c12 != 12 {
+            bail!("decoder.conv_out has {c12} channels, expected 12");
+        }
+        // pb (fastest channel index) under h
+        let s = g.reshape_4d(x, w, h, 2, 6 * f);
+        let s = g.cont(g.permute(s, 0, 2, 1, 3)); // [w, 2(pb), h, 6f]
+                                                  // then pa under w
+        let s = g.reshape_4d(s, w, 2 * h, 2, 3 * f);
+        let s = g.cont(g.permute(s, 1, 2, 0, 3)); // [2(pa), w, 2h, 3f]
+        Ok(g.reshape_4d(s, 2 * w, 2 * h, 3, f))
+    }
+
+    /// `[2W, 2H, 3, F]` -> `[W, H, 12, F]`, the inverse of [`Self::unpatchify`].
+    fn patchify(&self, img: Tensor) -> Tensor {
+        let g = self.g();
+        let [w2, h2, c, f] = ffi::shape(img);
+        debug_assert_eq!(c, 3);
+        let (w, h) = (w2 / 2, h2 / 2);
+        let s = g.reshape_4d(img, 2, w, h2, 3 * f); // [pa, w, h', 3f]
+        let s = g.cont(g.permute(s, 2, 0, 1, 3)); // [w, h', pa, 3f]
+        let s = g.reshape_4d(s, w, 2, h, 6 * f); // [w, pb, h, (pa, c, f)]
+        let s = g.cont(g.permute(s, 0, 2, 1, 3)); // [w, h, pb, ...]
+        g.reshape_4d(s, w, h, 12, f)
+    }
+
+    /// 2x2 average pooling of every frame.
+    fn pool2(&self, x: Tensor) -> Tensor {
+        let g = self.g();
+        let [w, h, c, n] = ffi::shape(x);
+        let s = g.reshape_4d(x, 2, w / 2, h, c * n);
+        let nb = ffi::strides(s);
+        let a = g.view_4d(s, 1, w / 2, h, c * n, nb[1], nb[2], nb[3], 0);
+        let b = g.view_4d(s, 1, w / 2, h, c * n, nb[1], nb[2], nb[3], nb[0]);
+        let s = g.reshape_4d(g.add(a, b), w / 2, 2, h / 2, c * n);
+        let nb = ffi::strides(s);
+        let a = g.view_4d(s, w / 2, 1, h / 2, c * n, nb[1], nb[2], nb[3], 0);
+        let b = g.view_4d(s, w / 2, 1, h / 2, c * n, nb[1], nb[2], nb[3], nb[1]);
+        g.scale(g.reshape_4d(g.add(a, b), w / 2, h / 2, c, n), 0.25)
+    }
+
+    /// `AvgDown3D` with `factor_s = 2` and `factor_t` 1 or 2: pooled frames, and for
+    /// `factor_t = 2` frame pairs `(2t', 2t'+1)` stacked into channels `2c + i` (the
+    /// first chunk's single frame is paired with a zero frame in front of it).
+    fn avg_down(&mut self, x: Tensor, time: bool) -> Tensor {
+        let p = self.pool2(x);
+        if !time {
+            return p;
+        }
+        let [w, h, c, n] = ffi::shape(p);
+        let (p, n) = if n % 2 == 1 {
+            let z = self.zeros([w, h, c, 1], "avgpad");
+            (self.g().concat(z, p, 3), n + 1)
+        } else {
+            (p, n)
+        };
+        let g = self.g();
+        let s = g.reshape_4d(p, w * h, c, 2, n / 2); // [hw, c, i, t']
+        let s = g.cont(g.permute(s, 0, 2, 1, 3)); // [hw, i, c, t']
+        g.reshape_4d(s, w, h, 2 * c, n / 2)
+    }
+
+    /// `WanResample` downsample2d/downsample3d: zero-pad right/bottom by one and a
+    /// stride-2 3x3 conv, then (3-D) a stride-2 causal time conv that skips the
+    /// first latent frame and halves the rest.
+    fn downsample(&mut self, prefix: &str, x: Tensor, time: bool) -> Result<Tensor> {
+        let g = self.g();
+        let padded = g.pad(x, 1, 1, 0, 0);
+        let k = self.w.get(&format!("{prefix}.resample.1.weight"))?;
+        let y = self.conv2(k, padded, 2, 0);
+        let mut x = self.bias(y, &format!("{prefix}.resample.1.bias"))?;
+        if time {
+            let [w, h, c, n] = ffi::shape(x);
+            if self.first_chunk {
+                // the first frame passes through and becomes the next chunk's context
+                let slot = self.slot;
+                self.slot += 1;
+                self.keep_cache(slot, Some(x))?;
+            } else {
+                let (slot, cache) = self.take_cache(prefix, [w, h, c, 1])?;
+                let g = self.g();
+                let xx = g.concat(cache, x, 3); // [w, h, c, n + 1]
+                let nb = ffi::strides(xx);
+                let last = g.view_4d(xx, w, h, c, 1, nb[1], nb[2], nb[3], (n as usize) * nb[3]);
+                self.keep_cache(slot, Some(last))?;
+                let g = self.g();
+                // frames k, k+2, k+4, ... of the concatenation, stacked along the channels
+                let tap =
+                    |k: usize| g.view_4d(xx, w, h, c, n / 2, nb[1], nb[2], 2 * nb[3], k * nb[3]);
+                let stacked = g.concat(g.concat(tap(0), tap(1), 2), tap(2), 2);
+                let kt = self.w.get(&format!("{prefix}.time_conv.weight"))?; // [1, 1, 3c, c]
+                let y = self.conv2(kt, stacked, 1, 0);
+                x = self.bias(y, &format!("{prefix}.time_conv.bias"))?;
+            }
+        }
+        Ok(x)
+    }
+
+    /// The encoder over one chunk of pixel frames `[W, H, 3, F]` (F = 1, then 4):
+    /// the mean of the posterior, `[W/16, H/16, 48, T]`.
+    fn encoder(&mut self, img: Tensor) -> Result<Tensor> {
+        let mut x = self.patchify(img);
+        x = self.cconv("encoder.conv_in", x, 1)?;
+        for b in 0..4 {
+            let p = format!("encoder.down_blocks.{b}");
+            let x_copy = x;
+            for r in 0..2 {
+                x = self.resnet(&format!("{p}.resnets.{r}"), x)?;
+            }
+            match b {
+                0 => {
+                    x = self.downsample(&format!("{p}.downsampler"), x, false)?;
+                    let short = self.avg_down(x_copy, false);
+                    x = self.g().add(x, short);
+                }
+                1 | 2 => {
+                    x = self.downsample(&format!("{p}.downsampler"), x, true)?;
+                    let short = self.avg_down(x_copy, true);
+                    x = self.g().add(x, short);
+                }
+                _ => x = self.g().add(x, x_copy),
+            }
+        }
+        x = self.resnet("encoder.mid_block.resnets.0", x)?;
+        x = self.attention("encoder.mid_block.attentions.0", x)?;
+        x = self.resnet("encoder.mid_block.resnets.1", x)?;
+        let x = self.norm(x, "encoder.norm_out.gamma")?;
+        let x = self.cconv("encoder.conv_out", self.g().silu(x), 1)?;
+        let x = self.conv1("quant_conv", x)?; // [w, h, 96, t]: mean, then log-variance
+        let g = self.g();
+        let [w, h, _, t] = ffi::shape(x);
+        let nb = ffi::strides(x);
+        Ok(g.cont(g.view_4d(x, w, h, 48, t, nb[1], nb[2], nb[3], 0)))
+    }
+
+    fn decoder(&mut self, z: Tensor) -> Result<Tensor> {
+        let mut x = self.conv1("post_quant_conv", z)?;
+        x = self.cconv("decoder.conv_in", x, 1)?;
+        x = self.resnet("decoder.mid_block.resnets.0", x)?;
+        x = self.attention("decoder.mid_block.attentions.0", x)?;
+        x = self.resnet("decoder.mid_block.resnets.1", x)?;
+        for b in 0..4 {
+            let p = format!("decoder.up_blocks.{b}");
+            let x_copy = x;
+            for r in 0..3 {
+                x = self.resnet(&format!("{p}.resnets.{r}"), x)?;
+            }
+            match b {
+                0 | 1 => {
+                    x = self.upsample(&format!("{p}.upsampler"), x, true)?;
+                    x = self.g().add(x, self.dup_up_3d(x_copy));
+                }
+                2 => {
+                    x = self.upsample(&format!("{p}.upsampler"), x, false)?;
+                    x = self.g().add(x, self.dup_up_2d(x_copy));
+                }
+                _ => {}
+            }
+        }
+        let x = self.norm(x, "decoder.norm_out.gamma")?;
+        let x = self.cconv("decoder.conv_out", self.g().silu(x), 1)?;
+        self.unpatchify(x)
+    }
+}
+
+/// `ggml_conv_2d_direct` is 4x faster than im2col on Vulkan and 10-30x slower
+/// on Metal and CUDA; `MEDIAGEN_DIRECT_CONV=0|1` overrides.
+fn direct_conv(be: &Backend) -> bool {
+    let wanted = match std::env::var("MEDIAGEN_DIRECT_CONV").as_deref() {
+        Ok("1") => true,
+        Ok("0") => false,
+        _ => be.gpu_name().starts_with("Vulkan"),
+    };
+    wanted && be.supports_direct_conv()
+}
+
+/// Decodes latent frames `z[i]` (`[C][H][W]` each, VAE-space, already denormalized)
+/// into RGB, one latent frame per graph.
+pub fn decode(w: &Weights, be: &Backend, z: &[Vec<f32>], c: i64, h: i64, wd: i64) -> Result<Chunk> {
+    if c != 48 {
+        bail!("expected 48 latent channels, got {c}");
+    }
+    let mut caches = Caches::new(be);
+    let mut out = Chunk {
+        frames: 0,
+        height: 0,
+        width: 0,
+        rgb: Vec::new(),
+    };
+    let timing = std::env::var_os("MEDIAGEN_TIMING").is_some();
+    let direct = direct_conv(be);
+    for (i, frame) in z.iter().enumerate() {
+        let t_start = std::time::Instant::now();
+        let mut gr = Graph::new(be.api, 16 * 1024)?;
+        // torch [C][H][W] -> ggml [W, H, C, 1]
+        let mut x = vec![0f32; (wd * h * c) as usize];
+        for ci in 0..c as usize {
+            for hi in 0..h as usize {
+                for wi in 0..wd as usize {
+                    x[wi + (wd as usize) * (hi + (h as usize) * ci)] =
+                        frame[(ci * h as usize + hi) * wd as usize + wi];
+                }
+            }
+        }
+        let zt = gr.input_f32(&[wd, h, c, 1], &x, "z");
+        let mut b = Build {
+            gr: &mut gr,
+            w,
+            direct,
+            caches: &mut caches,
+            slot: 0,
+            filled: Vec::new(),
+            first_chunk: i == 0,
+        };
+        let rgb = b.decoder(zt)?;
+        let rgb = b.g().cont(rgb);
+        b.gr.mark_output(rgb);
+        let filled = std::mem::take(&mut b.filled);
+        drop(b);
+        let t_built = t_start.elapsed();
+        gr.compute(be)?;
+        let t_computed = t_start.elapsed();
+        let [ow, oh, _, of] = ffi::shape(rgb);
+        let data = gr.output_f32(rgb);
+        if out.frames == 0 {
+            out.width = ow;
+            out.height = oh;
+        }
+        // [w, h, 3, f] -> [f][h][w][3]
+        let (ow, oh) = (ow as usize, oh as usize);
+        for f in 0..of as usize {
+            for y in 0..oh {
+                for xx in 0..ow {
+                    for ch in 0..3 {
+                        out.rgb.push(data[xx + ow * (y + oh * (ch + 3 * f))]);
+                    }
+                }
+            }
+        }
+        out.frames += of;
+        caches.advance(filled);
+        if timing {
+            eprintln!(
+                "[llmman] mediagen: vae chunk {i}: build {:.2} s, compute {:.2} s, readback {:.2} s",
+                t_built.as_secs_f64(),
+                (t_computed - t_built).as_secs_f64(),
+                (t_start.elapsed() - t_computed).as_secs_f64()
+            );
+        }
+    }
+    Ok(out)
+}
+
+/// Encodes RGB frames (`[f][h][w][3]`, in `[-1, 1]`, `F = 4k + 1`) to the posterior
+/// mean, one latent frame `[48][H/16][W/16]` per 4 pixel frames after the first,
+/// chunked as the reference does (frame 0 alone, then groups of 4).
+pub fn encode(
+    w: &Weights,
+    be: &Backend,
+    rgb: &[f32],
+    frames: i64,
+    h: i64,
+    wd: i64,
+) -> Result<Vec<Vec<f32>>> {
+    if frames < 1 || (frames - 1) % 4 != 0 {
+        bail!("the encoder takes 4k + 1 frames, got {frames}");
+    }
+    let mut caches = Caches::new(be);
+    let mut out = Vec::new();
+    let direct = direct_conv(be);
+    let (hu, wu) = (h as usize, wd as usize);
+    let mut f0 = 0usize;
+    let mut first = true;
+    while (f0 as i64) < frames {
+        let n = if first { 1 } else { 4 };
+        // [f][h][w][3] -> ggml [W, H, 3, n]
+        let mut x = vec![0f32; wu * hu * 3 * n];
+        for fi in 0..n {
+            for y in 0..hu {
+                for xx in 0..wu {
+                    for ch in 0..3 {
+                        x[xx + wu * (y + hu * (ch + 3 * fi))] =
+                            rgb[(((f0 + fi) * hu + y) * wu + xx) * 3 + ch];
+                    }
+                }
+            }
+        }
+        let mut gr = Graph::new(be.api, 16 * 1024)?;
+        let img = gr.input_f32(&[wd, h, 3, n as i64], &x, "img");
+        let mut b = Build {
+            gr: &mut gr,
+            w,
+            direct,
+            caches: &mut caches,
+            slot: 0,
+            filled: Vec::new(),
+            first_chunk: first,
+        };
+        let z = b.encoder(img)?;
+        b.gr.mark_output(z);
+        let filled = std::mem::take(&mut b.filled);
+        drop(b);
+        gr.compute(be)?;
+        let [lw, lh, c, lt] = ffi::shape(z);
+        let data = gr.output_f32(z);
+        let (lw, lh, c) = (lw as usize, lh as usize, c as usize);
+        for t in 0..lt as usize {
+            let mut frame = vec![0f32; c * lh * lw];
+            for ci in 0..c {
+                for y in 0..lh {
+                    for xx in 0..lw {
+                        frame[(ci * lh + y) * lw + xx] = data[xx + lw * (y + lh * (ci + c * t))];
+                    }
+                }
+            }
+            out.push(frame);
+        }
+        caches.advance(filled);
+        f0 += n;
+        first = false;
+    }
+    Ok(out)
+}
+
+/// Rewrites the VAE as `dst` with every 5-D conv weight `[oc, ic, kt, kh, kw]`
+/// merged to `[oc, kt*ic, kh, kw]` (tap major), so a causal 3-D conv is one 2-D
+/// conv over the frames stacked along the channels ([`Build::stack_taps`]).
+pub fn merge_time_taps(src: &Path, dst: &Path) -> Result<()> {
+    let mut tensors = read_safetensors_raw(src)?;
+    for t in &mut tensors {
+        if t.shape.len() != 5 {
+            continue;
+        }
+        let esz = match t.dtype.as_str() {
+            "BF16" | "F16" => 2usize,
+            "F32" => 4,
+            other => bail!("{}: unsupported dtype {other}", t.name),
+        };
+        let [oc, ic, kt, kh, kw] = [0, 1, 2, 3, 4].map(|i| t.shape[i] as usize);
+        let spatial = kh * kw * esz;
+        let mut merged = vec![0u8; t.bytes.len()];
+        for o in 0..oc {
+            for i in 0..ic {
+                for k in 0..kt {
+                    let from = ((o * ic + i) * kt + k) * spatial;
+                    let to = ((o * kt + k) * ic + i) * spatial;
+                    merged[to..to + spatial].copy_from_slice(&t.bytes[from..from + spatial]);
+                }
+            }
+        }
+        t.bytes = merged;
+        t.shape = vec![oc as i64, (kt * ic) as i64, kh as i64, kw as i64];
+    }
+    write_safetensors_raw(dst, &tensors, "time taps merged")
+}
+
+/// The tap-merged file for `src`, created in `cache_dir` when missing.
+pub fn merged_path(src: &Path, cache_dir: &Path) -> Result<std::path::PathBuf> {
+    let name = src.file_stem().and_then(|s| s.to_str()).unwrap_or("vae");
+    let dst = cache_dir.join(format!("{name}.merged.safetensors"));
+    if !dst.exists() {
+        std::fs::create_dir_all(cache_dir)?;
+        let t0 = std::time::Instant::now();
+        merge_time_taps(src, &dst)
+            .with_context(|| format!("merging the time taps of {}", src.display()))?;
+        eprintln!(
+            "[llmman] mediagen: merged the VAE's conv time taps into {} in {:.1} s",
+            dst.display(),
+            t0.elapsed().as_secs_f64()
+        );
+    }
+    Ok(dst)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merged_taps_are_tap_major() {
+        let dir = std::env::temp_dir().join(format!("llmman-merge-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        // [oc=1, ic=2, kt=3, kh=1, kw=1]: value = ic*10 + kt
+        let vals: Vec<f32> = (0..2)
+            .flat_map(|i| (0..3).map(move |t| (i * 10 + t) as f32))
+            .collect();
+        let src = dir.join("in.safetensors");
+        write_safetensors_raw(
+            &src,
+            &[crate::mediagen::weights::RawTensor {
+                name: "k.weight".into(),
+                dtype: "F32".into(),
+                shape: vec![1, 2, 3, 1, 1],
+                bytes: vals.iter().flat_map(|v| v.to_le_bytes()).collect(),
+            }],
+            "test",
+        )
+        .unwrap();
+        let dst = dir.join("out.safetensors");
+        merge_time_taps(&src, &dst).unwrap();
+        let out = read_safetensors_raw(&dst).unwrap();
+        assert_eq!(out[0].shape, [1, 6, 1, 1]);
+        // channel = kt * ic + i
+        assert_eq!(out[0].f32s().unwrap(), [0.0, 10.0, 1.0, 11.0, 2.0, 12.0]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/mediagen/encode.rs
+++ b/src/mediagen/encode.rs
@@ -159,6 +159,86 @@ pub fn mp4(res: &Output) -> Result<Vec<u8>> {
     out
 }
 
+/// A PNG/JPEG (or a data URL) as one RGB frame.
+pub fn decode_image(bytes: &[u8]) -> Result<super::Frames> {
+    let img = image::load_from_memory(bytes)
+        .context("decoding the conditioning image (PNG or JPEG)")?
+        .to_rgb8();
+    Ok(super::Frames {
+        width: img.width() as i64,
+        height: img.height() as i64,
+        n_frames: 1,
+        rgb: img.into_raw(),
+    })
+}
+
+/// A video container (anything ffmpeg reads) as RGB frames.
+pub fn decode_video(bytes: &[u8]) -> Result<super::Frames> {
+    if !has_ffmpeg() {
+        bail!("decoding a conditioning video needs the ffmpeg binary in PATH");
+    }
+    let dir = std::env::temp_dir().join(format!(
+        "llmman-mediagen-in-{}-{:08x}",
+        std::process::id(),
+        super::rand_seed()
+    ));
+    std::fs::create_dir(&dir).context("creating a temporary directory")?;
+    let run = || -> Result<super::Frames> {
+        let src = dir.join("in.bin");
+        std::fs::write(&src, bytes)?;
+        let probe = Command::new("ffprobe")
+            .args([
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=width,height",
+                "-of",
+                "csv=p=0",
+            ])
+            .arg(&src)
+            .output()
+            .context("running ffprobe")?;
+        if !probe.status.success() {
+            bail!("ffprobe: {}", String::from_utf8_lossy(&probe.stderr).trim());
+        }
+        let dims = String::from_utf8_lossy(&probe.stdout);
+        let mut it = dims.trim().split(',');
+        let (w, h): (i64, i64) = (
+            it.next()
+                .and_then(|v| v.trim().parse().ok())
+                .context("video width")?,
+            it.next()
+                .and_then(|v| v.trim().parse().ok())
+                .context("video height")?,
+        );
+        let out = Command::new("ffmpeg")
+            .args(["-loglevel", "error", "-i"])
+            .arg(&src)
+            .args(["-f", "rawvideo", "-pix_fmt", "rgb24", "-"])
+            .output()
+            .context("running ffmpeg")?;
+        if !out.status.success() {
+            bail!("ffmpeg: {}", String::from_utf8_lossy(&out.stderr).trim());
+        }
+        let frame = (w * h * 3) as usize;
+        let n = out.stdout.len() / frame;
+        if n == 0 {
+            bail!("the conditioning video has no frames");
+        }
+        Ok(super::Frames {
+            width: w,
+            height: h,
+            n_frames: n as i64,
+            rgb: out.stdout[..n * frame].to_vec(),
+        })
+    };
+    let r = run();
+    let _ = std::fs::remove_dir_all(&dir);
+    r
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/mediagen/ffi.rs
+++ b/src/mediagen/ffi.rs
@@ -189,16 +189,19 @@ pub type LogCallback =
     unsafe extern "C" fn(level: c_int, text: *const c_char, user_data: *mut c_void);
 
 macro_rules! api {
-    ($(fn $name:ident($($arg:ident: $ty:ty),*) $(-> $ret:ty)?;)*) => {
-        /// The bound function pointers.
+    ($(fn $name:ident($($arg:ident: $ty:ty),*) $(-> $ret:ty)?;)*
+     optional: $(fn $oname:ident($($oarg:ident: $oty:ty),*) $(-> $oret:ty)?;)*) => {
+        /// The bound function pointers; `optional` ones may be absent from older releases.
         pub struct Api {
             _libs: Vec<Library>,
             $(pub $name: unsafe extern "C" fn($($arg: $ty),*) $(-> $ret)?,)*
+            $(pub $oname: Option<unsafe extern "C" fn($($oarg: $oty),*) $(-> $oret)?>,)*
         }
         impl Api {
             fn bind(libs: Vec<Library>) -> Result<Self> {
                 $(let $name = lookup(&libs, stringify!($name))?;)*
-                Ok(Self { _libs: libs, $($name,)* })
+                $(let $oname = lookup(&libs, stringify!($oname)).ok();)*
+                Ok(Self { _libs: libs, $($name,)* $($oname,)* })
             }
         }
     };
@@ -242,6 +245,7 @@ api! {
     fn ggml_sqrt(ctx: *mut GgmlContext, a: Tensor) -> Tensor;
     fn ggml_log(ctx: *mut GgmlContext, a: Tensor) -> Tensor;
     fn ggml_clamp(ctx: *mut GgmlContext, a: Tensor, min: f32, max: f32) -> Tensor;
+    fn ggml_cpy(ctx: *mut GgmlContext, a: Tensor, b: Tensor) -> Tensor;
     fn ggml_reshape_2d(ctx: *mut GgmlContext, a: Tensor, ne0: i64, ne1: i64) -> Tensor;
     fn ggml_reshape_3d(ctx: *mut GgmlContext, a: Tensor, ne0: i64, ne1: i64, ne2: i64) -> Tensor;
     fn ggml_reshape_4d(ctx: *mut GgmlContext, a: Tensor, ne0: i64, ne1: i64, ne2: i64, ne3: i64) -> Tensor;
@@ -323,6 +327,11 @@ api! {
     fn llama_sampler_init_dist(seed: u32) -> *mut LlamaSampler;
     fn llama_sampler_sample(smpl: *mut LlamaSampler, ctx: *mut LlamaContextT, idx: i32) -> LlamaToken;
     fn llama_sampler_free(smpl: *mut LlamaSampler);
+
+    optional:
+    // direct 2-D convolution (no im2col), ggml >= mid-2025
+    fn ggml_conv_2d_direct(ctx: *mut GgmlContext, a: Tensor, b: Tensor, s0: c_int, s1: c_int, p0: c_int, p1: c_int, d0: c_int, d1: c_int) -> Tensor;
+    fn ggml_backend_supports_op(backend: GgmlBackend, op: Tensor) -> bool;
 }
 
 fn lookup<T: Copy>(libs: &[Library], name: &str) -> Result<T> {

--- a/src/mediagen/mod.rs
+++ b/src/mediagen/mod.rs
@@ -6,12 +6,14 @@
 #![allow(clippy::not_unsafe_ptr_arg_deref, clippy::too_many_arguments)]
 
 pub mod backend;
+pub mod cosmos3;
 pub mod encode;
 pub mod ffi;
 pub mod ltx;
 pub mod server;
 pub mod weights;
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
@@ -28,7 +30,10 @@ pub struct ContextParams {
     pub vae: Option<PathBuf>,
     pub audio_vae: Option<PathBuf>,
     pub text_proj: Option<PathBuf>,
-    pub text_model: PathBuf,
+    /// Text encoder GGUF; LTX needs one, Cosmos3 has none.
+    pub text_model: Option<PathBuf>,
+    /// Every named file of the model pack (`vae/config.json`, `tokenizer.json`, ...).
+    pub files: BTreeMap<String, PathBuf>,
     pub use_gpu: bool,
     /// GPU layers of the text encoder.
     pub text_gpu_layers: i32,
@@ -44,12 +49,80 @@ pub struct GenParams {
     pub height: i64,
     pub n_frames: i64,
     pub fps: f32,
+    /// `0` for the model's default.
     pub n_steps: i32,
+    /// `0` for the model's default (LTX: 1, Cosmos3: 6).
     pub cfg_scale: f32,
     /// `None` picks a random seed.
     pub seed: Option<u32>,
     pub gen_audio: bool,
     pub enhance_prompt: bool,
+    /// Conditioning image: image-to-video (and the first frame of an action run).
+    pub image: Option<Frames>,
+    /// Conditioning clip: an action run's observed video, or the leading frames
+    /// of a video-to-video run.
+    pub video: Option<Frames>,
+    /// Video-to-video: the latent frames kept from the clip (`(0, 1)` in the reference).
+    pub condition_frames: Vec<i64>,
+    /// Video-to-video: take the conditioning frames from the end of the clip.
+    pub condition_keep_last: bool,
+    /// An action-conditioned run (Cosmos3).
+    pub action: Option<ActionParams>,
+    /// Scheduler flow shift override (Cosmos3: Karras sigmas when `None`).
+    pub flow_shift: Option<f32>,
+}
+
+/// Decoded RGB frames, `[f][h][w][3]` bytes.
+#[derive(Clone, Debug, Default)]
+pub struct Frames {
+    pub width: i64,
+    pub height: i64,
+    pub n_frames: i64,
+    pub rgb: Vec<u8>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ActionMode {
+    /// Video from the first frame and the given actions.
+    ForwardDynamics,
+    /// Actions connecting the frames of the given video.
+    InverseDynamics,
+    /// Video and actions from the first frame.
+    Policy,
+}
+
+impl ActionMode {
+    pub fn parse(s: &str) -> Option<ActionMode> {
+        match s {
+            "forward_dynamics" | "fd" => Some(ActionMode::ForwardDynamics),
+            "inverse_dynamics" | "id" => Some(ActionMode::InverseDynamics),
+            "policy" => Some(ActionMode::Policy),
+            _ => None,
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            ActionMode::ForwardDynamics => "forward_dynamics",
+            ActionMode::InverseDynamics => "inverse_dynamics",
+            ActionMode::Policy => "policy",
+        }
+    }
+}
+
+/// `CosmosActionCondition`.
+#[derive(Clone, Debug)]
+pub struct ActionParams {
+    pub mode: ActionMode,
+    /// Action transitions in the chunk; the clip has one more frame.
+    pub chunk_size: i64,
+    /// Embodiment domain (`bridge_orig_lerobot`, `av`, ...).
+    pub domain: String,
+    /// Conditioning canvas tier: 256, 480, 704 or 720.
+    pub resolution_tier: i64,
+    /// `[T][raw_action_dim]` for forward dynamics.
+    pub actions: Vec<Vec<f32>>,
+    pub view_point: String,
 }
 
 impl Default for GenParams {
@@ -62,10 +135,16 @@ impl Default for GenParams {
             n_frames: 1,
             fps: 24.0,
             n_steps: 0,
-            cfg_scale: 1.0,
+            cfg_scale: 0.0,
             seed: None,
             gen_audio: false,
             enhance_prompt: true,
+            image: None,
+            video: None,
+            condition_frames: vec![0, 1],
+            condition_keep_last: false,
+            action: None,
+            flow_shift: None,
         }
     }
 }
@@ -83,6 +162,8 @@ pub struct Output {
     pub pcm: Vec<f32>,
     pub revised_prompt: String,
     pub seed: u32,
+    /// Predicted actions `[T][raw_action_dim]` of an action run.
+    pub actions: Vec<Vec<f32>>,
 }
 
 impl Output {
@@ -92,11 +173,22 @@ impl Output {
     }
 }
 
+/// The loaded model of one of the supported architectures.
+enum Inner {
+    Ltx(Box<LtxCtx>),
+    Cosmos3(Box<cosmos3::Model>),
+}
+
 pub struct Context {
     // dropped in this order: weight buffers before their backend
+    inner: Inner,
+    be: Backend,
+}
+
+/// An LTX-2 model with its Gemma text encoder and prompt caches.
+struct LtxCtx {
     ltx: Model,
     text: Box<TextEncoder>,
-    be: Backend,
     distilled: bool,
     flash_attn: bool,
     has_video_vae: bool,
@@ -106,12 +198,24 @@ pub struct Context {
     ncond: Option<(String, TextCond)>,
 }
 
+fn is_ltx(arch: &str) -> bool {
+    matches!(arch, "ltxv" | "ltx-video" | "ltxav")
+}
+
 /// Is this GGUF a diffusion transformer we can run?
 pub fn is_diffusion_model(path: &Path) -> bool {
     weights::read_index(path)
         .ok()
         .and_then(|i| i.metadata.get("general.architecture").cloned())
-        .is_some_and(|a| matches!(a.as_str(), "ltxv" | "ltx-video" | "ltxav"))
+        .is_some_and(|a| is_ltx(&a) || cosmos3::is_cosmos3(&a))
+}
+
+/// Does this architecture run without a separate text encoder GGUF?
+pub fn needs_text_encoder(path: &Path) -> bool {
+    weights::read_index(path)
+        .ok()
+        .and_then(|i| i.metadata.get("general.architecture").cloned())
+        .is_none_or(|a| !cosmos3::is_cosmos3(&a))
 }
 
 /// Audio latent frames covering the whole clip; the decoded audio is trimmed to the video.
@@ -125,14 +229,14 @@ pub fn audio_latent_frames(hp: &ltx::Hparams, n_video_frames: i64, fps: f32) -> 
 
 /// mt19937 + `std::normal_distribution<float>` as libc++ implements it (Marsaglia polar in
 /// `float`), for the same noise as the C++ implementation given a seed.
-struct Mt19937 {
+pub(super) struct Mt19937 {
     mt: [u32; 624],
     i: usize,
     saved: Option<f32>,
 }
 
 impl Mt19937 {
-    fn new(seed: u32) -> Self {
+    pub(super) fn new(seed: u32) -> Self {
         let mut mt = [0u32; 624];
         mt[0] = seed;
         for i in 1..624 {
@@ -172,7 +276,7 @@ impl Mt19937 {
         self.next_u32() as f32 / 4294967296.0
     }
 
-    fn normal(&mut self) -> f32 {
+    pub(super) fn normal(&mut self) -> f32 {
         if let Some(v) = self.saved.take() {
             return v;
         }
@@ -198,9 +302,94 @@ impl Context {
             .get("general.architecture")
             .cloned()
             .unwrap_or_default();
-        if !matches!(arch.as_str(), "ltxv" | "ltx-video" | "ltxav") {
+        let mut be = Backend::new(api, p.use_gpu, p.n_threads, 64 * 1024)?;
+        let inner = if is_ltx(&arch) {
+            Inner::Ltx(Box::new(LtxCtx::load(api, &mut be, p, &idx)?))
+        } else if cosmos3::is_cosmos3(&arch) {
+            let m = cosmos3::Model::load(
+                api,
+                &be,
+                &idx,
+                &p.model,
+                p.vae.as_deref(),
+                &p.files,
+                p.flash_attn,
+            )?;
+            be.release_compute()?;
+            Inner::Cosmos3(Box::new(m))
+        } else {
             bail!("unsupported diffusion architecture {arch:?}");
+        };
+        Ok(Context { inner, be })
+    }
+
+    pub fn supports_video(&self) -> bool {
+        match &self.inner {
+            Inner::Ltx(l) => l.has_video_vae,
+            Inner::Cosmos3(_) => true,
         }
+    }
+
+    pub fn supports_audio(&self) -> bool {
+        match &self.inner {
+            Inner::Ltx(l) => l.ltx.hp.has_audio && l.has_audio_vae,
+            Inner::Cosmos3(m) => m.sound.is_some(),
+        }
+    }
+
+    pub fn family(&self) -> &'static str {
+        match &self.inner {
+            Inner::Ltx(_) => "ltx",
+            Inner::Cosmos3(_) => "cosmos3",
+        }
+    }
+
+    /// Denoising steps when a request does not say (0: the schedule decides).
+    pub fn default_steps(&self) -> i32 {
+        match &self.inner {
+            Inner::Ltx(_) => 0,
+            Inner::Cosmos3(_) => cosmos3::DEFAULT_STEPS,
+        }
+    }
+
+    pub fn default_cfg(&self) -> f32 {
+        match &self.inner {
+            Inner::Ltx(_) => 1.0,
+            Inner::Cosmos3(_) => cosmos3::DEFAULT_CFG,
+        }
+    }
+
+    /// Frames come in `stride * k + 1`.
+    pub fn temporal_stride(&self) -> i64 {
+        match &self.inner {
+            Inner::Ltx(l) => l.ltx.hp.vae_scale_t,
+            Inner::Cosmos3(m) => m.hp.vae_scale_t,
+        }
+    }
+
+    /// Runs the whole pipeline; `progress(step, n_steps)` returning `false` cancels.
+    pub fn generate(
+        &mut self,
+        p: &GenParams,
+        progress: impl FnMut(i32, i32) -> bool,
+    ) -> Result<Output> {
+        let out = match &mut self.inner {
+            Inner::Ltx(l) => l.generate_inner(&mut self.be, p, progress),
+            Inner::Cosmos3(m) => m.generate(&mut self.be, p, progress),
+        };
+        // frees the compute buffers; recreates the GPU backend after a failure
+        self.be.release_compute()?;
+        out
+    }
+}
+
+impl LtxCtx {
+    fn load(
+        api: &'static Api,
+        be: &mut Backend,
+        p: &ContextParams,
+        idx: &weights::Index,
+    ) -> Result<LtxCtx> {
         let mut hp = match idx.metadata.get("config") {
             Some(c) => ltx::Hparams::from_config(c)?,
             None => ltx::Hparams::default(),
@@ -215,7 +404,6 @@ impl Context {
             .to_lowercase()
             .contains("distilled");
 
-        let mut be = Backend::new(api, p.use_gpu, p.n_threads, 64 * 1024)?;
         let buft = be.weight_buft();
         let t0 = Instant::now();
         let dit = Weights::load(api, &p.model, buft, &LoadOpts::default())?;
@@ -290,9 +478,12 @@ impl Context {
 
         // text encoder, with room for prompt enhancement
         let n_ctx = ltx.hp.text_max_tokens.max(2048) as u32;
+        let text_model = p.text_model.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("LTX needs a text encoder GGUF (role \"text_encoder\")")
+        })?;
         let text = TextEncoder::load(
             api,
-            &p.text_model.to_string_lossy(),
+            &text_model.to_string_lossy(),
             p.text_gpu_layers,
             n_ctx,
             p.n_threads,
@@ -304,8 +495,7 @@ impl Context {
             t0.elapsed().as_secs_f64(),
             ltx.hp.has_audio
         );
-        Ok(Context {
-            be,
+        Ok(LtxCtx {
             ltx,
             text,
             distilled,
@@ -318,19 +508,11 @@ impl Context {
         })
     }
 
-    pub fn supports_video(&self) -> bool {
-        self.has_video_vae
-    }
-
-    pub fn supports_audio(&self) -> bool {
+    fn supports_audio(&self) -> bool {
         self.ltx.hp.has_audio && self.has_audio_vae
     }
 
-    pub fn hp(&self) -> &ltx::Hparams {
-        &self.ltx.hp
-    }
-
-    fn get_cond(&mut self, prompt: &str, negative: bool) -> Result<TextCond> {
+    fn get_cond(&mut self, be: &Backend, prompt: &str, negative: bool) -> Result<TextCond> {
         let slot = if negative { &self.ncond } else { &self.cond };
         if let Some((p, c)) = slot {
             if p == prompt {
@@ -350,7 +532,7 @@ impl Context {
         }
         let cond = ltx::text::build_text_cond(
             &self.ltx,
-            &self.be,
+            be,
             &packed,
             n_tokens,
             n_hidden,
@@ -395,20 +577,9 @@ impl Context {
         Ok(cond)
     }
 
-    /// Runs the whole pipeline; `progress(step, n_steps)` returning `false` cancels.
-    pub fn generate(
-        &mut self,
-        p: &GenParams,
-        progress: impl FnMut(i32, i32) -> bool,
-    ) -> Result<Output> {
-        let out = self.generate_inner(p, progress);
-        // frees the compute buffers; recreates the GPU backend after a failure
-        self.be.release_compute()?;
-        out
-    }
-
     fn generate_inner(
         &mut self,
+        be: &mut Backend,
         p: &GenParams,
         mut progress: impl FnMut(i32, i32) -> bool,
     ) -> Result<Output> {
@@ -429,7 +600,7 @@ impl Context {
             eprintln!("[llmman] mediagen: n_frames must be 8k+1, using {n_frames}");
         }
         let gen_audio = p.gen_audio && n_frames > 1 && self.supports_audio();
-        let cfg = p.cfg_scale;
+        let cfg = if p.cfg_scale > 0.0 { p.cfg_scale } else { 1.0 };
         let use_cfg = cfg > 1.0;
 
         // prompt enhancement, fixed seed like the reference pipelines
@@ -451,9 +622,9 @@ impl Context {
             }
         }
 
-        let cond = self.get_cond(&prompt, false)?;
+        let cond = self.get_cond(be, &prompt, false)?;
         let ncond = if use_cfg {
-            Some(self.get_cond(&p.negative_prompt, true)?)
+            Some(self.get_cond(be, &p.negative_prompt, true)?)
         } else {
             None
         };
@@ -501,7 +672,7 @@ impl Context {
                 fps: p.fps,
                 flash: self.flash_attn,
             };
-            let (mut v_pred, mut a_pred) = ltx::dit::forward(&self.ltx, &self.be, &inp)?;
+            let (mut v_pred, mut a_pred) = ltx::dit::forward(&self.ltx, be, &inp)?;
             if v_pred.len() != lat.x.len() || a_pred.len() != alat.x.len() {
                 bail!("transformer output does not match the latents");
             }
@@ -511,7 +682,7 @@ impl Context {
             }
             if let Some(nc) = &ncond {
                 let inp = ltx::dit::Inputs { cond: nc, ..inp };
-                let (v_unc, a_unc) = ltx::dit::forward(&self.ltx, &self.be, &inp)?;
+                let (v_unc, a_unc) = ltx::dit::forward(&self.ltx, be, &inp)?;
                 for (p, u) in v_pred.iter_mut().zip(&v_unc) {
                     *p = u + cfg * (*p - u);
                 }
@@ -540,7 +711,7 @@ impl Context {
         }
 
         // the transformer's compute buffers are of no use to the VAE
-        self.be.release_compute()?;
+        be.release_compute()?;
         let mut out = Output {
             fps: p.fps,
             revised_prompt: prompt,
@@ -549,8 +720,8 @@ impl Context {
         };
         {
             let t0 = Instant::now();
-            let dec = ltx::vae::decode(&self.ltx, &mut self.be, &lat);
-            self.be.release_compute()?;
+            let dec = ltx::vae::decode(&self.ltx, be, &lat);
+            be.release_compute()?;
             let (of, oh, ow, rgb) = dec?;
             eprintln!(
                 "[llmman] mediagen: decoded {of} frame(s) of {ow}x{oh} in {:.2} s",
@@ -567,7 +738,7 @@ impl Context {
         }
         if gen_audio {
             let t0 = Instant::now();
-            match ltx::audio::decode(&self.ltx, &self.be, &alat) {
+            match ltx::audio::decode(&self.ltx, be, &alat) {
                 Err(e) => eprintln!(
                     "[llmman] mediagen: audio decoding failed ({e}), returning video only"
                 ),
@@ -591,14 +762,14 @@ impl Context {
 }
 
 /// `MEDIAGEN_DUMP=<prefix>` writes intermediates as raw f32 files, like the C++ implementation.
-fn dump(name: &str, data: &[f32]) {
+pub(super) fn dump(name: &str, data: &[f32]) {
     if let Ok(prefix) = std::env::var("MEDIAGEN_DUMP") {
         let bytes: Vec<u8> = data.iter().flat_map(|v| v.to_le_bytes()).collect();
         let _ = std::fs::write(format!("{prefix}.{name}.bin"), bytes);
     }
 }
 
-fn rand_seed() -> u32 {
+pub(super) fn rand_seed() -> u32 {
     let mut b = [0u8; 4];
     if std::fs::File::open("/dev/urandom")
         .and_then(|mut f| std::io::Read::read_exact(&mut f, &mut b))

--- a/src/mediagen/server.rs
+++ b/src/mediagen/server.rs
@@ -17,7 +17,7 @@ use base64::Engine;
 use serde_json::{json, Value};
 use tokio::sync::mpsc;
 
-use super::{encode, Context, GenParams};
+use super::{encode, ActionMode, ActionParams, Context, GenParams};
 
 const MAX_DIM: i64 = 4096;
 const MAX_FRAMES: i64 = 1025;
@@ -39,6 +39,13 @@ pub struct Server {
     counter: AtomicU32,
     supports_video: bool,
     supports_audio: bool,
+    /// Frame counts are `stride * k + 1`.
+    temporal_stride: i64,
+    /// `"ltx"` or `"cosmos3"`.
+    family: &'static str,
+    /// The model's own defaults when a request leaves them out.
+    default_steps: i32,
+    default_cfg: f32,
 }
 
 type Shared = Arc<Server>;
@@ -129,7 +136,8 @@ fn common_params(body: &Value) -> Result<GenParams, Error> {
     p.width = round_dim("width", get_i64(body, "width", w), 32)?;
     p.height = round_dim("height", get_i64(body, "height", h), 32)?;
     p.n_steps = in_range("steps", get_i64(body, "steps", 0), 0, MAX_STEPS)? as i32;
-    p.cfg_scale = get_f64(body, "cfg_scale", 1.0) as f32;
+    // 0: the model's default
+    p.cfg_scale = get_f64(body, "cfg_scale", 0.0) as f32;
     p.seed = match get_i64(body, "seed", -1) {
         s if s < 0 => None,
         s => Some(in_range("seed", s, 0, u32::MAX as i64)? as u32),
@@ -137,6 +145,107 @@ fn common_params(body: &Value) -> Result<GenParams, Error> {
     p.enhance_prompt = get_bool(body, "enhance_prompt", true);
     p.negative_prompt = get_str(body, "negative_prompt");
     Ok(p)
+}
+
+/// A base64 field, with or without a `data:...;base64,` prefix.
+fn get_b64(body: &Value, k: &str) -> Result<Option<Vec<u8>>, Error> {
+    let Some(v) = body.get(k) else {
+        return Ok(None);
+    };
+    let s = v
+        .as_str()
+        .ok_or_else(|| Error::Invalid(format!("\"{k}\" must be a base64 string")))?;
+    let s = s.rsplit_once(";base64,").map_or(s, |(_, d)| d).trim();
+    base64::engine::general_purpose::STANDARD
+        .decode(s)
+        .map(Some)
+        .map_err(|e| Error::Invalid(format!("\"{k}\": invalid base64: {e}")))
+}
+
+/// The conditioning inputs of `/v1/videos`: `image` (PNG/JPEG), `video` (a
+/// container ffmpeg reads) and an `action` run.
+fn conditioning(body: &Value, p: &mut GenParams) -> Result<(), Error> {
+    if let Some(bytes) = get_b64(body, "image")?.or(get_b64(body, "input_reference")?) {
+        p.image = Some(encode::decode_image(&bytes).map_err(|e| Error::Invalid(e.to_string()))?);
+    }
+    if let Some(bytes) = get_b64(body, "video")? {
+        p.video = Some(encode::decode_video(&bytes).map_err(|e| Error::Invalid(e.to_string()))?);
+    }
+    if let Some(v) = body.get("condition_frames") {
+        p.condition_frames = v
+            .as_array()
+            .map(|a| a.iter().filter_map(Value::as_i64).collect())
+            .filter(|f: &Vec<i64>| !f.is_empty())
+            .ok_or_else(|| {
+                Error::Invalid("\"condition_frames\" must be a list of latent frame indexes".into())
+            })?;
+    }
+    match body.get("condition_video_keep").and_then(Value::as_str) {
+        None | Some("first") => {}
+        Some("last") => p.condition_keep_last = true,
+        Some(_) => {
+            return Err(Error::Invalid(
+                "\"condition_video_keep\" must be first or last".into(),
+            ))
+        }
+    }
+    if let Some(f) = body.get("flow_shift").and_then(Value::as_f64) {
+        if !(f.is_finite() && f > 0.0) {
+            return Err(Error::Invalid("\"flow_shift\" must be positive".into()));
+        }
+        p.flow_shift = Some(f as f32);
+    }
+    let Some(a) = body.get("action") else {
+        return Ok(());
+    };
+    let mode = a
+        .get("mode")
+        .and_then(Value::as_str)
+        .and_then(ActionMode::parse)
+        .ok_or_else(|| {
+            Error::Invalid(
+                "\"action.mode\" must be forward_dynamics, inverse_dynamics or policy".into(),
+            )
+        })?;
+    let actions: Vec<Vec<f32>> = match a.get("actions") {
+        None | Some(Value::Null) => Vec::new(),
+        Some(v) => serde_json::from_value(v.clone()).map_err(|_| {
+            Error::Invalid("\"action.actions\" must be a [T][D] array of numbers".into())
+        })?,
+    };
+    let chunk_size = match a.get("chunk_size").and_then(Value::as_i64) {
+        Some(n) => n,
+        None if !actions.is_empty() => actions.len() as i64,
+        None => return Err(Error::Invalid("\"action.chunk_size\" is required".into())),
+    };
+    if p.image.is_none() && p.video.is_none() {
+        return Err(Error::Invalid(
+            "an action run needs \"image\" or \"video\"".into(),
+        ));
+    }
+    if mode == ActionMode::InverseDynamics && p.video.is_none() {
+        return Err(Error::Invalid("inverse dynamics needs \"video\"".into()));
+    }
+    if mode == ActionMode::ForwardDynamics && actions.is_empty() {
+        return Err(Error::Invalid(
+            "forward dynamics needs \"action.actions\"".into(),
+        ));
+    }
+    p.action = Some(ActionParams {
+        mode,
+        chunk_size: in_range("action.chunk_size", chunk_size, 1, 1024)?,
+        domain: get_str(a, "domain"),
+        resolution_tier: a
+            .get("resolution_tier")
+            .and_then(Value::as_i64)
+            .unwrap_or(480),
+        actions,
+        view_point: match get_str(a, "view_point") {
+            s if s.is_empty() => "ego_view".to_string(),
+            s => s,
+        },
+    });
+    Ok(())
 }
 
 fn check_pixels(p: &GenParams) -> Result<(), Error> {
@@ -173,7 +282,7 @@ async fn models(State(s): State<Shared>) -> Json<Value> {
         "models": [{
             "name": s.model_name, "model": s.model_name, "modified_at": "", "size": "", "digest": "",
             "type": "model", "description": "", "tags": [""], "capabilities": caps, "parameters": "",
-            "details": {"parent_model": "", "format": "gguf", "family": "ltx", "families": ["ltx"],
+            "details": {"parent_model": "", "format": "gguf", "family": s.family, "families": [s.family],
                         "parameter_size": "", "quantization_level": ""}
         }],
         "object": "list",
@@ -189,7 +298,7 @@ async fn props(State(s): State<Shared>) -> Json<Value> {
             "vision": false, "video": false, "audio": false,
             "image_generation": s.supports_video, "video_generation": s.supports_video, "audio_generation": s.supports_audio,
         },
-        "default_generation_settings": {"width": 768, "height": 512, "fps": 24.0, "steps": 0, "cfg_scale": 1.0},
+        "default_generation_settings": {"width": 768, "height": 512, "fps": 24.0, "steps": s.default_steps, "cfg_scale": s.default_cfg},
         "build_info": format!("llmman {}", env!("CARGO_PKG_VERSION")),
     }))
 }
@@ -322,9 +431,15 @@ async fn videos(State(s): State<Shared>, body: axum::body::Bytes) -> Result<Resp
         };
     }
     let n_frames = in_range("frames", n_frames, 9, MAX_FRAMES)?;
-    p.n_frames = (n_frames - 1) / 8 * 8 + 1;
+    let st = s.temporal_stride;
+    p.n_frames = (n_frames - 1) / st * st + 1;
+    conditioning(&body, &mut p)?;
+    if let Some(a) = &p.action {
+        // the clip is the action chunk plus one frame, on the tier's canvas
+        p.n_frames = a.chunk_size + 1;
+    }
     check_pixels(&p)?;
-    p.gen_audio = get_bool(&body, "audio", s.supports_audio);
+    p.gen_audio = get_bool(&body, "audio", s.supports_audio && p.action.is_none());
     let response_format = body
         .get("response_format")
         .and_then(|v| v.as_str())
@@ -353,6 +468,9 @@ async fn videos(State(s): State<Shared>, body: axum::body::Bytes) -> Result<Resp
         "fps": out.fps, "n_frames": out.n_frames, "has_audio": !out.pcm.is_empty(),
         "revised_prompt": out.revised_prompt,
     });
+    if !out.actions.is_empty() {
+        job["actions"] = json!(out.actions);
+    }
     if !mp4.is_empty() {
         job["content_url"] = json!(format!("/v1/videos/{id}/content"));
     }
@@ -451,7 +569,8 @@ async fn speech(State(s): State<Shared>, body: axum::body::Bytes) -> Result<Resp
     // audio is generated jointly with a small video
     p.width = 256;
     p.height = 256;
-    p.n_frames = (((seconds * p.fps as f64).round() as i64) / 8 * 8 + 1).max(9);
+    let st = s.temporal_stride;
+    p.n_frames = (((seconds * p.fps as f64).round() as i64) / st * st + 1).max(9);
     p.gen_audio = true;
     let out = generate(s, p, None, Arc::new(AtomicBool::new(false))).await?;
     if out.pcm.is_empty() {
@@ -468,6 +587,10 @@ pub fn router(ctx: Context, model_name: String, model_path: String) -> Router {
     let s = Arc::new(Server {
         supports_video: ctx.supports_video(),
         supports_audio: ctx.supports_audio(),
+        temporal_stride: ctx.temporal_stride(),
+        family: ctx.family(),
+        default_steps: ctx.default_steps(),
+        default_cfg: ctx.default_cfg(),
         ctx: Mutex::new(ctx),
         model_name,
         model_path,

--- a/src/mediagen/weights.rs
+++ b/src/mediagen/weights.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{BufReader, Read, Seek, SeekFrom};
+use std::io::{BufReader, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -519,4 +519,107 @@ fn convert(api: &Api, from: u32, to: u32, src: &[u8], n: i64) -> Result<Option<V
         }
         other => bail!("cannot convert to ggml type {other}"),
     }
+}
+
+/// One tensor of a safetensors file as stored: dtype name, torch-order shape, raw bytes.
+pub struct RawTensor {
+    pub name: String,
+    pub dtype: String,
+    pub shape: Vec<i64>,
+    pub bytes: Vec<u8>,
+}
+
+impl RawTensor {
+    /// The bytes as f32 (F32 tensors only).
+    pub fn f32s(&self) -> Result<Vec<f32>> {
+        if self.dtype != "F32" {
+            bail!("{}: expected F32, got {}", self.name, self.dtype);
+        }
+        Ok(self
+            .bytes
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|c| f32::from_le_bytes(*c))
+            .collect())
+    }
+}
+
+/// Every tensor of a safetensors file, sorted by name.
+pub fn read_safetensors_raw(path: &Path) -> Result<Vec<RawTensor>> {
+    let mut f = File::open(path).with_context(|| path.display().to_string())?;
+    let mut len = [0u8; 8];
+    f.read_exact(&mut len)?;
+    let n = u64::from_le_bytes(len) as usize;
+    let mut header = vec![0u8; n];
+    f.read_exact(&mut header)?;
+    let header: serde_json::Value =
+        serde_json::from_slice(&header).context("safetensors header")?;
+    let entries = header.as_object().context("safetensors header")?;
+    let base = 8 + n as u64;
+    let mut out = Vec::new();
+    for (name, e) in entries {
+        if name == "__metadata__" {
+            continue;
+        }
+        let shape: Vec<i64> = e["shape"]
+            .as_array()
+            .with_context(|| format!("{name}: shape"))?
+            .iter()
+            .filter_map(serde_json::Value::as_i64)
+            .collect();
+        let (o0, o1) = (
+            e["data_offsets"][0]
+                .as_u64()
+                .with_context(|| format!("{name}: offsets"))?,
+            e["data_offsets"][1]
+                .as_u64()
+                .with_context(|| format!("{name}: offsets"))?,
+        );
+        f.seek(SeekFrom::Start(base + o0))?;
+        let mut bytes = vec![0u8; (o1 - o0) as usize];
+        f.read_exact(&mut bytes)?;
+        out.push(RawTensor {
+            name: name.clone(),
+            dtype: e["dtype"].as_str().context("dtype")?.to_string(),
+            shape,
+            bytes,
+        });
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(out)
+}
+
+/// Writes `tensors` as a safetensors file (atomically, via a `.tmp` sibling).
+pub fn write_safetensors_raw(path: &Path, tensors: &[RawTensor], note: &str) -> Result<()> {
+    let mut hdr = serde_json::Map::new();
+    let mut offset = 0u64;
+    for t in tensors {
+        let end = offset + t.bytes.len() as u64;
+        hdr.insert(
+            t.name.clone(),
+            serde_json::json!({"dtype": t.dtype, "shape": t.shape, "data_offsets": [offset, end]}),
+        );
+        offset = end;
+    }
+    hdr.insert(
+        "__metadata__".into(),
+        serde_json::json!({"format": "pt", "llmman": note}),
+    );
+    let mut hb = serde_json::to_vec(&serde_json::Value::Object(hdr))?;
+    while !hb.len().is_multiple_of(8) {
+        hb.push(b' ');
+    }
+    let tmp = path.with_extension("tmp");
+    {
+        let mut w = std::io::BufWriter::new(File::create(&tmp)?);
+        w.write_all(&(hb.len() as u64).to_le_bytes())?;
+        w.write_all(&hb)?;
+        for t in tensors {
+            w.write_all(&t.bytes)?;
+        }
+        w.flush()?;
+    }
+    std::fs::rename(&tmp, path)?;
+    Ok(())
 }

--- a/src/modelpack.rs
+++ b/src/modelpack.rs
@@ -59,6 +59,8 @@ pub struct DiffusionPaths {
     pub text_proj: Option<PathBuf>,
     /// Text encoder GGUF (`--text-encoder`).
     pub text_encoder: Option<PathBuf>,
+    /// Every raw layer by its `org.cncf.model.filepath` (tokenizer, configs, ...).
+    pub files: std::collections::BTreeMap<String, PathBuf>,
 }
 
 impl ModelPath {
@@ -492,6 +494,12 @@ pub fn resolve_model(
             ..Default::default()
         };
         for l in &manifest.layers {
+            // raw layers only: a tar layer's blob is the archive, not the file
+            if let (Some(fp), true) = (layer_filepath(l), l.media_type.ends_with(".raw")) {
+                paths
+                    .files
+                    .insert(fp.to_string(), named_blob_path(store_path, cache_path, l)?);
+            }
             let Some(role) = layer_role(l) else { continue };
             let p = named(l)?;
             match role {
@@ -499,6 +507,8 @@ pub fn resolve_model(
                 "audio_vae" => paths.audio_vae = Some(p),
                 "text_proj" => paths.text_proj = Some(p),
                 "text_encoder" => paths.text_encoder = Some(p),
+                // Cosmos3 sidecars its generation path does not use
+                "vision_encoder" | "sound_tokenizer" => {}
                 other => {
                     eprintln!("[llmman] {model_ref}: ignoring layer with unknown role {other:?}")
                 }
@@ -671,13 +681,16 @@ mod tests {
     fn manifest_with(
         layers: Vec<crate::storage::oci::Descriptor>,
     ) -> (OciStore, crate::storage::oci::Manifest) {
+        // parallel tests can share a clock tick; the counter keeps their stores apart
+        static N: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
         let dir = std::env::temp_dir().join(format!(
-            "llmman-modelpack-caps-{}-{}",
+            "llmman-modelpack-caps-{}-{}-{}",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
-                .as_nanos()
+                .as_nanos(),
+            N.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
         ));
         let store = OciStore::open(&dir).unwrap();
         let config = store

--- a/src/textgen/chat.rs
+++ b/src/textgen/chat.rs
@@ -1,0 +1,80 @@
+//! Chat template rendering: the model's own Jinja template, as llama-server
+//! applies it, so the prompt tokens are the same.
+
+use anyhow::{anyhow, Result};
+use minijinja::{context, Environment, Error, ErrorKind, Value};
+use serde_json::Value as Json;
+
+fn raise_exception(msg: String) -> Result<Value, Error> {
+    Err(Error::new(ErrorKind::InvalidOperation, msg))
+}
+
+fn strftime_now(fmt: String) -> String {
+    chrono::Local::now().format(&fmt).to_string()
+}
+
+/// Renders `messages` (OpenAI shape) with `template`, ending with the
+/// assistant turn opener. `tools` is passed through for templates that
+/// know about them; `thinking` is the template's `enable_thinking` knob.
+pub fn render(template: &str, messages: &[Json], tools: Option<&Json>, bos: &str, eos: &str, thinking: bool) -> Result<String> {
+    let mut env = Environment::new();
+    env.set_trim_blocks(true);
+    env.set_lstrip_blocks(true);
+    env.add_function("raise_exception", raise_exception);
+    env.add_function("strftime_now", strftime_now);
+    // the templates are written for Python's Jinja: dict.get, str.startswith, ...
+    env.set_unknown_method_callback(minijinja_contrib::pycompat::unknown_method_callback);
+    minijinja_contrib::add_to_environment(&mut env);
+    env.add_template("chat", template)?;
+    let tmpl = env.get_template("chat")?;
+    // text-only content parts become the string llama-server would see
+    let messages: Vec<Json> = messages.iter().map(flatten_content).collect();
+    let out = tmpl
+        .render(context! {
+            messages => Value::from_serialize(&messages),
+            tools => Value::from_serialize(&tools),
+            add_generation_prompt => true,
+            enable_thinking => thinking,
+            bos_token => bos,
+            eos_token => eos,
+        })
+        .map_err(|e| anyhow!("chat template: {e}"))?;
+    Ok(out)
+}
+
+fn flatten_content(m: &Json) -> Json {
+    let mut m = m.clone();
+    if let Some(parts) = m.get("content").and_then(|c| c.as_array()) {
+        let text: String = parts
+            .iter()
+            .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
+            .collect::<Vec<_>>()
+            .join("");
+        m["content"] = Json::String(text);
+    }
+    if m.get("content").is_none() {
+        m["content"] = Json::String(String::new());
+    }
+    m
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CHATML: &str = "{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}";
+
+    #[test]
+    fn renders_chatml() {
+        let msgs = vec![serde_json::json!({"role": "user", "content": "hi"})];
+        let out = render(CHATML, &msgs, None, "<s>", "</s>", true).unwrap();
+        assert_eq!(out, "<|im_start|>user\nhi<|im_end|>\n<|im_start|>assistant\n");
+    }
+
+    #[test]
+    fn flattens_content_parts() {
+        let msgs = vec![serde_json::json!({"role": "user", "content": [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]})];
+        let out = render(CHATML, &msgs, None, "", "", true).unwrap();
+        assert!(out.contains("user\nab<|im_end|>"));
+    }
+}

--- a/src/textgen/engine.rs
+++ b/src/textgen/engine.rs
@@ -1,0 +1,555 @@
+//! Text generation over libllama: one model, one context, requests served
+//! from a dedicated thread. Context size and GPU offload are fitted to the
+//! memory the devices report, so a load cannot run the machine out of memory.
+
+use std::ffi::{CStr, CString};
+use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::{anyhow, bail, Result};
+use tokio::sync::mpsc as tmpsc;
+
+use crate::mediagen::ffi::{self, Api, LlamaBatch, LlamaContextParams, LlamaContextT, LlamaModel, LlamaModelParams, LlamaVocab};
+
+/// Sampling parameters; llama-server's defaults.
+#[derive(Clone, Debug)]
+pub struct Sampling {
+    pub max_tokens: i32,
+    pub temperature: f32,
+    pub top_k: i32,
+    pub top_p: f32,
+    pub min_p: f32,
+    pub repeat_penalty: f32,
+    pub repeat_last_n: i32,
+    pub frequency_penalty: f32,
+    pub presence_penalty: f32,
+    pub seed: Option<u32>,
+    pub stop: Vec<String>,
+}
+
+impl Default for Sampling {
+    fn default() -> Self {
+        Sampling {
+            max_tokens: -1,
+            temperature: 0.8,
+            top_k: 40,
+            top_p: 0.95,
+            min_p: 0.05,
+            repeat_penalty: 1.0,
+            repeat_last_n: 64,
+            frequency_penalty: 0.0,
+            presence_penalty: 0.0,
+            seed: None,
+            stop: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Finish {
+    Stop,
+    Length,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Timings {
+    pub prompt_n: usize,
+    pub prompt_ms: f64,
+    pub predicted_n: usize,
+    pub predicted_ms: f64,
+    /// Prompt tokens reused from the previous request's cache.
+    pub cached_n: usize,
+}
+
+pub enum Event {
+    Token { id: i32, text: String },
+    Done { finish: Finish, timings: Timings },
+    Error(String),
+}
+
+pub struct Request {
+    pub tokens: Vec<i32>,
+    pub sampling: Sampling,
+    pub tx: tmpsc::UnboundedSender<Event>,
+    pub cancel: Arc<AtomicBool>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ModelInfo {
+    pub path: String,
+    pub desc: String,
+    pub n_params: u64,
+    pub size: u64,
+    pub n_ctx: u32,
+    pub n_ctx_train: i32,
+    pub n_gpu_layers: i32,
+    pub chat_template: Option<String>,
+    pub bos: String,
+    pub eos: String,
+    pub add_bos: bool,
+    pub bos_id: i32,
+}
+
+/// Handle to the engine thread.
+#[derive(Clone)]
+pub struct Handle {
+    tx: mpsc::Sender<Request>,
+    pub info: Arc<ModelInfo>,
+    api: &'static Api,
+    vocab: *const LlamaVocab,
+}
+
+unsafe impl Send for Handle {}
+unsafe impl Sync for Handle {}
+
+impl Handle {
+    pub fn generate(&self, tokens: Vec<i32>, sampling: Sampling) -> (tmpsc::UnboundedReceiver<Event>, Arc<AtomicBool>) {
+        let (tx, rx) = tmpsc::unbounded_channel();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let req = Request { tokens, sampling, tx: tx.clone(), cancel: cancel.clone() };
+        if self.tx.send(req).is_err() {
+            let _ = tx.send(Event::Error("engine stopped".into()));
+        }
+        (rx, cancel)
+    }
+
+    pub fn tokenize(&self, text: &str, add_special: bool, parse_special: bool) -> Result<Vec<i32>> {
+        tokenize(self.api, self.vocab, text, add_special, parse_special)
+    }
+
+    pub fn detokenize(&self, tokens: &[i32], special: bool) -> String {
+        let mut buf = vec![0u8; tokens.len() * 8 + 16];
+        let mut n = unsafe {
+            (self.api.llama_detokenize)(self.vocab, tokens.as_ptr(), tokens.len() as i32, buf.as_mut_ptr() as *mut _, buf.len() as i32, false, special)
+        };
+        if n < 0 {
+            buf.resize((-n) as usize, 0);
+            n = unsafe {
+                (self.api.llama_detokenize)(self.vocab, tokens.as_ptr(), tokens.len() as i32, buf.as_mut_ptr() as *mut _, buf.len() as i32, false, special)
+            };
+        }
+        String::from_utf8_lossy(&buf[..n.max(0) as usize]).into_owned()
+    }
+}
+
+fn tokenize(api: &Api, vocab: *const LlamaVocab, text: &str, add_special: bool, parse_special: bool) -> Result<Vec<i32>> {
+    let ctext = CString::new(text)?;
+    let mut tokens = vec![0i32; text.len() + 16];
+    let mut n = unsafe {
+        (api.llama_tokenize)(vocab, ctext.as_ptr(), text.len() as i32, tokens.as_mut_ptr(), tokens.len() as i32, add_special, parse_special)
+    };
+    if n < 0 {
+        tokens.resize((-n) as usize, 0);
+        n = unsafe {
+            (api.llama_tokenize)(vocab, ctext.as_ptr(), text.len() as i32, tokens.as_mut_ptr(), tokens.len() as i32, add_special, parse_special)
+        };
+    }
+    if n < 0 {
+        bail!("failed to tokenize");
+    }
+    tokens.truncate(n as usize);
+    Ok(tokens)
+}
+
+fn meta(api: &Api, model: *const LlamaModel, key: &str) -> Option<String> {
+    let ckey = CString::new(key).ok()?;
+    let mut buf = vec![0u8; 4096];
+    let n = unsafe { (api.llama_model_meta_val_str)(model, ckey.as_ptr(), buf.as_mut_ptr() as *mut _, buf.len()) };
+    (n >= 0).then(|| String::from_utf8_lossy(&buf[..n as usize]).into_owned())
+}
+
+/// Free and total bytes of the first GPU device, if any.
+fn gpu_memory(api: &Api) -> Option<(usize, usize)> {
+    unsafe {
+        for i in 0..(api.ggml_backend_dev_count)() {
+            let dev = (api.ggml_backend_dev_get)(i);
+            let ty = (api.ggml_backend_dev_type)(dev);
+            if ty == ffi::GGML_BACKEND_DEVICE_TYPE_GPU || ty == ffi::GGML_BACKEND_DEVICE_TYPE_IGPU {
+                let (mut free, mut total) = (0usize, 0usize);
+                (api.ggml_backend_dev_memory)(dev, &mut free, &mut total);
+                return Some((free, total));
+            }
+        }
+    }
+    None
+}
+
+/// The vocab outlives the model it belongs to only as long as the engine
+/// thread does, which owns the model.
+struct VocabPtr(*const LlamaVocab);
+unsafe impl Send for VocabPtr {}
+
+/// The engine thread's state.
+struct Engine {
+    api: &'static Api,
+    model: *mut LlamaModel,
+    ctx: *mut LlamaContextT,
+    vocab: *const LlamaVocab,
+    n_ctx: u32,
+    n_batch: u32,
+    batch: LlamaBatch,
+    /// Tokens currently in the KV cache of sequence 0.
+    cache: Vec<i32>,
+}
+
+impl Drop for Engine {
+    fn drop(&mut self) {
+        unsafe {
+            (self.api.llama_batch_free)(self.batch);
+            (self.api.llama_free)(self.ctx);
+            (self.api.llama_model_free)(self.model);
+        }
+    }
+}
+
+pub struct LoadOpts {
+    /// Requested context; `0` means the model's training context.
+    pub n_ctx: u32,
+    pub n_threads: i32,
+    pub flash_attn: bool,
+}
+
+/// Loads the model and starts the engine thread.
+pub fn spawn(api: &'static Api, path: &str, opts: LoadOpts) -> Result<Handle> {
+    let (tx, rx) = mpsc::channel::<Request>();
+    let (ready_tx, ready_rx) = mpsc::channel::<Result<(Arc<ModelInfo>, VocabPtr)>>();
+    let path = path.to_string();
+    std::thread::Builder::new()
+        .name("textgen".into())
+        .spawn(move || match Engine::load(api, &path, &opts) {
+            Ok((mut engine, info)) => {
+                let _ = ready_tx.send(Ok((Arc::new(info), VocabPtr(engine.vocab))));
+                while let Ok(req) = rx.recv() {
+                    engine.serve(req);
+                }
+            }
+            Err(e) => {
+                let _ = ready_tx.send(Err(e));
+            }
+        })?;
+    let (info, vocab) = ready_rx.recv().map_err(|_| anyhow!("engine thread died"))??;
+    Ok(Handle { tx, info, api, vocab: vocab.0 })
+}
+
+impl Engine {
+    fn load(api: &'static Api, path: &str, opts: &LoadOpts) -> Result<(Engine, ModelInfo)> {
+        let cpath = CString::new(path)?;
+        let gpu = gpu_memory(api);
+        // 10% of the device, or 512 MiB, whichever is larger, stays free
+        let budget = gpu.map(|(free, total)| free.saturating_sub((total / 10).max(512 << 20)));
+        let mut n_gpu_layers = 999;
+        let mut model = ptr::null_mut();
+        for attempt in 0..4 {
+            let mut mp = unsafe { (api.llama_model_default_params)() };
+            {
+                let p = mp.view_mut::<LlamaModelParams>();
+                if p.split_mode != 1 || p.main_gpu != 0 || p.vocab_only || p.check_tensors || !p.use_extra_bufts {
+                    bail!("llama_model_params layout does not match this libllama");
+                }
+                p.n_gpu_layers = n_gpu_layers;
+            }
+            model = unsafe { (api.llama_model_load_from_file)(cpath.as_ptr(), mp) };
+            if !model.is_null() {
+                break;
+            }
+            if attempt == 0 && budget.is_some() {
+                // probe the size with a CPU-only load next time round
+                n_gpu_layers = 0;
+            } else {
+                bail!("failed to load {path}");
+            }
+        }
+        let n_layer = unsafe { (api.llama_model_n_layer)(model) };
+        let size = unsafe { (api.llama_model_size)(model) };
+        if n_gpu_layers == 0 {
+            if let Some(b) = budget {
+                // as many layers as fit, leaving room for the context
+                let fit = ((b as f64 * 0.8 / size as f64) * n_layer as f64) as i32;
+                n_gpu_layers = fit.clamp(0, n_layer);
+                unsafe { (api.llama_model_free)(model) };
+                let mut mp = unsafe { (api.llama_model_default_params)() };
+                mp.view_mut::<LlamaModelParams>().n_gpu_layers = n_gpu_layers;
+                model = unsafe { (api.llama_model_load_from_file)(cpath.as_ptr(), mp) };
+                if model.is_null() {
+                    bail!("failed to load {path} with {n_gpu_layers} GPU layers");
+                }
+            }
+        }
+        let vocab = unsafe { (api.llama_model_get_vocab)(model) };
+        let n_ctx_train = unsafe { (api.llama_model_n_ctx_train)(model) };
+        let n_head_kv = unsafe { (api.llama_model_n_head_kv)(model) }.max(1);
+        let n_embd = unsafe { (api.llama_model_n_embd)(model) };
+        let arch = meta(api, model, "general.architecture").unwrap_or_default();
+        let head_dim = meta(api, model, &format!("{arch}.attention.key_length"))
+            .and_then(|v| v.parse::<i32>().ok())
+            .unwrap_or_else(|| {
+                let n_head = meta(api, model, &format!("{arch}.attention.head_count")).and_then(|v| v.parse::<i32>().ok()).unwrap_or(1);
+                n_embd / n_head.max(1)
+            });
+        // f16 K and V per token, every layer; an overestimate for SWA and hybrid models
+        let kv_per_token = n_layer as u64 * 2 * n_head_kv as u64 * head_dim as u64 * 2;
+
+        let mut n_ctx = if opts.n_ctx == 0 { n_ctx_train as u32 } else { opts.n_ctx.min(n_ctx_train as u32) };
+        if let Some(b) = budget {
+            let on_gpu = size * n_gpu_layers.min(n_layer) as u64 / n_layer.max(1) as u64;
+            let compute = (1u64 << 30).max(size / 10);
+            let for_kv = (b as u64).saturating_sub(on_gpu + compute);
+            let max_ctx = (for_kv / kv_per_token.max(1)) as u32 / 256 * 256;
+            if max_ctx < n_ctx {
+                eprintln!("[llmman] textgen: context {n_ctx} does not fit next to the weights, using {}", max_ctx.max(4096));
+                n_ctx = max_ctx.max(4096);
+            }
+        }
+        let n_batch = 2048u32.min(n_ctx);
+
+        let mut ctx: *mut LlamaContextT = ptr::null_mut();
+        while ctx.is_null() {
+            let mut cp = unsafe { (api.llama_context_default_params)() };
+            {
+                let p = cp.view_mut::<LlamaContextParams>();
+                if p.n_batch != 2048 || p.n_ubatch != 512 || p.flash_attn_type != ffi::LLAMA_FLASH_ATTN_TYPE_AUTO || p.type_k != ffi::ty::F16 || !p.offload_kqv || !p.op_offload || !p.swa_full || p.kv_unified {
+                    bail!("llama_context_params layout does not match this libllama");
+                }
+                p.n_ctx = n_ctx;
+                p.n_batch = n_batch;
+                p.n_ubatch = 512.min(n_batch);
+                p.n_seq_max = 1;
+                p.n_threads = opts.n_threads;
+                p.n_threads_batch = opts.n_threads;
+                p.no_perf = true;
+                p.flash_attn_type = if opts.flash_attn { ffi::LLAMA_FLASH_ATTN_TYPE_AUTO } else { ffi::LLAMA_FLASH_ATTN_TYPE_DISABLED };
+            }
+            ctx = unsafe { (api.llama_init_from_model)(model, cp) };
+            if ctx.is_null() {
+                if n_ctx <= 4096 {
+                    unsafe { (api.llama_model_free)(model) };
+                    bail!("failed to create a context of {n_ctx} tokens for {path}");
+                }
+                n_ctx = (n_ctx / 2).max(4096);
+                eprintln!("[llmman] textgen: context allocation failed, retrying with {n_ctx}");
+            }
+        }
+        let n_ctx = unsafe { (api.llama_n_ctx)(ctx) };
+        let batch = unsafe { (api.llama_batch_init)(n_batch as i32, 0, 1) };
+
+        let mut desc = vec![0u8; 256];
+        let n = unsafe { (api.llama_model_desc)(model, desc.as_mut_ptr() as *mut _, desc.len()) };
+        let desc = String::from_utf8_lossy(&desc[..n.max(0) as usize]).into_owned();
+        let tmpl = unsafe { (api.llama_model_chat_template)(model, ptr::null()) };
+        let chat_template = (!tmpl.is_null()).then(|| unsafe { CStr::from_ptr(tmpl) }.to_string_lossy().into_owned());
+        let piece = |tok: i32| -> String {
+            let mut buf = [0u8; 64];
+            let n = unsafe { (api.llama_token_to_piece)(vocab, tok, buf.as_mut_ptr() as *mut _, buf.len() as i32, 0, true) };
+            String::from_utf8_lossy(&buf[..n.max(0) as usize]).into_owned()
+        };
+        let bos_id = unsafe { (api.llama_vocab_bos)(vocab) };
+        let eos_id = unsafe { (api.llama_vocab_eos)(vocab) };
+        let info = ModelInfo {
+            path: path.to_string(),
+            desc,
+            n_params: unsafe { (api.llama_model_n_params)(model) },
+            size,
+            n_ctx,
+            n_ctx_train,
+            n_gpu_layers,
+            chat_template,
+            bos: if bos_id >= 0 { piece(bos_id) } else { String::new() },
+            eos: if eos_id >= 0 { piece(eos_id) } else { String::new() },
+            add_bos: unsafe { (api.llama_vocab_get_add_bos)(vocab) },
+            bos_id,
+        };
+        eprintln!(
+            "[llmman] textgen: {} loaded, n_ctx {n_ctx}, {n_gpu_layers} of {n_layer} layers on the GPU",
+            info.desc
+        );
+        Ok((Engine { api, model, ctx, vocab, n_ctx, n_batch, batch, cache: Vec::new() }, info))
+    }
+
+    fn decode(&mut self, tokens: &[i32], pos0: i32, logits_last: bool) -> Result<()> {
+        let api = self.api;
+        for (ci, chunk) in tokens.chunks(self.n_batch as usize).enumerate() {
+            let last_chunk = (ci + 1) * self.n_batch as usize >= tokens.len();
+            unsafe {
+                for (i, &tok) in chunk.iter().enumerate() {
+                    *self.batch.token.add(i) = tok;
+                    *self.batch.pos.add(i) = pos0 + (ci * self.n_batch as usize + i) as i32;
+                    *self.batch.n_seq_id.add(i) = 1;
+                    **self.batch.seq_id.add(i) = 0;
+                    *self.batch.logits.add(i) = (logits_last && last_chunk && i + 1 == chunk.len()) as i8;
+                }
+                self.batch.n_tokens = chunk.len() as i32;
+                let ret = (api.llama_decode)(self.ctx, self.batch);
+                if ret != 0 {
+                    bail!("llama_decode failed with {ret}");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn sampler(&self, s: &Sampling) -> *mut ffi::LlamaSampler {
+        let api = self.api;
+        unsafe {
+            let chain = (api.llama_sampler_chain_init)((api.llama_sampler_chain_default_params)());
+            let n_vocab = (api.llama_vocab_n_tokens)(self.vocab);
+            if s.repeat_penalty != 1.0 || s.frequency_penalty != 0.0 || s.presence_penalty != 0.0 {
+                (api.llama_sampler_chain_add)(chain, (api.llama_sampler_init_penalties)(n_vocab, s.repeat_last_n, s.repeat_penalty, s.frequency_penalty, s.presence_penalty));
+            }
+            if s.temperature <= 0.0 {
+                (api.llama_sampler_chain_add)(chain, (api.llama_sampler_init_greedy)());
+            } else {
+                if s.top_k > 0 {
+                    (api.llama_sampler_chain_add)(chain, (api.llama_sampler_init_top_k)(s.top_k));
+                }
+                (api.llama_sampler_chain_add)(chain, (api.llama_sampler_init_top_p)(s.top_p, 1));
+                (api.llama_sampler_chain_add)(chain, (api.llama_sampler_init_min_p)(s.min_p, 1));
+                (api.llama_sampler_chain_add)(chain, (api.llama_sampler_init_temp)(s.temperature));
+                (api.llama_sampler_chain_add)(chain, (api.llama_sampler_init_dist)(s.seed.unwrap_or_else(crate::mediagen::rand_seed)));
+            }
+            chain
+        }
+    }
+
+    fn serve(&mut self, req: Request) {
+        let tx = req.tx.clone();
+        if let Err(e) = self.run(req) {
+            let _ = tx.send(Event::Error(e.to_string()));
+        }
+    }
+
+    fn run(&mut self, req: Request) -> Result<()> {
+        let api = self.api;
+        let mut prompt = req.tokens;
+        if prompt.is_empty() {
+            prompt.push(unsafe { (api.llama_vocab_bos)(self.vocab) });
+        }
+        let max_prompt = self.n_ctx as usize - 4;
+        if prompt.len() > max_prompt {
+            bail!("the request ({} tokens) exceeds the available context size ({} tokens)", prompt.len(), self.n_ctx);
+        }
+        // reuse the cached prefix; the last prompt token is always decoded, for its logits
+        let mut common = prompt.iter().zip(&self.cache).take_while(|(a, b)| a == b).count();
+        if common == prompt.len() {
+            common -= 1;
+        }
+        unsafe {
+            (api.llama_memory_seq_rm)((api.llama_get_memory)(self.ctx), 0, common as i32, -1);
+        }
+        self.cache.truncate(common);
+        let t0 = Instant::now();
+        self.decode(&prompt[common..], common as i32, true)?;
+        self.cache.extend_from_slice(&prompt[common..]);
+        // the backend may still be computing: time the whole prefill
+        unsafe { (api.llama_synchronize)(self.ctx) };
+        let prompt_ms = t0.elapsed().as_secs_f64() * 1000.0;
+
+        let smpl = self.sampler(&req.sampling);
+        let max_tokens = if req.sampling.max_tokens < 0 { i32::MAX } else { req.sampling.max_tokens };
+        let mut pending = Vec::new(); // bytes not yet a whole UTF-8 sequence
+        let mut text = String::new(); // everything emitted, for stop strings
+        let mut finish = Finish::Length;
+        let mut n_gen = 0;
+        let t1 = Instant::now();
+        let stop_max = req.sampling.stop.iter().map(|s| s.len()).max().unwrap_or(0);
+        let mut result = Ok(());
+        while n_gen < max_tokens && !req.cancel.load(Ordering::Relaxed) {
+            if self.cache.len() >= self.n_ctx as usize {
+                break;
+            }
+            let id = unsafe { (api.llama_sampler_sample)(smpl, self.ctx, -1) };
+            n_gen += 1;
+            if unsafe { (api.llama_vocab_is_eog)(self.vocab, id) } {
+                finish = Finish::Stop;
+                break;
+            }
+            let mut buf = [0u8; 256];
+            let n = unsafe { (api.llama_token_to_piece)(self.vocab, id, buf.as_mut_ptr() as *mut _, buf.len() as i32, 0, true) };
+            pending.extend_from_slice(&buf[..n.max(0) as usize]);
+            let piece = take_utf8(&mut pending);
+            let mut emit = piece;
+            let mut stopped = false;
+            if stop_max > 0 {
+                let already = text.len();
+                text.push_str(&emit);
+                if let Some(pos) = req.sampling.stop.iter().filter_map(|s| text.find(s.as_str())).min() {
+                    // up to the stop string; nothing if it began in text already sent
+                    emit = if pos > already { text[already..pos].to_string() } else { String::new() };
+                    stopped = true;
+                } else if text.len() > 4 * stop_max {
+                    let mut cut = text.len() - 2 * stop_max;
+                    while !text.is_char_boundary(cut) {
+                        cut -= 1;
+                    }
+                    text.drain(..cut);
+                }
+            }
+            if !emit.is_empty() && tx_send(&req.tx, Event::Token { id, text: emit }).is_err() {
+                break;
+            }
+            if stopped {
+                finish = Finish::Stop;
+                break;
+            }
+            if let Err(e) = self.decode(&[id], self.cache.len() as i32, true) {
+                result = Err(e);
+                break;
+            }
+            self.cache.push(id);
+        }
+        unsafe { (api.llama_sampler_free)(smpl) };
+        result?;
+        let timings = Timings {
+            prompt_n: prompt.len(),
+            prompt_ms,
+            predicted_n: n_gen as usize,
+            predicted_ms: t1.elapsed().as_secs_f64() * 1000.0,
+            cached_n: common,
+        };
+        let _ = tx_send(&req.tx, Event::Done { finish, timings });
+        Ok(())
+    }
+}
+
+fn tx_send(tx: &tmpsc::UnboundedSender<Event>, ev: Event) -> Result<(), ()> {
+    tx.send(ev).map_err(|_| ())
+}
+
+/// Splits off the longest valid UTF-8 prefix.
+fn take_utf8(pending: &mut Vec<u8>) -> String {
+    match std::str::from_utf8(pending) {
+        Ok(s) => {
+            let s = s.to_string();
+            pending.clear();
+            s
+        }
+        Err(e) => {
+            let valid = e.valid_up_to();
+            if e.error_len().is_some() {
+                // not a partial sequence: drop the bad byte
+                let s = String::from_utf8_lossy(&pending[..valid + 1]).into_owned();
+                pending.drain(..valid + 1);
+                return s;
+            }
+            let s = String::from_utf8_lossy(&pending[..valid]).into_owned();
+            pending.drain(..valid);
+            s
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn utf8_is_emitted_only_when_complete() {
+        let mut p = "héllo".as_bytes()[..2].to_vec(); // 'h' + first byte of 'é'
+        assert_eq!(take_utf8(&mut p), "h");
+        p.extend_from_slice(&"héllo".as_bytes()[2..]);
+        assert_eq!(take_utf8(&mut p), "éllo");
+        assert!(p.is_empty());
+    }
+}

--- a/src/textgen/mod.rs
+++ b/src/textgen/mod.rs
@@ -1,0 +1,6 @@
+//! Text generation backend on the llama.cpp release libraries: the same
+//! `dlopen` route as `crate::mediagen`, serving llama-server's endpoints.
+
+pub mod chat;
+pub mod engine;
+pub mod server;

--- a/src/textgen/server.rs
+++ b/src/textgen/server.rs
@@ -1,0 +1,340 @@
+//! The endpoints the daemon proxies to a text backend, in llama-server's
+//! shapes: OpenAI chat and text completions, llama-server's `/completion`,
+//! and the model / health / props probes.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{header, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde_json::{json, Value};
+
+use super::chat;
+use super::engine::{Event, Finish, Handle, Sampling, Timings};
+
+struct Server {
+    engine: Handle,
+    model_name: String,
+}
+
+type Shared = Arc<Server>;
+
+enum Error {
+    Invalid(String),
+    Failed(String),
+}
+
+impl IntoResponse for Error {
+    fn into_response(self) -> Response {
+        let (status, ty, msg) = match self {
+            Error::Invalid(m) => (StatusCode::BAD_REQUEST, "invalid_request_error", m),
+            Error::Failed(m) => (StatusCode::INTERNAL_SERVER_ERROR, "server_error", m),
+        };
+        (status, Json(json!({"error": {"code": status.as_u16(), "message": msg, "type": ty}}))).into_response()
+    }
+}
+
+fn now() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0)
+}
+
+fn f32_of(body: &Value, keys: &[&str], d: f32) -> f32 {
+    keys.iter().find_map(|k| body.get(k).and_then(|v| v.as_f64())).map_or(d, |v| v as f32)
+}
+
+fn i32_of(body: &Value, keys: &[&str], d: i32) -> i32 {
+    keys.iter().find_map(|k| body.get(k).and_then(|v| v.as_i64())).map_or(d, |v| v as i32)
+}
+
+/// Sampling fields, OpenAI names and llama-server names alike.
+fn sampling(body: &Value) -> Result<Sampling, Error> {
+    let d = Sampling::default();
+    let seed = i32_of(body, &["seed"], -1);
+    let stop = match body.get("stop") {
+        Some(Value::String(s)) => vec![s.clone()],
+        Some(Value::Array(a)) => a.iter().filter_map(|v| v.as_str().map(str::to_string)).collect(),
+        _ => Vec::new(),
+    };
+    Ok(Sampling {
+        max_tokens: i32_of(body, &["max_completion_tokens", "max_tokens", "n_predict"], d.max_tokens),
+        temperature: f32_of(body, &["temperature"], d.temperature),
+        top_k: i32_of(body, &["top_k"], d.top_k),
+        top_p: f32_of(body, &["top_p"], d.top_p),
+        min_p: f32_of(body, &["min_p"], d.min_p),
+        repeat_penalty: f32_of(body, &["repeat_penalty"], d.repeat_penalty),
+        repeat_last_n: i32_of(body, &["repeat_last_n"], d.repeat_last_n),
+        frequency_penalty: f32_of(body, &["frequency_penalty"], d.frequency_penalty),
+        presence_penalty: f32_of(body, &["presence_penalty"], d.presence_penalty),
+        seed: (seed >= 0).then_some(seed as u32),
+        stop,
+    })
+}
+
+fn parse_body(body: &[u8]) -> Result<Value, Error> {
+    serde_json::from_slice(body).map_err(|e| Error::Invalid(format!("invalid JSON: {e}")))
+}
+
+fn timings_json(t: &Timings) -> Value {
+    json!({
+        "prompt_n": t.prompt_n,
+        "prompt_ms": t.prompt_ms,
+        "prompt_per_token_ms": if t.prompt_n > 0 { t.prompt_ms / t.prompt_n as f64 } else { 0.0 },
+        "prompt_per_second": if t.prompt_ms > 0.0 { t.prompt_n as f64 * 1000.0 / t.prompt_ms } else { 0.0 },
+        "predicted_n": t.predicted_n,
+        "predicted_ms": t.predicted_ms,
+        "predicted_per_token_ms": if t.predicted_n > 0 { t.predicted_ms / t.predicted_n as f64 } else { 0.0 },
+        "predicted_per_second": if t.predicted_ms > 0.0 { t.predicted_n as f64 * 1000.0 / t.predicted_ms } else { 0.0 },
+        "cache_n": t.cached_n,
+    })
+}
+
+fn finish_str(f: Finish) -> &'static str {
+    match f {
+        Finish::Stop => "stop",
+        Finish::Length => "length",
+    }
+}
+
+async fn health() -> Json<Value> {
+    Json(json!({"status": "ok"}))
+}
+
+async fn models(State(s): State<Shared>) -> Json<Value> {
+    let info = &s.engine.info;
+    Json(json!({
+        "object": "list",
+        "data": [{
+            "id": s.model_name, "object": "model", "created": now(), "owned_by": "llmman",
+            "meta": {"n_ctx_train": info.n_ctx_train, "n_params": info.n_params, "size": info.size}
+        }],
+        "models": [{"name": s.model_name, "model": s.model_name, "capabilities": ["completion"]}]
+    }))
+}
+
+async fn props(State(s): State<Shared>) -> Json<Value> {
+    let info = &s.engine.info;
+    Json(json!({
+        "model_alias": s.model_name,
+        "model_path": info.path,
+        "default_generation_settings": {"n_ctx": info.n_ctx, "params": {"n_predict": -1}},
+        "total_slots": 1,
+        "chat_template": info.chat_template.clone().unwrap_or_default(),
+        "modalities": {"vision": false, "audio": false},
+        "build_info": format!("llmman {}", env!("CARGO_PKG_VERSION")),
+    }))
+}
+
+/// Tokens of a chat request: the model's template rendered over `messages`.
+fn chat_prompt(s: &Server, body: &Value) -> Result<Vec<i32>, Error> {
+    let messages = body.get("messages").and_then(|m| m.as_array()).ok_or_else(|| Error::Invalid("\"messages\" is required".into()))?;
+    let info = &s.engine.info;
+    let tmpl = info.chat_template.as_deref().ok_or_else(|| Error::Invalid("the model has no chat template".into()))?;
+    let thinking = body.get("chat_template_kwargs").and_then(|k| k.get("enable_thinking")).and_then(|v| v.as_bool())
+        .or_else(|| body.get("reasoning").and_then(|r| r.as_bool()))
+        .unwrap_or(true);
+    let text = chat::render(tmpl, messages, body.get("tools"), &info.bos, &info.eos, thinking).map_err(|e| Error::Invalid(e.to_string()))?;
+    let mut tokens = s.engine.tokenize(&text, false, true).map_err(|e| Error::Failed(e.to_string()))?;
+    if info.add_bos && tokens.first() != Some(&info.bos_id) {
+        tokens.insert(0, info.bos_id);
+    }
+    Ok(tokens)
+}
+
+/// Collects a whole generation.
+async fn collect(rx: &mut tokio::sync::mpsc::UnboundedReceiver<Event>) -> Result<(String, Finish, Timings), Error> {
+    let mut text = String::new();
+    while let Some(ev) = rx.recv().await {
+        match ev {
+            Event::Token { text: t, .. } => text.push_str(&t),
+            Event::Done { finish, timings } => return Ok((text, finish, timings)),
+            Event::Error(e) => return Err(Error::Failed(e)),
+        }
+    }
+    Err(Error::Failed("generation ended without a result".into()))
+}
+
+fn sse(events: tokio::sync::mpsc::UnboundedReceiver<Result<String, std::io::Error>>) -> Response {
+    let stream = futures::stream::unfold(events, |mut rx| async move { rx.recv().await.map(|v| (v, rx)) });
+    Response::builder()
+        .header(header::CONTENT_TYPE, "text/event-stream")
+        .header(header::CACHE_CONTROL, "no-cache")
+        .body(Body::from_stream(stream))
+        .unwrap()
+}
+
+async fn chat_completions(State(s): State<Shared>, body: axum::body::Bytes) -> Result<Response, Error> {
+    let body = parse_body(&body)?;
+    let tokens = chat_prompt(&s, &body)?;
+    let sampling = sampling(&body)?;
+    let stream = body.get("stream").and_then(|v| v.as_bool()).unwrap_or(false);
+    let id = format!("chatcmpl-{:08x}{:08x}", crate::mediagen::rand_seed(), crate::mediagen::rand_seed());
+    let model = s.model_name.clone();
+    let (mut rx, cancel) = s.engine.generate(tokens, sampling);
+    if !stream {
+        let (text, finish, t) = collect(&mut rx).await?;
+        return Ok(Json(json!({
+            "id": id, "object": "chat.completion", "created": now(), "model": model,
+            "choices": [{"index": 0, "finish_reason": finish_str(finish), "message": {"role": "assistant", "content": text}}],
+            "usage": {"prompt_tokens": t.prompt_n, "completion_tokens": t.predicted_n, "total_tokens": t.prompt_n + t.predicted_n},
+            "timings": timings_json(&t),
+        }))
+        .into_response());
+    }
+    let (tx, out) = tokio::sync::mpsc::unbounded_channel();
+    tokio::spawn(async move {
+        let chunk = |delta: Value, finish: Option<&str>, extra: Option<Value>| {
+            let mut v = json!({"id": id, "object": "chat.completion.chunk", "created": now(), "model": model,
+                "choices": [{"index": 0, "delta": delta, "finish_reason": finish}]});
+            if let Some(Value::Object(m)) = extra {
+                for (k, x) in m {
+                    v[k] = x;
+                }
+            }
+            format!("data: {v}\n\n")
+        };
+        let mut first = true;
+        while let Some(ev) = rx.recv().await {
+            let msg = match ev {
+                Event::Token { text, .. } => {
+                    let mut delta = json!({"content": text});
+                    if first {
+                        delta["role"] = json!("assistant");
+                        first = false;
+                    }
+                    chunk(delta, None, None)
+                }
+                Event::Done { finish, timings } => {
+                    let extra = json!({"usage": {"prompt_tokens": timings.prompt_n, "completion_tokens": timings.predicted_n, "total_tokens": timings.prompt_n + timings.predicted_n}, "timings": timings_json(&timings)});
+                    let _ = tx.send(Ok(chunk(json!({}), Some(finish_str(finish)), Some(extra))));
+                    let _ = tx.send(Ok("data: [DONE]\n\n".into()));
+                    break;
+                }
+                Event::Error(e) => format!("data: {}\n\n", json!({"error": {"message": e, "type": "server_error"}})),
+            };
+            if tx.send(Ok(msg)).is_err() {
+                cancel.store(true, std::sync::atomic::Ordering::Relaxed);
+                break;
+            }
+        }
+    });
+    Ok(sse(out))
+}
+
+fn prompt_tokens(s: &Server, prompt: &Value) -> Result<Vec<i32>, Error> {
+    match prompt {
+        Value::String(text) => s.engine.tokenize(text, true, true).map_err(|e| Error::Failed(e.to_string())),
+        Value::Array(a) if a.iter().all(|v| v.is_i64()) => Ok(a.iter().map(|v| v.as_i64().unwrap() as i32).collect()),
+        _ => Err(Error::Invalid("\"prompt\" must be a string or a list of tokens".into())),
+    }
+}
+
+async fn completions(State(s): State<Shared>, body: axum::body::Bytes) -> Result<Response, Error> {
+    let body = parse_body(&body)?;
+    let tokens = prompt_tokens(&s, body.get("prompt").ok_or_else(|| Error::Invalid("\"prompt\" is required".into()))?)?;
+    let sampling = sampling(&body)?;
+    let stream = body.get("stream").and_then(|v| v.as_bool()).unwrap_or(false);
+    let id = format!("cmpl-{:08x}{:08x}", crate::mediagen::rand_seed(), crate::mediagen::rand_seed());
+    let model = s.model_name.clone();
+    let (mut rx, cancel) = s.engine.generate(tokens, sampling);
+    if !stream {
+        let (text, finish, t) = collect(&mut rx).await?;
+        return Ok(Json(json!({
+            "id": id, "object": "text_completion", "created": now(), "model": model,
+            "choices": [{"index": 0, "text": text, "finish_reason": finish_str(finish)}],
+            "usage": {"prompt_tokens": t.prompt_n, "completion_tokens": t.predicted_n, "total_tokens": t.prompt_n + t.predicted_n},
+            "timings": timings_json(&t),
+        }))
+        .into_response());
+    }
+    let (tx, out) = tokio::sync::mpsc::unbounded_channel();
+    tokio::spawn(async move {
+        while let Some(ev) = rx.recv().await {
+            let msg = match ev {
+                Event::Token { text, .. } => format!("data: {}\n\n", json!({"id": id, "object": "text_completion", "created": now(), "model": model, "choices": [{"index": 0, "text": text, "finish_reason": null}]})),
+                Event::Done { finish, timings } => {
+                    let _ = tx.send(Ok(format!("data: {}\n\n", json!({"id": id, "object": "text_completion", "created": now(), "model": model, "choices": [{"index": 0, "text": "", "finish_reason": finish_str(finish)}], "timings": timings_json(&timings)}))));
+                    let _ = tx.send(Ok("data: [DONE]\n\n".into()));
+                    break;
+                }
+                Event::Error(e) => format!("data: {}\n\n", json!({"error": {"message": e}})),
+            };
+            if tx.send(Ok(msg)).is_err() {
+                cancel.store(true, std::sync::atomic::Ordering::Relaxed);
+                break;
+            }
+        }
+    });
+    Ok(sse(out))
+}
+
+/// llama-server's native `/completion`.
+async fn completion(State(s): State<Shared>, body: axum::body::Bytes) -> Result<Response, Error> {
+    let body = parse_body(&body)?;
+    let tokens = prompt_tokens(&s, body.get("prompt").ok_or_else(|| Error::Invalid("\"prompt\" is required".into()))?)?;
+    let sampling = sampling(&body)?;
+    let stream = body.get("stream").and_then(|v| v.as_bool()).unwrap_or(false);
+    let model = s.model_name.clone();
+    let (mut rx, cancel) = s.engine.generate(tokens, sampling);
+    if !stream {
+        let (text, finish, t) = collect(&mut rx).await?;
+        return Ok(Json(json!({
+            "content": text, "model": model, "stop": true, "stop_type": if finish == Finish::Stop { "eos" } else { "limit" },
+            "tokens_predicted": t.predicted_n, "tokens_evaluated": t.prompt_n, "tokens_cached": t.cached_n, "timings": timings_json(&t),
+        }))
+        .into_response());
+    }
+    let (tx, out) = tokio::sync::mpsc::unbounded_channel();
+    tokio::spawn(async move {
+        while let Some(ev) = rx.recv().await {
+            let msg = match ev {
+                Event::Token { text, .. } => format!("data: {}\n\n", json!({"content": text, "stop": false})),
+                Event::Done { finish, timings } => {
+                    let _ = tx.send(Ok(format!("data: {}\n\n", json!({"content": "", "stop": true, "stop_type": if finish == Finish::Stop { "eos" } else { "limit" }, "tokens_predicted": timings.predicted_n, "tokens_evaluated": timings.prompt_n, "timings": timings_json(&timings)}))));
+                    break;
+                }
+                Event::Error(e) => format!("data: {}\n\n", json!({"error": {"message": e}})),
+            };
+            if tx.send(Ok(msg)).is_err() {
+                cancel.store(true, std::sync::atomic::Ordering::Relaxed);
+                break;
+            }
+        }
+    });
+    Ok(sse(out))
+}
+
+async fn tokenize(State(s): State<Shared>, body: axum::body::Bytes) -> Result<Json<Value>, Error> {
+    let body = parse_body(&body)?;
+    let content = body.get("content").and_then(|v| v.as_str()).ok_or_else(|| Error::Invalid("\"content\" is required".into()))?;
+    let add_special = body.get("add_special").and_then(|v| v.as_bool()).unwrap_or(false);
+    let tokens = s.engine.tokenize(content, add_special, true).map_err(|e| Error::Failed(e.to_string()))?;
+    Ok(Json(json!({"tokens": tokens})))
+}
+
+async fn detokenize(State(s): State<Shared>, body: axum::body::Bytes) -> Result<Json<Value>, Error> {
+    let body = parse_body(&body)?;
+    let tokens: Vec<i32> = body.get("tokens").and_then(|v| v.as_array()).map(|a| a.iter().filter_map(|v| v.as_i64()).map(|v| v as i32).collect()).unwrap_or_default();
+    Ok(Json(json!({"content": s.engine.detokenize(&tokens, false)})))
+}
+
+pub fn router(engine: Handle, model_name: String) -> Router {
+    let s = Arc::new(Server { engine, model_name });
+    Router::new()
+        .route("/health", get(health))
+        .route("/v1/health", get(health))
+        .route("/v1/models", get(models))
+        .route("/models", get(models))
+        .route("/props", get(props))
+        .route("/v1/chat/completions", post(chat_completions))
+        .route("/v1/completions", post(completions))
+        .route("/completion", post(completion))
+        .route("/completions", post(completion))
+        .route("/tokenize", post(tokenize))
+        .route("/detokenize", post(detokenize))
+        .with_state(s)
+}


### PR DESCRIPTION
Adds `src/mediagen/cosmos3` beside `ltx` so the Cosmos3 GGUFs published as `ai/cosmos3-{edge,nano,super}` run on llmman's ggml path: text-to-image/video, image- and video-to-video, sound (Nano/Super), and the three action modes — natively and with `--ociman`, on Metal, CUDA and Vulkan.

- `dit.rs`: two-stream omni transformer; the understanding stream runs once per prompt, its K/V feed every step of the generation stream (vision + sound + action tokens, GQA, 3-D mRoPE).
- `vae.rs`: Wan 2.2 encoder/decoder with the reference's per-frame chunking; causal caches stay on the device (`ggml_cpy`, double-buffered); direct conv on Vulkan (4× faster), im2col elsewhere.
- `audio.rs`, `sched.rs`, `tokenizer.rs`: sound tokenizer decoder, UniPC (Karras and flow-shift schedules), chat/action prompts.
- API: `/v1/videos` takes `image`, `video`, `condition_frames`, `action {...}`, `flow_shift`, returns `actions`; `llmman run` gets the matching flags.
- Also: clippy lint on Rust 1.98, temp-dir race in the `modelpack` tests.

**Verification** (vs diffusers, identical noise): Edge BF16 t2i velocity cosine 0.999999 and image PSNR 48 dB vs fp32; t2v frames 56–58 dB; i2v conditioning latent 1.0000; v2v conditioned frames 55 dB; Nano action modes: actions cosine 0.998 (inverse dynamics) / 0.973 (policy); sound decoder waveform cosine 1.0000, end to end 0.997 (BF16) / 0.99 (Q8_0) / 0.18 (Q4_K_M — README recommends `:q8_0` for sound). End to end via `llmman run` on Metal, CUDA and Vulkan, native and `--ociman docker`/`podman`. 640² image, 35 steps: ~16 s (GB10) / ~15 s (M4 Max); 21-frame 448² decode 8 s CUDA, 5.5 s Vulkan, 29 s Metal (compute-bound in ggml's Metal conv).
