### PR TITLE
Re-extract incomplete safetensors cache files

### DIFF
--- a/src/modelpack.rs
+++ b/src/modelpack.rs
@@ -586,7 +586,12 @@ fn extract_safetensors_dir(
             continue;
         }
         let dest = cache_dir.join(rel_path);
-        if dest.exists() {
+        // exists() is not complete: a killed copy can leave a short dest.
+        if dest
+            .metadata()
+            .map(|m| m.is_file() && m.len() == layer.size)
+            .unwrap_or(false)
+        {
             continue;
         }
 
@@ -906,6 +911,33 @@ mod tests {
         assert_eq!(p.format(), "omni");
         assert_eq!(p.path(), Path::new("/cache/cosmos"));
         assert_eq!(p.mmproj(), None);
+    }
+
+    #[test]
+    fn extract_safetensors_dir_replaces_dest_shorter_than_layer_size() {
+        let weights = b"complete-weights-bytes";
+        let layer_hex = "aa".repeat(32);
+        let mut layer = descriptor(&format!("sha256:{layer_hex}"), "model.safetensors");
+        layer.media_type = "application/vnd.cncf.model.weight.v1.raw".into();
+        layer.size = weights.len() as u64;
+        let (store, manifest) = manifest_with(vec![layer]);
+
+        let blob = store.root().join("blobs").join("sha256").join(&layer_hex);
+        std::fs::create_dir_all(blob.parent().unwrap()).unwrap();
+        std::fs::write(&blob, weights).unwrap();
+
+        let cache = store.root().join("cache");
+        let dest = cache.join("bb".repeat(32)).join("model.safetensors");
+        std::fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        std::fs::write(&dest, b"trunc").unwrap();
+
+        let digest = format!("sha256:{}", "bb".repeat(32));
+        extract_safetensors_dir(store.root(), &cache, &digest, &manifest).unwrap();
+        assert_eq!(std::fs::read(&dest).unwrap(), weights);
+
+        std::fs::remove_file(&blob).unwrap();
+        extract_safetensors_dir(store.root(), &cache, &digest, &manifest).unwrap();
+        assert_eq!(std::fs::read(&dest).unwrap(), weights);
     }
 
     #[test]


### PR DESCRIPTION
This PR is:

- To treat a safetensors cache file as reusable only when its size matches the OCI layer size.
- To retry extraction when a cached file is missing or incomplete.
- To avoid keeping a broken cache file around until someone deletes the cache manually.

Before this change, `extract_safetensors_dir` skipped a cached destination as soon as the path existed. If a copy stopped partway through, the short file could stay in the cache and later loads would fail somewhere inside vLLM or MLX.

This change keeps the same fast path for completed files, but recopies when the cached file size does not match the layer it came from.
