### PR TITLE
feat(providers): define your own provider endpoints in llmman.conf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,12 +224,26 @@ jobs:
           }
 
       # ── Upload artefacts ──────────────────────────────────────────────────
+      # Two attempts: the upload's final "FinalizeArtifact" call gets a
+      # transient 403 from GitHub's blob store now and then, after every
+      # byte is up. The action has no retry of its own, so the second
+      # attempt overwrites whatever the first left behind.
       - name: Upload binary (docker)
+        id: upload
+        continue-on-error: true
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: llmman-docker-${{ matrix.target }}
           path: dist-docker/${{ matrix.binary }}
           if-no-files-found: error
+      - name: Upload binary (docker, retry)
+        if: steps.upload.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: llmman-docker-${{ matrix.target }}
+          path: dist-docker/${{ matrix.binary }}
+          if-no-files-found: error
+          overwrite: true
 
   # --------------------------------------------------------------------------
   # Unit tests: every #[cfg(test)] module under src/, which live in the
@@ -1579,12 +1593,23 @@ jobs:
             | xargs -0 sha256sum > checksums.txt
           cat checksums.txt
 
+      # Two attempts, as for the binaries above.
       - name: Upload checksums artifact
+        id: upload_checksums
+        continue-on-error: true
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-checksums
           path: dist/checksums.txt
           if-no-files-found: error
+      - name: Upload checksums artifact (retry)
+        if: steps.upload_checksums.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-checksums
+          path: dist/checksums.txt
+          if-no-files-found: error
+          overwrite: true
 
       - name: Build release notes
         id: notes

--- a/docs/api.md
+++ b/docs/api.md
@@ -116,6 +116,11 @@ no price). `llmman providers`, `list --provider`, `run --provider` and
 `launch --provider` are all clients of it, so the catalog is fetched and
 cached in one process: the one that forwards the request upstream.
 
+A provider [defined in `llmman.conf`](providers.md#your-own-endpoints)
+appears alongside the catalog ones with `key_optional: true`, no
+`key_env` unless the file names one, and — on `/llmman/providers/{id}`
+— whatever model ids its own `GET /models` reports, unpriced.
+
 `/llmman/node` reports this node's memory and loaded/stored models; it
 is what aggregation peers ask each other. See [aggregation.md](aggregation.md).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -119,7 +119,8 @@ cached in one process: the one that forwards the request upstream.
 A provider [defined in `llmman.conf`](providers.md#your-own-endpoints)
 appears alongside the catalog ones with `key_optional: true`, no
 `key_env` unless the file names one, and — on `/llmman/providers/{id}`
-— whatever model ids its own `GET /models` reports, unpriced.
+— for the `openai` wire, whatever model ids its own `GET /models`
+reports, unpriced.
 
 `/llmman/node` reports this node's memory and loaded/stored models; it
 is what aggregation peers ask each other. See [aggregation.md](aggregation.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,8 +22,8 @@ The store uses [OCI Image Layout](https://github.com/opencontainers/image-spec/b
 ## llmman.conf
 
 Everything that needs a file rather than an environment variable lives in
-one place: short-name aliases, provider API keys, the signature trust
-policy, and the peers of an aggregation.
+one place: short-name aliases, provider API keys and endpoints, the
+signature trust policy, and the peers of an aggregation.
 
 ```toml
 # ~/.config/llmman/llmman.conf
@@ -33,6 +33,9 @@ gemma4 = "docker.io/ai/gemma4"
 
 [providers.openrouter]
 api_key = "sk-or-..."
+
+[providers.gpubox]                 # an endpoint models.dev does not list
+base_url = "http://gpubox:8000/v1"
 
 [verify]
 default = "off"
@@ -139,6 +142,29 @@ travels per request in an `Authorization` header. A key found by
 `llmman serve` is the fallback for a request that presents none, and is
 only spent for a daemon bound to loopback. `llmman providers` reports
 which of the two has a usable key.
+
+### Your own provider endpoints
+
+A `[providers.<id>]` that sets `base_url` *defines* a provider rather
+than keying a catalog one — an inference server at some host or URL
+models.dev does not list, or a replacement URL for one it does:
+
+```toml
+[providers.gpubox]
+base_url    = "http://gpubox:8000/v1"   # required; http or https
+wire        = "openai"                  # default; or "anthropic"
+api_key     = "..."                     # optional: most local servers take none
+api_key_env = "GPUBOX_API_KEY"          # optional: a variable to read it from
+name        = "GPU box"                 # optional: for listings
+```
+
+`wire`, `api_key_env` and `name` only mean something on a definition, so
+a table that sets one without `base_url` is rejected, as is a `base_url`
+that is not an absolute `http`/`https` URL — by `llmman config set` on
+the spot, or at load with the rest of the file. Later files override
+earlier ones field by field. `llmman serve` reads the file at startup,
+so a new definition needs a restart. See
+[providers.md](providers.md#your-own-endpoints) for how one is used.
 
 ### Short-name aliases
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -80,7 +80,7 @@ From there it is a provider like any other: `run`, `list`, `launch` and
 | `base_url` | Required to define one. An absolute `http://` or `https://` URL the wire's route is appended to — `/chat/completions` for `openai`, `/messages` for `anthropic` — so it usually ends in `/v1`. |
 | `wire` | `openai` (default) or `anthropic`. See [Wire formats](#wire-formats). |
 | `api_key` | Sent as the wire's credential when set. Most local servers take none, and none is sent. |
-| `api_key_env` | An environment variable to read the key from instead; it wins over `api_key`, as for a catalog provider. |
+| `api_key_env` | An environment variable to read the key from instead; it wins over `api_key`, as for a catalog provider. `""` clears one an earlier file named. |
 | `name` | Display name for listings. The id when absent. |
 
 The rules the catalog is filtered by do not apply. They vet a list

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -87,24 +87,29 @@ The rules the catalog is filtered by do not apply. They vet a list
 fetched from the network at runtime; a URL you wrote into your own
 owner-only file needs no vetting beyond parsing. So a defined provider
 may be plain `http` — that is the point on a LAN — and may take no key.
-If it has a key *and* a plain-http URL, `llmman serve` warns once at
-startup that the key crosses the network in cleartext, and sends it.
+If it has a key *and* a plain-http URL, whichever process is about to
+send the key warns that it crosses the network in cleartext, and sends
+it.
 
 A defined provider with a catalog id (`[providers.openai]` with a
 `base_url`) replaces the catalog entry, which is how a proxy or regional
 endpoint gets used without renaming the provider in every integration's
 config. The catalog's model list goes with it.
 
-Models are not listed in the file. `list --provider <id>` and the
-`--model` check ask the endpoint's own `GET /models` (the OpenAI route
-every compatible server answers) and take what it says; a box that is
-down or lacks the route lists nothing, and the request still goes to it.
-`llmman providers` shows `-` in the models column for the same reason.
+Models are not listed in the file. For an `openai`-wire provider,
+`list --provider <id>` and the `--model` check ask the endpoint's own
+`GET /models` and take what it says; a box that is down or lacks the
+route lists nothing, and the request still goes to it. An `anthropic`
+provider has no such route and lists nothing. `llmman providers` shows
+`-` in the models column for the same reason.
 
 `llmman serve` reads `llmman.conf` once, at startup, so a provider added
 while it runs needs a restart to appear. A machine that cannot reach
-models.dev at all still has its defined providers: they stand alone
-when the catalog cannot be loaded.
+models.dev at all still has its defined providers.
+
+The `base_url` is reported by the daemon's API and printed in warnings,
+so it may not carry a `user:password@`; `api_key` is where a credential
+goes. The id may not contain `/`.
 
 ## Hybrid model pairs
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -50,6 +50,62 @@ no authentication, so `run` and `launch` never send a key to a remote
 for a caller that presented none. (`providers` and `list --provider`
 read the catalog only and work against any daemon.)
 
+## Your own endpoints
+
+A provider models.dev has never heard of — vLLM or llama-server on a
+box down the hall, LM Studio on a laptop, a proxy in front of OpenAI —
+is defined in `llmman.conf` by giving a `[providers.<id>]` a
+`base_url`:
+
+```toml
+[providers.gpubox]
+base_url = "http://gpubox:8000/v1"
+```
+
+```console
+$ llmman config set providers.gpubox.base_url http://gpubox:8000/v1
+$ llmman providers gpubox
+PROVIDER    NAME      API KEY    KEY            MODELS
+gpubox      gpubox    -          none needed    -
+$ llmman list --provider gpubox                # asks the box's own /models
+$ llmman launch opencode --provider gpubox --model qwen3-coder
+```
+
+From there it is a provider like any other: `run`, `list`, `launch` and
+`--overflow-provider` all take the id, and requests still go through
+`llmman serve`, which forwards to the URL.
+
+| Field | Meaning |
+|-------|---------|
+| `base_url` | Required to define one. An absolute `http://` or `https://` URL the wire's route is appended to — `/chat/completions` for `openai`, `/messages` for `anthropic` — so it usually ends in `/v1`. |
+| `wire` | `openai` (default) or `anthropic`. See [Wire formats](#wire-formats). |
+| `api_key` | Sent as the wire's credential when set. Most local servers take none, and none is sent. |
+| `api_key_env` | An environment variable to read the key from instead; it wins over `api_key`, as for a catalog provider. |
+| `name` | Display name for listings. The id when absent. |
+
+The rules the catalog is filtered by do not apply. They vet a list
+fetched from the network at runtime; a URL you wrote into your own
+owner-only file needs no vetting beyond parsing. So a defined provider
+may be plain `http` — that is the point on a LAN — and may take no key.
+If it has a key *and* a plain-http URL, `llmman serve` warns once at
+startup that the key crosses the network in cleartext, and sends it.
+
+A defined provider with a catalog id (`[providers.openai]` with a
+`base_url`) replaces the catalog entry, which is how a proxy or regional
+endpoint gets used without renaming the provider in every integration's
+config. The catalog's model list goes with it.
+
+Models are not listed in the file. `list --provider <id>` and the
+`--model` check ask the endpoint's own `GET /models` (the OpenAI route
+every compatible server answers) and take what it says; a box that is
+down or lacks the route lists nothing, and the request still goes to it.
+`llmman providers` shows `-` in the models column for the same reason.
+
+`llmman serve` reads `llmman.conf` once, at startup, so a provider added
+while it runs needs a restart to appear. A machine that cannot reach
+models.dev at all still has its defined providers: they stand alone
+when the catalog cannot be loaded.
+
 ## Hybrid model pairs
 
 `--overflow-provider` and `--overflow-model` pair the local `--model`
@@ -141,10 +197,16 @@ Each provider is spoken to in one of two wire formats, reported as
 
 - `openai`: OpenAI Chat Completions with `Authorization: Bearer <key>`.
   Every `@ai-sdk/openai-compatible` provider, plus the hand-checked
-  endpoints for `openai`, `google`, `groq`, `mistral` and the rest.
+  endpoints for `openai`, `google`, `groq`, `mistral` and the rest, and
+  the default for a provider [defined in `llmman.conf`](#your-own-endpoints).
 - `anthropic`: the Anthropic Messages API with `x-api-key: <key>`.
   `anthropic` itself. Other Messages-compatible endpoints are not
-  offered: their auth scheme varies and has not been checked.
+  offered from the catalog, since their auth scheme varies and has not
+  been checked; one you know takes `x-api-key` can be defined with
+  `wire = "anthropic"`.
+
+A provider that takes no key gets no credential header at all, not an
+empty one.
 
 Anthropic is never reached through its OpenAI-compatibility shim. What a
 request becomes on the way to a `wire: anthropic` provider depends on

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -321,18 +321,18 @@ fn resolve_provider_model(
     // Read here, not left to the daemon, so a missing key names the
     // variable to set in llmman's own output. It travels per request in
     // the integration's own Authorization header (see client_api_key in
-    // cmd::serve), never to disk or a command line.
-    //
-    // The placeholder goes instead whenever the daemon's key is the one
-    // that matters — an integration that cannot carry one, or a shell
-    // without one where the daemon has it — since that is what makes
-    // serve fall back to its own.
-    //
-    // A provider that takes no key (one `llmman.conf` defines, see
-    // `key_optional`) gets the placeholder too when nobody has one: the
-    // daemon forwards such a request bare, and the placeholder is what
-    // tells it the integration's header is not a credential.
-    let key = match (entry.api_key(), key_travels_per_request) {
+    // cmd::serve), never to disk or a command line. The placeholder goes
+    // instead whenever the daemon's key is the one that matters — an
+    // integration that cannot carry one, or a shell without one where
+    // the daemon has it — or when the provider takes none at all
+    // (`key_optional`): it is what tells serve the header is not a
+    // credential.
+    let key = if key_travels_per_request {
+        entry.client_key()
+    } else {
+        None
+    };
+    let key = match (key, key_travels_per_request) {
         (Some(key), true) => key,
         (_, false) => {
             // Fatal, not a warning: this integration cannot carry a key,

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -327,6 +327,11 @@ fn resolve_provider_model(
     // that matters — an integration that cannot carry one, or a shell
     // without one where the daemon has it — since that is what makes
     // serve fall back to its own.
+    //
+    // A provider that takes no key (one `llmman.conf` defines, see
+    // `key_optional`) gets the placeholder too when nobody has one: the
+    // daemon forwards such a request bare, and the placeholder is what
+    // tells it the integration's header is not a credential.
     let key = match (entry.api_key(), key_travels_per_request) {
         (Some(key), true) => key,
         (_, false) => {
@@ -336,12 +341,12 @@ fn resolve_provider_model(
             // would spend it. Warning and handing off would surface as a
             // 401 inside someone else's TUI.
             anyhow::ensure!(
-                entry.key_usable,
+                entry.key_usable || entry.key_optional,
                 "{integration} is configured through a file, so it cannot send an API key: \
                  llmman serve needs a key of its own, and must be bound to loopback to \
                  spend it.\n\
                  Where the daemon runs, {}, then restart it.",
-                providers::key_hint(&entry.id, &entry.key_env)
+                entry.key_hint()
             );
             providers::PLACEHOLDER_API_KEY.to_string()
         }
@@ -352,11 +357,8 @@ fn resolve_provider_model(
             );
             providers::PLACEHOLDER_API_KEY.to_string()
         }
-        (None, true) => anyhow::bail!(
-            "no API key for {} — {}",
-            entry.name,
-            providers::key_hint(&entry.id, &entry.key_env)
-        ),
+        (None, true) if entry.key_optional => providers::PLACEHOLDER_API_KEY.to_string(),
+        (None, true) => anyhow::bail!("no API key for {} — {}", entry.name, entry.key_hint()),
     };
 
     Ok((providers::format_remote_ref(provider, model), key))

--- a/src/cmd/providers.rs
+++ b/src/cmd/providers.rs
@@ -87,15 +87,14 @@ fn matches(provider: &ProviderSummary, needle: Option<&str>) -> bool {
     provider.id.to_lowercase().contains(needle) || provider.name.to_lowercase().contains(needle)
 }
 
-/// The variable column: `-` for a provider `llmman.conf` defines without
-/// naming one, whose key (if any) is in the file alone.
+/// The variable column: `-` for a configured provider that names none.
 fn key_env(provider: &ProviderSummary) -> &str {
     provider.key_env.as_deref().unwrap_or("-")
 }
 
-/// The models column: a configured provider has no catalog models, and
-/// `0` would read as "serves nothing" when the truth is "not asked" —
-/// `llmman list --provider <id>` asks its endpoint.
+/// The models column: `-` for a configured provider, whose endpoint is
+/// only asked by `llmman list --provider <id>`; `0` would read as
+/// "serves nothing".
 fn model_count(provider: &ProviderSummary) -> String {
     if provider.key_optional && provider.models == 0 {
         "-".to_string()
@@ -112,8 +111,8 @@ fn model_count(provider: &ProviderSummary) -> String {
 /// is not "shell". "withheld" is one the daemon has but will not spend,
 /// being bound where others could reach it (see `resolve_remote_target`
 /// in cmd::serve) — a state of its own, since what needs fixing there is
-/// the bind, not the key. "none needed" is a provider that takes no key
-/// and has none: nothing to act on.
+/// the bind, not the key. "none needed" is a keyless provider: nothing
+/// to act on.
 fn key_status(provider: &ProviderSummary) -> &'static str {
     match (provider.key_usable, provider.key_here(), provider.key_set) {
         (true, _, _) => "set",

--- a/src/cmd/providers.rs
+++ b/src/cmd/providers.rs
@@ -47,7 +47,7 @@ pub fn run(args: &ProvidersArgs) -> anyhow::Result<()> {
     let name_w = shown.iter().map(|p| p.name.len()).max().unwrap_or(4).max(4);
     let key_w = shown
         .iter()
-        .map(|p| p.key_env.len())
+        .map(|p| key_env(p).len())
         .max()
         .unwrap_or(7)
         .max(7);
@@ -67,9 +67,9 @@ pub fn run(args: &ProvidersArgs) -> anyhow::Result<()> {
             "{:<id_w$}    {:<name_w$}    {:<key_w$}    {:<14}    {}",
             p.id,
             p.name,
-            p.key_env,
+            key_env(p),
             key_status(p),
-            p.models,
+            model_count(p),
             id_w = id_w,
             name_w = name_w,
             key_w = key_w,
@@ -87,6 +87,23 @@ fn matches(provider: &ProviderSummary, needle: Option<&str>) -> bool {
     provider.id.to_lowercase().contains(needle) || provider.name.to_lowercase().contains(needle)
 }
 
+/// The variable column: `-` for a provider `llmman.conf` defines without
+/// naming one, whose key (if any) is in the file alone.
+fn key_env(provider: &ProviderSummary) -> &str {
+    provider.key_env.as_deref().unwrap_or("-")
+}
+
+/// The models column: a configured provider has no catalog models, and
+/// `0` would read as "serves nothing" when the truth is "not asked" —
+/// `llmman list --provider <id>` asks its endpoint.
+fn model_count(provider: &ProviderSummary) -> String {
+    if provider.key_optional && provider.models == 0 {
+        "-".to_string()
+    } else {
+        provider.models.to_string()
+    }
+}
+
 /// Where a *usable* key is — the one thing to act on before `--provider`
 /// works.
 ///
@@ -95,12 +112,14 @@ fn matches(provider: &ProviderSummary, needle: Option<&str>) -> bool {
 /// is not "shell". "withheld" is one the daemon has but will not spend,
 /// being bound where others could reach it (see `resolve_remote_target`
 /// in cmd::serve) — a state of its own, since what needs fixing there is
-/// the bind, not the key.
+/// the bind, not the key. "none needed" is a provider that takes no key
+/// and has none: nothing to act on.
 fn key_status(provider: &ProviderSummary) -> &'static str {
     match (provider.key_usable, provider.key_here(), provider.key_set) {
         (true, _, _) => "set",
         (false, true, _) => "set (client)",
         (false, false, true) => "set (withheld)",
+        (false, false, false) if provider.key_optional => "none needed",
         (false, false, false) => "unset",
     }
 }
@@ -113,9 +132,10 @@ mod tests {
         ProviderSummary {
             id: id.to_string(),
             name: name.to_string(),
-            key_env: "LLMMAN_TEST_PROVIDER_KEY_UNSET".to_string(),
+            key_env: Some("LLMMAN_TEST_PROVIDER_KEY_UNSET".to_string()),
             key_set: false,
             key_usable: false,
+            key_optional: false,
             models: 0,
         }
     }
@@ -145,6 +165,19 @@ mod tests {
         // the variable.
         p.key_set = true;
         assert_eq!(key_status(&p), "set (withheld)");
+        p.key_usable = true;
+        assert_eq!(key_status(&p), "set");
+
+        // A provider that takes no key is not "unset": there is nothing
+        // to set. One that has a key anyway reports it as any other.
+        let mut p = summary("gpubox", "GPU box");
+        p.key_env = None;
+        p.key_optional = true;
+        assert_eq!(key_status(&p), "none needed");
+        assert_eq!(key_env(&p), "-");
+        assert_eq!(model_count(&p), "-");
+        assert_eq!(model_count(&summary("openai", "OpenAI")), "0");
+        p.key_set = true;
         p.key_usable = true;
         assert_eq!(key_status(&p), "set");
     }

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -388,13 +388,14 @@ fn provider_model(provider: &str, model: &str) -> anyhow::Result<(String, Option
     entry.warn_unlisted(model);
 
     // Naming where the missing key goes beats a 401 mid-conversation —
-    // unless the daemon has the key, in which case it spends its own.
+    // unless the daemon has the key, in which case it spends its own, or
+    // the provider takes none (one `llmman.conf` defines).
     let key = entry.api_key();
     anyhow::ensure!(
-        key.is_some() || entry.daemon_key_usable(),
+        key.is_some() || entry.daemon_key_usable() || entry.key_optional,
         "no API key for {} — {}",
         entry.name,
-        crate::providers::key_hint(&entry.id, &entry.key_env)
+        entry.key_hint()
     );
     Ok((crate::providers::format_remote_ref(provider, model), key))
 }

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -388,9 +388,8 @@ fn provider_model(provider: &str, model: &str) -> anyhow::Result<(String, Option
     entry.warn_unlisted(model);
 
     // Naming where the missing key goes beats a 401 mid-conversation —
-    // unless the daemon has the key, in which case it spends its own, or
-    // the provider takes none (one `llmman.conf` defines).
-    let key = entry.api_key();
+    // unless the daemon has one of its own, or the provider takes none.
+    let key = entry.client_key();
     anyhow::ensure!(
         key.is_some() || entry.daemon_key_usable() || entry.key_optional,
         "no API key for {} — {}",

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -1700,9 +1700,10 @@ struct RemoteTarget {
     /// The catalog's output ceiling, for a wire that requires
     /// `max_tokens` (see [`anthropic::DEFAULT_MAX_TOKENS`]).
     max_output: Option<u32>,
-    /// API key for this request. See [`resolve_remote_target`] for where
-    /// it comes from.
-    api_key: String,
+    /// API key for this request, or `None` for a provider that takes
+    /// none (see `Provider::key_optional`). See [`resolve_remote_target`]
+    /// for where it comes from.
+    api_key: Option<String>,
 }
 
 impl std::fmt::Debug for RemoteTarget {
@@ -1712,7 +1713,7 @@ impl std::fmt::Debug for RemoteTarget {
             .field("base_url", &self.base_url)
             .field("wire", &self.wire)
             .field("model", &self.model)
-            .field("api_key", &"<redacted>")
+            .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
             .finish()
     }
 }
@@ -1740,15 +1741,23 @@ impl Target {
     /// auth, which is why nothing below ever forwarded the client's own
     /// `Authorization` header upstream — and must keep not forwarding it,
     /// so a key meant for one provider can never be relayed to another.
+    /// A remote target without a key (a configured provider that takes
+    /// none) likewise gets no credential header, only the wire's other
+    /// ones.
     fn authorize(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
         match self {
             Self::Local(_) => req,
             Self::Peer(_) => req.header(aggregation::HOP, "1"),
-            Self::Remote(remote) => match remote.wire {
-                Wire::OpenAi => req.bearer_auth(&remote.api_key),
-                Wire::Anthropic => req
-                    .header("x-api-key", &remote.api_key)
-                    .header("anthropic-version", anthropic::VERSION),
+            Self::Remote(remote) => match (remote.wire, remote.api_key.as_deref()) {
+                (Wire::OpenAi, Some(key)) => req.bearer_auth(key),
+                (Wire::OpenAi, None) => req,
+                (Wire::Anthropic, key) => {
+                    let req = req.header("anthropic-version", anthropic::VERSION);
+                    match key {
+                        Some(key) => req.header("x-api-key", key),
+                        None => req,
+                    }
+                }
             },
         }
     }
@@ -1904,29 +1913,36 @@ async fn resolve_remote_target(
             .then(|| provider.api_key())
             .flatten()
     };
-    let api_key = client_api_key(headers).or_else(own_key).ok_or_else(|| {
-        AppError(
-            anyhow!(
-                "no API key for provider {provider_id:?} — send it as an Authorization \
-                 header{}",
-                if is_cross_site(headers) {
-                    ". This request came from another site, so llmman serve's own \
-                     environment is deliberately not used"
-                        .to_string()
-                } else if crate::daemon::reachable_only_locally() {
-                    format!(
-                        ", or give llmman serve a key of its own: {}",
-                        crate::providers::key_hint(&provider.id, &provider.key_env)
-                    )
-                } else {
-                    ". llmman serve is not bound to loopback, so its own environment is \
-                     deliberately not used"
-                        .to_string()
-                }
-            ),
-            StatusCode::UNAUTHORIZED,
-        )
-    })?;
+    let api_key = match client_api_key(headers).or_else(own_key) {
+        Some(key) => Some(key),
+        // A configured provider that takes no key: the request goes up
+        // bare. Not a catalog one, where that is a certain 401 better
+        // explained here than relayed from upstream.
+        None if provider.key_optional => None,
+        None => {
+            return Err(AppError(
+                anyhow!(
+                    "no API key for provider {provider_id:?} — send it as an Authorization \
+                     header{}",
+                    if is_cross_site(headers) {
+                        ". This request came from another site, so llmman serve's own \
+                         environment is deliberately not used"
+                            .to_string()
+                    } else if crate::daemon::reachable_only_locally() {
+                        format!(
+                            ", or give llmman serve a key of its own: {}",
+                            crate::providers::key_hint(&provider.id, provider.key_env.as_deref())
+                        )
+                    } else {
+                        ". llmman serve is not bound to loopback, so its own environment is \
+                         deliberately not used"
+                            .to_string()
+                    }
+                ),
+                StatusCode::UNAUTHORIZED,
+            ));
+        }
+    };
 
     let target = RemoteTarget {
         provider: provider_id,
@@ -3985,11 +4001,15 @@ struct ProviderSummary {
     id: String,
     name: String,
     base_url: String,
-    key_env: String,
+    /// Absent for a configured provider that names no variable, whose
+    /// key — if it has one — is in `llmman.conf` alone.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    key_env: Option<String>,
     /// What is spoken at `base_url`: `openai` or `anthropic` (see
     /// [`crate::providers::Wire`]).
     wire: &'static str,
-    /// Whether *this daemon's* environment holds `key_env`.
+    /// Whether this daemon holds a key for it, in its environment or its
+    /// `llmman.conf`.
     key_set: bool,
     /// Whether it would actually spend it for a request that presents no
     /// key of its own — `key_set` plus this daemon's own bind check, which
@@ -3997,6 +4017,10 @@ struct ProviderSummary {
     /// "will my keyless request work" has to read this, not `key_set`:
     /// its own `LLMMAN_HOST` says nothing about how the daemon is bound.
     key_usable: bool,
+    /// Whether a request with no key at all is forwarded anyway (see
+    /// `Provider::key_optional`). True for a provider `llmman.conf`
+    /// defines.
+    key_optional: bool,
     models: usize,
 }
 
@@ -4010,6 +4034,7 @@ impl From<&crate::providers::Provider> for ProviderSummary {
             wire: p.wire.as_str(),
             key_set: p.api_key().is_some(),
             key_usable: daemon_key_usable(p),
+            key_optional: p.key_optional,
             models: p.models.len(),
         }
     }
@@ -4034,12 +4059,16 @@ struct ProviderResponse {
     id: String,
     name: String,
     base_url: String,
-    key_env: String,
+    /// See [`ProviderSummary::key_env`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    key_env: Option<String>,
     /// See [`ProviderSummary::wire`].
     wire: &'static str,
     key_set: bool,
     /// See [`ProviderSummary::key_usable`].
     key_usable: bool,
+    /// See [`ProviderSummary::key_optional`].
+    key_optional: bool,
     models: Vec<ProviderModelResponse>,
 }
 
@@ -4071,6 +4100,7 @@ impl From<&crate::providers::Provider> for ProviderResponse {
             wire: p.wire.as_str(),
             key_set: p.api_key().is_some(),
             key_usable: daemon_key_usable(p),
+            key_optional: p.key_optional,
             models: p
                 .models
                 .iter()
@@ -4096,7 +4126,11 @@ async fn handle_llmman_providers() -> Result<impl IntoResponse, AppError> {
 
 /// `GET /llmman/providers/:id` — one provider, or a 404 naming
 /// near-matches (see [`crate::providers::unknown_provider_error`]).
+///
+/// A provider `llmman.conf` defines has no catalog models; its endpoint
+/// is asked instead (see [`configured_provider_models`]).
 async fn handle_llmman_provider(
+    State(state): State<AppState>,
     UrlPath(id): UrlPath<String>,
 ) -> Result<impl IntoResponse, AppError> {
     let catalog = provider_catalog().await?;
@@ -4106,7 +4140,74 @@ async fn handle_llmman_provider(
             StatusCode::NOT_FOUND,
         )
     })?;
-    Ok(Json(ProviderResponse::from(provider)))
+    let mut response = ProviderResponse::from(provider);
+    if provider.key_optional && provider.models.is_empty() {
+        response.models = configured_provider_models(&state.0.client, provider)
+            .await
+            .into_iter()
+            .map(|id| ProviderModelResponse { id, cost: None })
+            .collect();
+    }
+    Ok(Json(response))
+}
+
+/// How long a configured provider gets to answer `GET /models` before
+/// the listing goes out without one. Short: this sits in front of
+/// `llmman launch`, and a LAN box that is down should cost a moment, not
+/// a hang.
+const CONFIGURED_MODELS_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// The model ids a configured provider reports at `GET {base_url}/models`
+/// — the OpenAI route vLLM, llama-server, LM Studio and every compatible
+/// proxy answer — or none when it cannot, or does not: the listing is a
+/// convenience for `llmman list --provider` and the `--model` check, and
+/// an endpoint that lacks it is still one requests can go to.
+///
+/// Authenticated the way a request would be (see `resolve_remote_target`),
+/// minus the caller's own key: this is a GET the daemon makes for itself,
+/// so only its own key is on offer, and only under the bind rule that
+/// gates spending it for a request.
+async fn configured_provider_models(
+    client: &Client,
+    provider: &crate::providers::Provider,
+) -> Vec<String> {
+    #[derive(Deserialize)]
+    struct ModelsResponse {
+        #[serde(default)]
+        data: Vec<ModelEntry>,
+    }
+    #[derive(Deserialize)]
+    struct ModelEntry {
+        id: String,
+    }
+
+    if provider.wire != Wire::OpenAi {
+        return Vec::new();
+    }
+    let url = provider.url("/v1/models");
+    let mut req = client.get(&url).timeout(CONFIGURED_MODELS_TIMEOUT);
+    if daemon_key_usable(provider) {
+        if let Some(key) = provider.api_key() {
+            req = req.bearer_auth(key);
+        }
+    }
+    let listed = async {
+        let resp = req.send().await?.error_for_status()?;
+        resp.json::<ModelsResponse>().await
+    }
+    .await;
+    match listed {
+        Ok(models) => {
+            let mut ids: Vec<String> = models.data.into_iter().map(|m| m.id).collect();
+            ids.sort_unstable();
+            ids.dedup();
+            ids
+        }
+        Err(e) => {
+            crate::debug_log!("provider {}: GET {url} failed: {e}", provider.id);
+            Vec::new()
+        }
+    }
 }
 
 /// Ollama's GET /api/version, extended with this daemon's own identity —
@@ -7953,7 +8054,7 @@ mod tests {
             wire,
             model: "mock-model".into(),
             max_output: None,
-            api_key: "sk-test".into(),
+            api_key: Some("sk-test".into()),
         }))
     }
 
@@ -8610,7 +8711,7 @@ mod tests {
             wire,
             model: model.into(),
             max_output: None,
-            api_key: "k".into(),
+            api_key: Some("k".into()),
         }
     }
 
@@ -9255,7 +9356,7 @@ mod tests {
                         wire: Wire::OpenAi,
                         model: "claude".into(),
                         max_output: None,
-                        api_key: "k".into(),
+                        api_key: Some("k".into()),
                     }))
                 } else {
                     Target::Local(1)
@@ -9794,6 +9895,138 @@ mod tests {
                 "{fields:?} carries a key"
             );
         }
+    }
+
+    /// A provider `llmman.conf` defines tells its clients it takes no
+    /// key and names no variable, so `launch`/`run` know not to demand
+    /// one — and the listing does not print a `null` where a variable
+    /// name goes.
+    #[test]
+    fn a_configured_provider_reports_its_key_as_optional() {
+        let catalog = fixture_catalog().with_configured(&[crate::config::ConfiguredProvider {
+            id: "gpubox".into(),
+            name: "GPU box".into(),
+            base_url: "http://gpubox:8000/v1".into(),
+            wire: Wire::OpenAi,
+            key_env: None,
+        }]);
+        let provider = catalog.get("gpubox").unwrap();
+        let json = serde_json::to_value(ProviderSummary::from(provider)).unwrap();
+        assert_eq!(json["key_optional"], true);
+        assert_eq!(json["key_set"], false);
+        assert!(json.get("key_env").is_none(), "{json}");
+        assert_eq!(json["base_url"], "http://gpubox:8000/v1");
+        // The catalog entry is untouched, and still demands its key.
+        let json = serde_json::to_value(ProviderSummary::from(catalog.get("openrouter").unwrap()))
+            .unwrap();
+        assert_eq!(json["key_optional"], false);
+    }
+
+    /// A keyless target sends no credential header at all — not an empty
+    /// bearer, which vLLM and llama-server reject as a malformed token —
+    /// while the Anthropic wire still gets its version header.
+    #[test]
+    fn a_keyless_remote_target_sends_no_credential_header() {
+        let client = Client::new();
+        let keyless = |wire: Wire| {
+            Target::Remote(Arc::new(RemoteTarget {
+                provider: "gpubox".into(),
+                base_url: "http://gpubox:8000/v1".into(),
+                wire,
+                model: "m".into(),
+                max_output: None,
+                api_key: None,
+            }))
+        };
+        let headers = |target: &Target| {
+            target
+                .authorize(client.post("http://gpubox:8000/v1/x"))
+                .build()
+                .unwrap()
+                .headers()
+                .clone()
+        };
+        let openai = headers(&keyless(Wire::OpenAi));
+        assert!(
+            openai.get(reqwest::header::AUTHORIZATION).is_none(),
+            "{openai:?}"
+        );
+        let anthropic = headers(&keyless(Wire::Anthropic));
+        assert!(anthropic.get("x-api-key").is_none(), "{anthropic:?}");
+        assert_eq!(
+            anthropic.get("anthropic-version").unwrap(),
+            anthropic::VERSION
+        );
+        // And with a key, the header is back.
+        let keyed = headers(&remote_target_on("http://gpubox:8000/v1", Wire::OpenAi));
+        assert_eq!(
+            keyed.get(reqwest::header::AUTHORIZATION).unwrap(),
+            "Bearer sk-test"
+        );
+    }
+
+    /// The models of a configured provider come from its own `/models`,
+    /// so `list --provider gpubox` shows what the box actually serves; a
+    /// box that is down or lacks the route costs an empty list, never an
+    /// error, since requests can still go to it.
+    #[tokio::test]
+    async fn a_configured_providers_models_are_asked_of_its_endpoint() {
+        // A mock vLLM: `/v1/models` in OpenAI's list shape, recording the
+        // headers it was sent; nothing else.
+        let seen: Arc<tokio::sync::Mutex<Vec<HeaderMap>>> = Arc::default();
+        let captured = seen.clone();
+        let app = Router::new().route(
+            "/v1/models",
+            get(move |headers: HeaderMap| async move {
+                captured.lock().await.push(headers);
+                Json(serde_json::json!({ "object": "list", "data": [
+                    { "id": "qwen3-coder", "object": "model" },
+                    { "id": "gemma4", "object": "model" },
+                    { "id": "gemma4", "object": "model" }
+                ]}))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!(
+            "http://127.0.0.1:{}/v1",
+            listener.local_addr().unwrap().port()
+        );
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let provider =
+            crate::providers::Provider::from_configured(&crate::config::ConfiguredProvider {
+                id: "gpubox".into(),
+                name: "gpubox".into(),
+                base_url: base.clone(),
+                wire: Wire::OpenAi,
+                key_env: None,
+            });
+        let client = Client::new();
+        let models = configured_provider_models(&client, &provider).await;
+        assert_eq!(
+            models,
+            vec!["gemma4".to_string(), "qwen3-coder".to_string()]
+        );
+        let calls = seen.lock().await;
+        assert!(
+            calls[0].get("authorization").is_none(),
+            "a keyless provider was sent a bearer: {:?}",
+            calls[0]
+        );
+        drop(calls);
+
+        // Nothing listening: an empty list, not a failure.
+        let mut down = provider.clone();
+        down.base_url = "http://127.0.0.1:9/v1".into();
+        assert!(configured_provider_models(&client, &down).await.is_empty());
+
+        // The Anthropic wire has no /models, and is not asked.
+        let mut anthropic = provider.clone();
+        anthropic.wire = Wire::Anthropic;
+        assert!(configured_provider_models(&client, &anthropic)
+            .await
+            .is_empty());
+        assert_eq!(seen.lock().await.len(), 1, "no second request was made");
     }
 
     // -- Idle-timeout auto-unload reaper --------------------------------------

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -1741,9 +1741,7 @@ impl Target {
     /// auth, which is why nothing below ever forwarded the client's own
     /// `Authorization` header upstream — and must keep not forwarding it,
     /// so a key meant for one provider can never be relayed to another.
-    /// A remote target without a key (a configured provider that takes
-    /// none) likewise gets no credential header, only the wire's other
-    /// ones.
+    /// A keyless remote target gets no credential header either.
     fn authorize(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
         match self {
             Self::Local(_) => req,
@@ -1915,9 +1913,7 @@ async fn resolve_remote_target(
     };
     let api_key = match client_api_key(headers).or_else(own_key) {
         Some(key) => Some(key),
-        // A configured provider that takes no key: the request goes up
-        // bare. Not a catalog one, where that is a certain 401 better
-        // explained here than relayed from upstream.
+        // A configured provider that takes no key goes up bare.
         None if provider.key_optional => None,
         None => {
             return Err(AppError(
@@ -4001,8 +3997,7 @@ struct ProviderSummary {
     id: String,
     name: String,
     base_url: String,
-    /// Absent for a configured provider that names no variable, whose
-    /// key — if it has one — is in `llmman.conf` alone.
+    /// Absent for a configured provider that names no variable.
     #[serde(skip_serializing_if = "Option::is_none")]
     key_env: Option<String>,
     /// What is spoken at `base_url`: `openai` or `anthropic` (see
@@ -4017,9 +4012,8 @@ struct ProviderSummary {
     /// "will my keyless request work" has to read this, not `key_set`:
     /// its own `LLMMAN_HOST` says nothing about how the daemon is bound.
     key_usable: bool,
-    /// Whether a request with no key at all is forwarded anyway (see
-    /// `Provider::key_optional`). True for a provider `llmman.conf`
-    /// defines.
+    /// Whether a keyless request is forwarded anyway (see
+    /// `Provider::key_optional`).
     key_optional: bool,
     models: usize,
 }
@@ -4127,8 +4121,8 @@ async fn handle_llmman_providers() -> Result<impl IntoResponse, AppError> {
 /// `GET /llmman/providers/:id` — one provider, or a 404 naming
 /// near-matches (see [`crate::providers::unknown_provider_error`]).
 ///
-/// A provider `llmman.conf` defines has no catalog models; its endpoint
-/// is asked instead (see [`configured_provider_models`]).
+/// A configured provider's models come from its endpoint instead
+/// ([`configured_provider_models`]).
 async fn handle_llmman_provider(
     State(state): State<AppState>,
     UrlPath(id): UrlPath<String>,
@@ -4151,22 +4145,16 @@ async fn handle_llmman_provider(
     Ok(Json(response))
 }
 
-/// How long a configured provider gets to answer `GET /models` before
-/// the listing goes out without one. Short: this sits in front of
-/// `llmman launch`, and a LAN box that is down should cost a moment, not
-/// a hang.
+/// How long a configured provider gets to answer `GET /models`. Short:
+/// this sits in front of `llmman launch`, and a box that is down should
+/// cost a moment, not a hang.
 const CONFIGURED_MODELS_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// The model ids a configured provider reports at `GET {base_url}/models`
-/// — the OpenAI route vLLM, llama-server, LM Studio and every compatible
-/// proxy answer — or none when it cannot, or does not: the listing is a
-/// convenience for `llmman list --provider` and the `--model` check, and
-/// an endpoint that lacks it is still one requests can go to.
-///
-/// Authenticated the way a request would be (see `resolve_remote_target`),
-/// minus the caller's own key: this is a GET the daemon makes for itself,
-/// so only its own key is on offer, and only under the bind rule that
-/// gates spending it for a request.
+/// The model ids an OpenAI-wire configured provider reports at
+/// `GET {base_url}/models`, or none when it cannot or does not: the
+/// listing is a convenience, and an endpoint without it still takes
+/// requests. The daemon's own key is sent under the same bind rule as
+/// for a request (`daemon_key_usable`).
 async fn configured_provider_models(
     client: &Client,
     provider: &crate::providers::Provider,

--- a/src/config.rs
+++ b/src/config.rs
@@ -353,12 +353,6 @@ fn validate(conf: &Conf) -> Result<(), String> {
                 }
             }
         }
-        if p.api_key_env
-            .as_deref()
-            .is_some_and(|v| v.trim().is_empty())
-        {
-            return Err(format!("[providers.{id}] api_key_env is blank"));
-        }
     }
     Ok(())
 }
@@ -426,8 +420,10 @@ fn configured_from(files: &[File]) -> Vec<ConfiguredProvider> {
             if let Some(wire) = p.wire {
                 entry.wire = wire;
             }
-            if let Some(var) = &p.api_key_env {
-                entry.key_env = Some(var.trim().to_string());
+            // Blank clears a variable an earlier file named, as `api_key = ""`
+            // clears a key.
+            if let Some(var) = p.api_key_env.as_deref().map(str::trim) {
+                entry.key_env = (!var.is_empty()).then(|| var.to_string());
             }
             if let Some(name) = p.name.as_deref().map(str::trim).filter(|n| !n.is_empty()) {
                 entry.name = name.to_string();
@@ -738,16 +734,22 @@ mod tests {
     /// keeps the rest, as keys merge.
     #[test]
     fn a_later_definition_overrides_field_by_field() {
-        let system =
-            file("[providers.gpubox]\nbase_url = \"http://gpubox:8000/v1\"\nname = \"Shared box\"");
+        let system = file(
+            "[providers.gpubox]\nbase_url = \"http://gpubox:8000/v1\"\nname = \"Shared box\"\n\
+             api_key_env = \"SHARED_KEY\"",
+        );
         let user = file(
-            "[providers.gpubox]\nbase_url = \"http://10.0.0.5:8000/v1\"\nwire = \"anthropic\"",
+            "[providers.gpubox]\nbase_url = \"http://10.0.0.5:8000/v1\"\nwire = \"anthropic\"\n\
+             api_key_env = \"\"",
         );
         let merged = configured_from(&[system, user]);
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].base_url, "http://10.0.0.5:8000/v1");
         assert_eq!(merged[0].name, "Shared box");
         assert_eq!(merged[0].wire, crate::providers::Wire::Anthropic);
+        // A blank clears the inherited variable, so /etc's key does not
+        // follow the user to another endpoint.
+        assert_eq!(merged[0].key_env, None);
     }
 
     /// What `config set` has to refuse on the spot: a `base_url` that is
@@ -781,7 +783,6 @@ mod tests {
         assert!(err.contains("api_key_env, name"), "{err}");
 
         assert!(bad("base_url = \"http://g/v1\"\nwire = \"ollama\"").contains("wire"));
-        assert!(bad("base_url = \"http://g/v1\"\napi_key_env = \" \"").contains("blank"));
         assert!(bad("base_url = \"http://g/v1\"\nbase_ulr = \"x\"").contains("base_ulr"));
 
         // The good shapes parse, and come out normalized: lowercase

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,10 @@
 //! [providers.openrouter]               # crate::providers
 //! api_key = "sk-or-..."
 //!
+//! [providers.gpubox]                   # a provider models.dev does not list
+//! base_url = "http://gpubox:8000/v1"
+//! wire     = "openai"                  # default; or "anthropic"
+//!
 //! [verify]                             # crate::verify
 //! default = "off"
 //!
@@ -76,11 +80,37 @@ pub struct AggregationConf {
     pub peers: Option<String>,
 }
 
+/// One `[providers.<id>]` table.
+///
+/// Two things at once, told apart by `base_url`. Without it the table
+/// attaches an `api_key` to a provider the models.dev catalog already
+/// lists. With it the table *defines* a provider of its own — an
+/// inference server on some host llmman would otherwise have no way to
+/// name: vLLM, llama-server, LM Studio, a proxy in front of OpenAI. Such
+/// an entry shadows a catalog provider with the same id, which is also
+/// how a catalog URL that is wrong for one network gets corrected.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ProviderConf {
     #[serde(default)]
     api_key: Option<String>,
+    /// Base URL the wire's route is appended to (`/chat/completions`,
+    /// `/messages`). Plain `http://` is accepted here, unlike for a
+    /// catalog entry: this URL was typed by the user into their own
+    /// owner-only file, not fetched from the network at runtime.
+    #[serde(default)]
+    base_url: Option<String>,
+    /// What is spoken at `base_url`; `openai` unless said otherwise.
+    #[serde(default)]
+    wire: Option<crate::providers::Wire>,
+    /// Environment variable holding the key, for a defined provider that
+    /// wants one. A defined provider with neither this nor `api_key`
+    /// simply sends no credential — most local servers take none.
+    #[serde(default)]
+    api_key_env: Option<String>,
+    /// Display name for listings; the id when absent.
+    #[serde(default)]
+    name: Option<String>,
 }
 
 /// Hand-written so the key cannot reach a log through the derived
@@ -90,8 +120,50 @@ impl std::fmt::Debug for ProviderConf {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ProviderConf")
             .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
+            .field("base_url", &self.base_url)
+            .field("wire", &self.wire)
+            .field("api_key_env", &self.api_key_env)
+            .field("name", &self.name)
             .finish()
     }
+}
+
+impl ProviderConf {
+    /// Whether this table defines a provider rather than only keying one.
+    fn defines(&self) -> bool {
+        self.base_url.is_some()
+    }
+
+    /// The fields that only make sense on a definition, for the check in
+    /// [`validate`].
+    fn definition_only_fields(&self) -> Vec<&'static str> {
+        let mut set = Vec::new();
+        if self.wire.is_some() {
+            set.push("wire");
+        }
+        if self.api_key_env.is_some() {
+            set.push("api_key_env");
+        }
+        if self.name.is_some() {
+            set.push("name");
+        }
+        set
+    }
+}
+
+/// A provider `llmman.conf` defines, merged across every file that
+/// mentions it. What `crate::providers` turns into a `Provider`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConfiguredProvider {
+    pub id: String,
+    /// `name` from the file, else the id.
+    pub name: String,
+    /// Without its trailing slash, as `Provider::base_url` is kept.
+    pub base_url: String,
+    pub wire: crate::providers::Wire,
+    /// `api_key_env`, when set. The `api_key` itself is not here: it is
+    /// reached through [`provider_api_key`], behind the file-mode gate.
+    pub key_env: Option<String>,
 }
 
 /// The `[verify]` section. [`crate::verify`] owns what these strings
@@ -259,7 +331,117 @@ fn load() -> Result<Vec<File>, String> {
 /// Parse one `llmman.conf`. Split out from [`load`] so the format is
 /// testable without a file, a home directory, or a particular umask.
 pub(crate) fn parse(text: &str) -> Result<Conf, String> {
-    toml::from_str(text).map_err(|e| e.to_string())
+    let conf: Conf = toml::from_str(text).map_err(|e| e.to_string())?;
+    validate(&conf)?;
+    Ok(conf)
+}
+
+/// What the TOML shape alone cannot say. Run at parse time so `llmman
+/// config set providers.gpubox.base_url gpubox:8000` is refused on the
+/// spot, for the same reason a misspelled field is: a bad URL that
+/// parsed happily would surface as a connection error inside someone
+/// else's TUI, and a `wire` on a table that defines nothing would be a
+/// setting that silently never takes effect.
+fn validate(conf: &Conf) -> Result<(), String> {
+    for (id, p) in &conf.providers {
+        if let Some(url) = &p.base_url {
+            base_url_of(url).map_err(|e| format!("[providers.{id}] base_url: {e}"))?;
+        } else {
+            let only_on_definition = p.definition_only_fields();
+            if !only_on_definition.is_empty() {
+                return Err(format!(
+                    "[providers.{id}] sets {} but no base_url; those fields define a \
+                     provider, and without a base_url the table only holds a key for the \
+                     catalog provider {id:?}",
+                    only_on_definition.join(", ")
+                ));
+            }
+        }
+        if p.api_key_env
+            .as_deref()
+            .is_some_and(|v| v.trim().is_empty())
+        {
+            return Err(format!("[providers.{id}] api_key_env is blank"));
+        }
+    }
+    Ok(())
+}
+
+/// Normalizes a configured `base_url`: an absolute `http`/`https` URL,
+/// with any trailing slash gone so a route appends cleanly.
+///
+/// A route suffix someone pasted from a curl example
+/// (`.../v1/chat/completions`) is left alone rather than stripped: the
+/// URL is the user's own to get right, and `crate::providers::base_url_of`
+/// is for a catalog whose entries llmman cannot edit.
+fn base_url_of(url: &str) -> Result<String, String> {
+    let url = url.trim();
+    let parsed = reqwest::Url::parse(url).map_err(|e| format!("{url:?}: {e}"))?;
+    match parsed.scheme() {
+        "http" | "https" => {}
+        other => {
+            return Err(format!(
+                "{url:?}: scheme must be http or https, not {other}"
+            ))
+        }
+    }
+    if parsed.host_str().is_none() {
+        return Err(format!("{url:?}: no host"));
+    }
+    if parsed.query().is_some() || parsed.fragment().is_some() {
+        return Err(format!("{url:?}: a base URL has no query or fragment"));
+    }
+    Ok(url.trim_end_matches('/').to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Configured providers
+// ---------------------------------------------------------------------------
+
+/// Every provider `llmman.conf` defines (a `[providers.<id>]` with a
+/// `base_url`), sorted by id, for `crate::providers` to add to — and
+/// shadow — the catalog. Read once for the process, like the keys.
+pub fn configured_providers() -> &'static [ConfiguredProvider] {
+    static CACHE: OnceLock<Vec<ConfiguredProvider>> = OnceLock::new();
+    CACHE.get_or_init(|| configured_from(files().unwrap_or_default()))
+}
+
+/// Merged field by field, later files overriding earlier, the same way
+/// the keys merge: a user file that re-defines an id `/etc` defined
+/// replaces the fields it sets and keeps the rest. (Each file still has
+/// to carry the `base_url` — see [`validate`] — since a file is checked
+/// on its own.) Split out to be testable without a filesystem.
+fn configured_from(files: &[File]) -> Vec<ConfiguredProvider> {
+    let mut merged: HashMap<&str, ConfiguredProvider> = HashMap::new();
+    for file in files {
+        for (id, p) in file.conf.providers.iter().filter(|(_, p)| p.defines()) {
+            let base_url = p
+                .base_url
+                .as_deref()
+                .and_then(|u| base_url_of(u).ok())
+                .expect("validated at parse");
+            let entry = merged.entry(id).or_insert_with(|| ConfiguredProvider {
+                id: id.clone(),
+                name: id.clone(),
+                base_url: String::new(),
+                wire: crate::providers::Wire::OpenAi,
+                key_env: None,
+            });
+            entry.base_url = base_url;
+            if let Some(wire) = p.wire {
+                entry.wire = wire;
+            }
+            if let Some(var) = &p.api_key_env {
+                entry.key_env = Some(var.trim().to_string());
+            }
+            if let Some(name) = p.name.as_deref().map(str::trim).filter(|n| !n.is_empty()) {
+                entry.name = name.to_string();
+            }
+        }
+    }
+    let mut out: Vec<ConfiguredProvider> = merged.into_values().collect();
+    out.sort_by(|a, b| a.id.cmp(&b.id));
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -500,6 +682,125 @@ mod tests {
     #[test]
     fn malformed_toml_is_an_error() {
         assert!(parse("[providers.openai").is_err());
+    }
+
+    // -- configured providers ------------------------------------------------
+
+    /// A `[providers.<id>]` with a `base_url` defines a provider; every
+    /// other field has a default. One without is only a key, as before.
+    #[test]
+    fn a_base_url_turns_a_provider_table_into_a_definition() {
+        let files = [file(
+            r#"
+            [providers.gpubox]
+            base_url = "http://gpubox:8000/v1/"
+
+            [providers.relay]
+            base_url    = "https://relay.example/v1"
+            wire        = "anthropic"
+            api_key_env = "RELAY_KEY"
+            name        = "Claude relay"
+            api_key     = "sk-relay"
+
+            [providers.openrouter]
+            api_key = "sk-or"
+            "#,
+        )];
+        let configured = configured_from(&files);
+        assert_eq!(
+            configured,
+            vec![
+                ConfiguredProvider {
+                    id: "gpubox".into(),
+                    name: "gpubox".into(),
+                    // Trailing slash gone: a route appends its own.
+                    base_url: "http://gpubox:8000/v1".into(),
+                    wire: crate::providers::Wire::OpenAi,
+                    key_env: None,
+                },
+                ConfiguredProvider {
+                    id: "relay".into(),
+                    name: "Claude relay".into(),
+                    base_url: "https://relay.example/v1".into(),
+                    wire: crate::providers::Wire::Anthropic,
+                    key_env: Some("RELAY_KEY".into()),
+                },
+            ]
+        );
+        // The key of a defined provider is reached the same way as any.
+        assert_eq!(
+            files[0]
+                .conf
+                .provider_keys()
+                .get("relay")
+                .map(String::as_str),
+            Some("sk-relay")
+        );
+        assert!(configured_from(&[]).is_empty());
+    }
+
+    /// A later file re-defining an id replaces the fields it sets and
+    /// keeps the rest, as keys merge.
+    #[test]
+    fn a_later_definition_overrides_field_by_field() {
+        let system =
+            file("[providers.gpubox]\nbase_url = \"http://gpubox:8000/v1\"\nname = \"Shared box\"");
+        let user = file(
+            "[providers.gpubox]\nbase_url = \"http://10.0.0.5:8000/v1\"\nwire = \"anthropic\"",
+        );
+        let merged = configured_from(&[system, user]);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].base_url, "http://10.0.0.5:8000/v1");
+        assert_eq!(merged[0].name, "Shared box");
+        assert_eq!(merged[0].wire, crate::providers::Wire::Anthropic);
+    }
+
+    /// What `config set` has to refuse on the spot: a `base_url` that is
+    /// not an absolute http(s) URL, a definition field on a table that
+    /// defines nothing, a `wire` llmman does not speak.
+    #[test]
+    fn a_bad_provider_definition_is_a_parse_error() {
+        let bad = |body: &str| parse(&format!("[providers.gpubox]\n{body}")).expect_err(body);
+
+        assert!(bad("base_url = \"gpubox:8000\"").contains("base_url"));
+        assert!(bad("base_url = \"gpubox:8000/v1\"").contains("base_url"));
+        assert!(bad("base_url = \"ftp://gpubox/v1\"").contains("http or https"));
+        assert!(bad("base_url = \"http://\"").contains("base_url"));
+        assert!(bad("base_url = \"http://gpubox/v1?x=1\"").contains("query"));
+        assert!(bad("base_url = \"\"").contains("base_url"));
+
+        let err = bad("wire = \"anthropic\"");
+        assert!(err.contains("no base_url"), "{err}");
+        assert!(err.contains("wire"), "{err}");
+        let err = bad("api_key_env = \"X\"\nname = \"n\"");
+        assert!(err.contains("api_key_env, name"), "{err}");
+
+        assert!(bad("base_url = \"http://g/v1\"\nwire = \"ollama\"").contains("wire"));
+        assert!(bad("base_url = \"http://g/v1\"\napi_key_env = \" \"").contains("blank"));
+        assert!(bad("base_url = \"http://g/v1\"\nbase_ulr = \"x\"").contains("base_ulr"));
+
+        // And the good shapes parse: bare host, port, path, no path,
+        // IPv6, https.
+        for url in [
+            "http://gpubox:8000/v1",
+            "http://gpubox",
+            "http://127.0.0.1:11434/v1",
+            "http://[::1]:8000/v1",
+            "https://relay.example/api/v1",
+        ] {
+            parse(&format!("[providers.gpubox]\nbase_url = {url:?}")).expect(url);
+        }
+    }
+
+    /// The definition fields show in `Debug`; the key still does not.
+    #[test]
+    fn debug_output_shows_a_definition_but_never_a_key() {
+        let c = conf(
+            "[providers.gpubox]\nbase_url = \"http://gpubox:8000/v1\"\napi_key = \"sk-secret-value\"",
+        );
+        let rendered = format!("{c:?}");
+        assert!(rendered.contains("gpubox:8000"), "{rendered}");
+        assert!(!rendered.contains("sk-secret-value"), "{rendered}");
     }
 
     // -- aggregation peers ---------------------------------------------------

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,32 +80,23 @@ pub struct AggregationConf {
     pub peers: Option<String>,
 }
 
-/// One `[providers.<id>]` table.
-///
-/// Two things at once, told apart by `base_url`. Without it the table
-/// attaches an `api_key` to a provider the models.dev catalog already
-/// lists. With it the table *defines* a provider of its own — an
-/// inference server on some host llmman would otherwise have no way to
-/// name: vLLM, llama-server, LM Studio, a proxy in front of OpenAI. Such
-/// an entry shadows a catalog provider with the same id, which is also
-/// how a catalog URL that is wrong for one network gets corrected.
+/// One `[providers.<id>]` table. Without `base_url` it keys a catalog
+/// provider; with it, it *defines* one — an inference server at a host
+/// models.dev does not list — and shadows any catalog entry with its id.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ProviderConf {
     #[serde(default)]
     api_key: Option<String>,
-    /// Base URL the wire's route is appended to (`/chat/completions`,
-    /// `/messages`). Plain `http://` is accepted here, unlike for a
-    /// catalog entry: this URL was typed by the user into their own
-    /// owner-only file, not fetched from the network at runtime.
+    /// Base URL the wire's route is appended to. Plain `http://` is
+    /// allowed: the user typed it into their own owner-only file.
     #[serde(default)]
     base_url: Option<String>,
-    /// What is spoken at `base_url`; `openai` unless said otherwise.
+    /// What is spoken at `base_url`; `openai` by default.
     #[serde(default)]
     wire: Option<crate::providers::Wire>,
-    /// Environment variable holding the key, for a defined provider that
-    /// wants one. A defined provider with neither this nor `api_key`
-    /// simply sends no credential — most local servers take none.
+    /// Variable holding the key. With neither this nor `api_key`, no
+    /// credential is sent — most local servers take none.
     #[serde(default)]
     api_key_env: Option<String>,
     /// Display name for listings; the id when absent.
@@ -134,8 +125,7 @@ impl ProviderConf {
         self.base_url.is_some()
     }
 
-    /// The fields that only make sense on a definition, for the check in
-    /// [`validate`].
+    /// Fields that only mean something on a definition (see [`validate`]).
     fn definition_only_fields(&self) -> Vec<&'static str> {
         let mut set = Vec::new();
         if self.wire.is_some() {
@@ -336,25 +326,31 @@ pub(crate) fn parse(text: &str) -> Result<Conf, String> {
     Ok(conf)
 }
 
-/// What the TOML shape alone cannot say. Run at parse time so `llmman
-/// config set providers.gpubox.base_url gpubox:8000` is refused on the
-/// spot, for the same reason a misspelled field is: a bad URL that
-/// parsed happily would surface as a connection error inside someone
-/// else's TUI, and a `wire` on a table that defines nothing would be a
-/// setting that silently never takes effect.
+/// What the TOML shape alone cannot say, checked at parse time so
+/// `llmman config set` refuses it on the spot.
 fn validate(conf: &Conf) -> Result<(), String> {
     for (id, p) in &conf.providers {
-        if let Some(url) = &p.base_url {
-            base_url_of(url).map_err(|e| format!("[providers.{id}] base_url: {e}"))?;
-        } else {
-            let only_on_definition = p.definition_only_fields();
-            if !only_on_definition.is_empty() {
-                return Err(format!(
-                    "[providers.{id}] sets {} but no base_url; those fields define a \
-                     provider, and without a base_url the table only holds a key for the \
-                     catalog provider {id:?}",
-                    only_on_definition.join(", ")
-                ));
+        // `<provider>/<model>` is how a reference travels (see
+        // `crate::providers::split_remote_ref`), so a slash in the id
+        // could never be routed.
+        if id.is_empty() || id.contains('/') {
+            return Err(format!(
+                "[providers.{id:?}]: a provider id cannot be empty or contain '/'"
+            ));
+        }
+        match &p.base_url {
+            Some(url) => {
+                base_url_of(url).map_err(|e| format!("[providers.{id}] base_url: {e}"))?;
+            }
+            None => {
+                let only_on_definition = p.definition_only_fields();
+                if !only_on_definition.is_empty() {
+                    return Err(format!(
+                        "[providers.{id}] sets {} but no base_url, so it only keys the catalog \
+                         provider {id:?}",
+                        only_on_definition.join(", ")
+                    ));
+                }
             }
         }
         if p.api_key_env
@@ -367,13 +363,11 @@ fn validate(conf: &Conf) -> Result<(), String> {
     Ok(())
 }
 
-/// Normalizes a configured `base_url`: an absolute `http`/`https` URL,
-/// with any trailing slash gone so a route appends cleanly.
-///
-/// A route suffix someone pasted from a curl example
-/// (`.../v1/chat/completions`) is left alone rather than stripped: the
-/// URL is the user's own to get right, and `crate::providers::base_url_of`
-/// is for a catalog whose entries llmman cannot edit.
+/// Normalizes a configured `base_url`: an absolute `http`/`https` URL
+/// with no query, fragment or userinfo, lowercased scheme and host, and
+/// no trailing slash. Userinfo is refused because the URL is reported by
+/// the daemon's API and printed in warnings; `api_key` is where a
+/// credential goes.
 fn base_url_of(url: &str) -> Result<String, String> {
     let url = url.trim();
     let parsed = reqwest::Url::parse(url).map_err(|e| format!("{url:?}: {e}"))?;
@@ -388,29 +382,30 @@ fn base_url_of(url: &str) -> Result<String, String> {
     if parsed.host_str().is_none() {
         return Err(format!("{url:?}: no host"));
     }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(format!(
+            "{url:?}: a base URL cannot carry a username or password; use api_key"
+        ));
+    }
     if parsed.query().is_some() || parsed.fragment().is_some() {
         return Err(format!("{url:?}: a base URL has no query or fragment"));
     }
-    Ok(url.trim_end_matches('/').to_string())
+    Ok(parsed.as_str().trim_end_matches('/').to_string())
 }
 
 // ---------------------------------------------------------------------------
 // Configured providers
 // ---------------------------------------------------------------------------
 
-/// Every provider `llmman.conf` defines (a `[providers.<id>]` with a
-/// `base_url`), sorted by id, for `crate::providers` to add to — and
-/// shadow — the catalog. Read once for the process, like the keys.
+/// Every provider `llmman.conf` defines, sorted by id. Read once for the
+/// process, like the keys.
 pub fn configured_providers() -> &'static [ConfiguredProvider] {
     static CACHE: OnceLock<Vec<ConfiguredProvider>> = OnceLock::new();
     CACHE.get_or_init(|| configured_from(files().unwrap_or_default()))
 }
 
-/// Merged field by field, later files overriding earlier, the same way
-/// the keys merge: a user file that re-defines an id `/etc` defined
-/// replaces the fields it sets and keeps the rest. (Each file still has
-/// to carry the `base_url` — see [`validate`] — since a file is checked
-/// on its own.) Split out to be testable without a filesystem.
+/// Merged field by field, later files overriding earlier, as keys do.
+/// Split out to be testable without a filesystem.
 fn configured_from(files: &[File]) -> Vec<ConfiguredProvider> {
     let mut merged: HashMap<&str, ConfiguredProvider> = HashMap::new();
     for file in files {
@@ -768,6 +763,16 @@ mod tests {
         assert!(bad("base_url = \"http://\"").contains("base_url"));
         assert!(bad("base_url = \"http://gpubox/v1?x=1\"").contains("query"));
         assert!(bad("base_url = \"\"").contains("base_url"));
+        // The URL is reported by the daemon's API; a secret does not go in it.
+        assert!(bad("base_url = \"https://user:pw@gpubox/v1\"").contains("api_key"));
+        assert!(bad("base_url = \"https://user@gpubox/v1\"").contains("api_key"));
+        // A slash in the id would never survive `split_remote_ref`.
+        assert!(
+            parse("[providers.\"team/gpu\"]\nbase_url = \"http://g/v1\"")
+                .expect_err("slash id")
+                .contains("'/'")
+        );
+        assert!(parse("[providers.\"\"]\napi_key = \"x\"").is_err());
 
         let err = bad("wire = \"anthropic\"");
         assert!(err.contains("no base_url"), "{err}");
@@ -779,15 +784,20 @@ mod tests {
         assert!(bad("base_url = \"http://g/v1\"\napi_key_env = \" \"").contains("blank"));
         assert!(bad("base_url = \"http://g/v1\"\nbase_ulr = \"x\"").contains("base_ulr"));
 
-        // And the good shapes parse: bare host, port, path, no path,
-        // IPv6, https.
-        for url in [
-            "http://gpubox:8000/v1",
-            "http://gpubox",
-            "http://127.0.0.1:11434/v1",
-            "http://[::1]:8000/v1",
-            "https://relay.example/api/v1",
+        // The good shapes parse, and come out normalized: lowercase
+        // scheme and host, no trailing slash.
+        for (url, want) in [
+            ("http://gpubox:8000/v1", "http://gpubox:8000/v1"),
+            ("http://gpubox", "http://gpubox"),
+            ("HTTP://GPUBox:8000/v1/", "http://gpubox:8000/v1"),
+            ("http://127.0.0.1:11434/v1", "http://127.0.0.1:11434/v1"),
+            ("http://[::1]:8000/v1", "http://[::1]:8000/v1"),
+            (
+                "https://relay.example/api/v1",
+                "https://relay.example/api/v1",
+            ),
         ] {
+            assert_eq!(base_url_of(url).expect(url), want);
             parse(&format!("[providers.gpubox]\nbase_url = {url:?}")).expect(url);
         }
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1153,8 +1153,7 @@ pub fn api_error(body: &str) -> Option<String> {
 pub struct ProviderSummary {
     pub id: String,
     pub name: String,
-    /// Absent for a provider `llmman.conf` defines without an
-    /// `api_key_env`: its key, if any, is in the file alone.
+    /// Absent for a configured provider that names no variable.
     #[serde(default)]
     pub key_env: Option<String>,
     /// Whether the key is set *where the daemon runs*. What this process
@@ -1165,9 +1164,8 @@ pub struct ProviderSummary {
     /// bound, which this process's `LLMMAN_HOST` says nothing about.
     #[serde(default)]
     pub key_usable: bool,
-    /// Whether a request with no key at all is forwarded (a provider
-    /// `llmman.conf` defines — see `Provider::key_optional`). Absent from
-    /// an older daemon means no, the answer for every catalog provider.
+    /// Whether a keyless request is forwarded (see
+    /// `Provider::key_optional`); absent from an older daemon means no.
     #[serde(default)]
     pub key_optional: bool,
     pub models: usize,
@@ -1248,22 +1246,32 @@ impl ProviderDetail {
         self.models.iter().map(|m| m.id.as_str()).collect()
     }
 
-    /// Where a key for this provider would go, for an error that found
-    /// none (see `crate::providers::key_hint`).
+    /// Where a key for this provider would go (see
+    /// `crate::providers::key_hint`).
     pub fn key_hint(&self) -> String {
         crate::providers::key_hint(&self.id, self.key_env.as_deref())
     }
 
+    /// Resolves the key this process would send, warning once if it is
+    /// about to cross the network in cleartext — the daemon's own
+    /// startup warning only covers the key *it* holds.
+    pub fn client_key(&self) -> Option<String> {
+        let key = self.api_key();
+        if key.is_some() && self.base_url.starts_with("http://") {
+            eprintln!(
+                "[llmman] warning: the API key for {} goes to {} over plain http",
+                self.name, self.base_url
+            );
+        }
+        key
+    }
+
     /// Warns when this provider does not list `model` — a warning, since
-    /// models.dev is a snapshot and a provider can serve a model (a new
-    /// release, a fine-tune, a private deployment) before it lists one.
-    ///
-    /// Silent when it lists nothing at all: a configured provider whose
-    /// `/models` was unreachable has no list to be absent from, and "does
-    /// not list X / lists no models" would say so twice about a box that
-    /// may well serve X.
+    /// models.dev is a snapshot and a provider can serve a model before it
+    /// lists one. Silent for a configured provider whose `/models` said
+    /// nothing: there is no list to be absent from.
     pub fn warn_unlisted(&self, model: &str) {
-        if self.models.is_empty() {
+        if self.key_optional && self.models.is_empty() {
             return;
         }
         if !self.models.iter().any(|m| m.id == model) {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1153,7 +1153,10 @@ pub fn api_error(body: &str) -> Option<String> {
 pub struct ProviderSummary {
     pub id: String,
     pub name: String,
-    pub key_env: String,
+    /// Absent for a provider `llmman.conf` defines without an
+    /// `api_key_env`: its key, if any, is in the file alone.
+    #[serde(default)]
+    pub key_env: Option<String>,
     /// Whether the key is set *where the daemon runs*. What this process
     /// itself holds is [`ProviderSummary::key_here`].
     pub key_set: bool,
@@ -1162,6 +1165,11 @@ pub struct ProviderSummary {
     /// bound, which this process's `LLMMAN_HOST` says nothing about.
     #[serde(default)]
     pub key_usable: bool,
+    /// Whether a request with no key at all is forwarded (a provider
+    /// `llmman.conf` defines — see `Provider::key_optional`). Absent from
+    /// an older daemon means no, the answer for every catalog provider.
+    #[serde(default)]
+    pub key_optional: bool,
     pub models: usize,
 }
 
@@ -1174,7 +1182,7 @@ impl ProviderSummary {
     /// Whether *this* process holds the key — the other way one reaches
     /// a provider, sent per request (see `client_api_key` in cmd::serve).
     pub fn key_here(&self) -> bool {
-        crate::providers::key_for(&self.id, &self.key_env).is_some()
+        crate::providers::key_for(&self.id, self.key_env.as_deref()).is_some()
     }
 }
 
@@ -1190,12 +1198,17 @@ pub struct ProviderDetail {
     pub id: String,
     pub name: String,
     pub base_url: String,
-    pub key_env: String,
+    /// See [`ProviderSummary::key_env`].
+    #[serde(default)]
+    pub key_env: Option<String>,
     /// See [`ProviderSummary::key_set`].
     pub key_set: bool,
     /// See [`ProviderSummary::key_usable`].
     #[serde(default)]
     pub key_usable: bool,
+    /// See [`ProviderSummary::key_optional`].
+    #[serde(default)]
+    pub key_optional: bool,
     pub models: Vec<ProviderModel>,
 }
 
@@ -1226,7 +1239,7 @@ impl ProviderDetail {
     /// prompt, and every key, regardless. It does not name the
     /// `llmman.conf` entry, which is keyed by the provider id.
     pub fn api_key(&self) -> Option<String> {
-        crate::providers::key_for(&self.id, &self.key_env)
+        crate::providers::key_for(&self.id, self.key_env.as_deref())
     }
 
     /// Just the ids, for a caller that only needs to name one (see
@@ -1235,10 +1248,24 @@ impl ProviderDetail {
         self.models.iter().map(|m| m.id.as_str()).collect()
     }
 
+    /// Where a key for this provider would go, for an error that found
+    /// none (see `crate::providers::key_hint`).
+    pub fn key_hint(&self) -> String {
+        crate::providers::key_hint(&self.id, self.key_env.as_deref())
+    }
+
     /// Warns when this provider does not list `model` — a warning, since
     /// models.dev is a snapshot and a provider can serve a model (a new
     /// release, a fine-tune, a private deployment) before it lists one.
+    ///
+    /// Silent when it lists nothing at all: a configured provider whose
+    /// `/models` was unreachable has no list to be absent from, and "does
+    /// not list X / lists no models" would say so twice about a box that
+    /// may well serve X.
     pub fn warn_unlisted(&self, model: &str) {
+        if self.models.is_empty() {
+            return;
+        }
         if !self.models.iter().any(|m| m.id == model) {
             eprintln!(
                 "[llmman] warning: {} does not list model {model:?}\n{}",

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -33,15 +33,14 @@
 //! half-supported: a provider llmman offers is one it can actually reach.
 //!
 //! The one way past the filter is `llmman.conf`: a `[providers.<id>]`
-//! with a `base_url` defines a provider by hand — an inference server on
-//! some host models.dev has never heard of — and is added to (or shadows)
-//! the catalog in [`catalog`]. Those rules exist to vet a list fetched
-//! from the network; a URL the user wrote into their own file needs no
-//! vetting beyond parsing, so a defined provider may be plain `http`,
-//! and may take no key at all. See [`Provider::key_optional`].
+//! with a `base_url` defines a provider by hand and is merged into the
+//! catalog in [`catalog`]. The rules above vet a list fetched from the
+//! network; a URL the user wrote needs none, so a defined provider may be
+//! plain `http` and may take no key ([`Provider::key_optional`]).
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime};
 
@@ -279,22 +278,18 @@ pub struct Provider {
     /// ...) is appended to. Never has a trailing slash.
     pub base_url: String,
     /// Environment variable holding this provider's API key. Always set
-    /// for a catalog provider; a configured one may name none, and then
-    /// only `llmman.conf` can hold its key.
+    /// for a catalog provider; a configured one may name none.
     pub key_env: Option<String>,
     /// What is spoken at `base_url`.
     pub wire: Wire,
-    /// Whether a request may go upstream with no credential at all.
-    /// True for a provider defined in `llmman.conf` — a vLLM or
-    /// llama-server on the LAN usually takes none — and never for a
-    /// catalog one, where a keyless request is a certain 401 better
-    /// reported before the handoff than inside an integration.
+    /// Whether a request may go upstream with no credential. True only
+    /// for a provider `llmman.conf` defines; for a catalog one a keyless
+    /// request is a certain 401, better reported before the handoff.
     pub key_optional: bool,
     /// Models this provider serves, sorted by id. Used to validate
     /// `--model`, to suggest values, and to answer `llmman list
     /// --provider`; the id is never sent upstream verbatim. Empty for a
-    /// configured provider, whose endpoint is asked instead (see
-    /// `cmd::serve`).
+    /// configured provider, whose endpoint is asked instead.
     pub models: Vec<Model>,
 }
 
@@ -332,9 +327,8 @@ impl Provider {
         rebase_url(&self.base_url, route)
     }
 
-    /// A provider as `llmman.conf` defines it. No models: the file names
-    /// an endpoint, not what it serves, and `cmd::serve` asks the
-    /// endpoint itself when a caller wants the list.
+    /// A provider as `llmman.conf` defines it. No models: `cmd::serve`
+    /// asks the endpoint when a caller wants the list.
     pub fn from_configured(conf: &crate::config::ConfiguredProvider) -> Self {
         Self {
             id: conf.id.clone(),
@@ -350,8 +344,7 @@ impl Provider {
 
 /// The API key for provider `id`: `var` from the environment, else the
 /// `[providers.<id>]` entry in `llmman.conf` (see [`crate::config`]).
-/// `None` when neither has one — or when there is no variable to read
-/// and the file has nothing, the case for most configured providers.
+/// `None` when neither has one.
 ///
 /// The environment wins, as it does for `aws` and `gh`: the file is the
 /// standing answer, an `export` the deliberate this-session-only
@@ -395,8 +388,6 @@ pub fn key_hint(id: &str, var: Option<&str>) -> String {
             toml_key(id),
             crate::config::user_path_display()
         ),
-        // A configured provider that names no variable: the file is the
-        // one place, so there is no "or".
         None => format!(
             "add an api_key to [providers.{}] in {}",
             toml_key(id),
@@ -607,22 +598,15 @@ impl Catalog {
         Ok(Self { providers })
     }
 
-    /// The providers `llmman.conf` defines, and nothing else — what a
-    /// machine that cannot reach models.dev still has (see [`catalog`]).
+    /// The providers `llmman.conf` defines and nothing else (see [`catalog`]).
     pub fn from_configured(configured: &[crate::config::ConfiguredProvider]) -> Self {
         Self::default().with_configured(configured)
     }
 
     /// Adds the providers `llmman.conf` defines. One with a catalog id
-    /// shadows the catalog entry: the file is the user's deliberate
-    /// answer, and is also the only way to correct a catalog URL for a
-    /// network where it is wrong (a proxy in front of `api.openai.com`).
-    ///
-    /// A plaintext `base_url` with a key behind it is warned about here,
-    /// once per load, rather than refused as a catalog entry's would be:
-    /// the URL is the user's own, and `http://gpubox:8000` on a LAN is
-    /// the whole point — but a key on that wire is still a key on that
-    /// wire, and the file cannot say which the user weighed.
+    /// shadows the catalog entry — the way to put a proxy in front of
+    /// `api.openai.com`. A plain-http `base_url` with a key behind it is
+    /// warned about once per load, not refused: the URL is the user's own.
     pub fn with_configured(mut self, configured: &[crate::config::ConfiguredProvider]) -> Self {
         for conf in configured {
             let provider = Provider::from_configured(conf);
@@ -811,55 +795,85 @@ const RETRY_COOLDOWN: Duration = Duration::from_secs(60);
 type Cached = (Instant, Duration, Result<Arc<Catalog>, String>);
 static CATALOG: Mutex<Option<Cached>> = Mutex::new(None);
 
-/// The routable provider catalog, fetched from models.dev on first use.
+/// Whether a background refresh (see [`catalog`]) is in flight.
+static REFRESHING: AtomicBool = AtomicBool::new(false);
+
+/// The routable provider catalog, fetched from models.dev on first use,
+/// with the providers `llmman.conf` defines merged on top
+/// ([`Catalog::with_configured`]).
 ///
 /// Memoized, but not for the life of the process: `llmman serve` runs for
 /// days, so a success is re-checked after [`CACHE_TTL`] and a failure
-/// after [`RETRY_COOLDOWN`] — otherwise one blip at startup would leave a
-/// daemon with no providers until someone restarted it.
-///
-/// The lock is held across the fetch, so concurrent callers wait for one
-/// load rather than racing several. Blocking: callers on an async runtime
-/// (`cmd::serve`) must go through `spawn_blocking`.
-///
-/// The providers `llmman.conf` defines are merged in on top (see
-/// [`Catalog::with_configured`]), and stand alone when models.dev cannot
-/// be loaded at all: a machine with no route out and a vLLM on the LAN
-/// is exactly where a defined provider is wanted, and must not be held
-/// hostage to a catalog it has no use for.
+/// after [`RETRY_COOLDOWN`]. An expired *success* is served as-is while
+/// a background thread refreshes it, so a request never waits on
+/// models.dev once there is anything to serve — in particular on an
+/// offline machine, where the configured providers stand alone and the
+/// retry would otherwise block a request for [`FETCH_TIMEOUT`] every
+/// cooldown. Only the first load, or one after a total failure, runs
+/// inline; the lock is held across it so concurrent callers wait for one
+/// load rather than racing several. Blocking: callers on an async
+/// runtime (`cmd::serve`) must go through `spawn_blocking`.
 pub fn catalog() -> anyhow::Result<Arc<Catalog>> {
     let mut cached = CATALOG.lock().unwrap_or_else(|e| e.into_inner());
-    let live = cached
-        .as_ref()
-        .is_some_and(|(at, good_for, _)| at.elapsed() < *good_for);
-    if !live {
-        let configured = crate::config::configured_providers();
-        // A stale catalog is held only as long as a failure: what
-        // produced it was a failed refresh, whatever it managed to
-        // return. See Loaded.
-        *cached = Some(match load() {
-            Ok(loaded) => (
-                Instant::now(),
-                loaded.good_for(),
-                Ok(Arc::new(loaded.into_catalog().with_configured(configured))),
-            ),
-            Err(e) if !configured.is_empty() => {
-                eprintln!(
-                    "[llmman] using only the {} provider(s) defined in llmman.conf ({e:#})",
-                    configured.len()
-                );
-                (
-                    Instant::now(),
-                    RETRY_COOLDOWN,
-                    Ok(Arc::new(Catalog::from_configured(configured))),
-                )
+    match cached.as_ref() {
+        Some((at, good_for, result)) if at.elapsed() < *good_for => result_of(result),
+        Some((_, _, Ok(stale))) => {
+            let stale = stale.clone();
+            if !REFRESHING.swap(true, Ordering::AcqRel) {
+                std::thread::spawn(|| {
+                    // Cleared on the way out however the load ends.
+                    struct Done;
+                    impl Drop for Done {
+                        fn drop(&mut self) {
+                            REFRESHING.store(false, Ordering::Release);
+                        }
+                    }
+                    let _done = Done;
+                    let entry = load_entry();
+                    *CATALOG.lock().unwrap_or_else(|e| e.into_inner()) = Some(entry);
+                });
             }
-            Err(e) => (Instant::now(), RETRY_COOLDOWN, Err(format!("{e:#}"))),
-        });
+            Ok(stale)
+        }
+        _ => {
+            let entry = load_entry();
+            let result = result_of(&entry.2);
+            *cached = Some(entry);
+            result
+        }
     }
-    match &cached.as_ref().expect("just populated").2 {
-        Ok(catalog) => Ok(catalog.clone()),
-        Err(e) => Err(anyhow::anyhow!(e.clone())),
+}
+
+fn result_of(result: &Result<Arc<Catalog>, String>) -> anyhow::Result<Arc<Catalog>> {
+    result.clone().map_err(anyhow::Error::msg)
+}
+
+/// One load, as [`catalog`] caches it. A failed load still yields a
+/// catalog when `llmman.conf` defines providers: a machine with no route
+/// out and a vLLM on the LAN is exactly where those are wanted. A stale
+/// or configured-only result is held only for [`RETRY_COOLDOWN`], since
+/// what produced it was a failed refresh.
+fn load_entry() -> Cached {
+    let configured = crate::config::configured_providers();
+    let now = Instant::now();
+    match load() {
+        Ok(loaded) => (
+            now,
+            loaded.good_for(),
+            Ok(Arc::new(loaded.into_catalog().with_configured(configured))),
+        ),
+        Err(e) if !configured.is_empty() => {
+            eprintln!(
+                "[llmman] using only the {} provider(s) defined in llmman.conf ({e:#})",
+                configured.len()
+            );
+            (
+                now,
+                RETRY_COOLDOWN,
+                Ok(Arc::new(Catalog::from_configured(configured))),
+            )
+        }
+        Err(e) => (now, RETRY_COOLDOWN, Err(format!("{e:#}"))),
     }
 }
 

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -31,6 +31,14 @@
 //!
 //! Everything filtered out is deliberately *absent* rather than
 //! half-supported: a provider llmman offers is one it can actually reach.
+//!
+//! The one way past the filter is `llmman.conf`: a `[providers.<id>]`
+//! with a `base_url` defines a provider by hand — an inference server on
+//! some host models.dev has never heard of — and is added to (or shadows)
+//! the catalog in [`catalog`]. Those rules exist to vet a list fetched
+//! from the network; a URL the user wrote into their own file needs no
+//! vetting beyond parsing, so a defined provider may be plain `http`,
+//! and may take no key at all. See [`Provider::key_optional`].
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -66,7 +74,12 @@ const OPENAI_COMPATIBLE_NPM: &[&str] = &[
 
 /// The wire format `llmman serve` speaks to a provider: the route, the
 /// credential header, and whether a request is translated on the way.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+///
+/// `Deserialize` for the `wire = "openai"` field of a provider defined in
+/// `llmman.conf` (see [`crate::config`]), spelled as [`Wire::as_str`]
+/// reports it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Wire {
     /// OpenAI Chat Completions, `Authorization: Bearer <key>`.
     OpenAi,
@@ -265,13 +278,23 @@ pub struct Provider {
     /// Base URL that the wire's route (`/chat/completions`, `/messages`,
     /// ...) is appended to. Never has a trailing slash.
     pub base_url: String,
-    /// Environment variable holding this provider's API key.
-    pub key_env: String,
+    /// Environment variable holding this provider's API key. Always set
+    /// for a catalog provider; a configured one may name none, and then
+    /// only `llmman.conf` can hold its key.
+    pub key_env: Option<String>,
     /// What is spoken at `base_url`.
     pub wire: Wire,
+    /// Whether a request may go upstream with no credential at all.
+    /// True for a provider defined in `llmman.conf` — a vLLM or
+    /// llama-server on the LAN usually takes none — and never for a
+    /// catalog one, where a keyless request is a certain 401 better
+    /// reported before the handoff than inside an integration.
+    pub key_optional: bool,
     /// Models this provider serves, sorted by id. Used to validate
     /// `--model`, to suggest values, and to answer `llmman list
-    /// --provider`; the id is never sent upstream verbatim.
+    /// --provider`; the id is never sent upstream verbatim. Empty for a
+    /// configured provider, whose endpoint is asked instead (see
+    /// `cmd::serve`).
     pub models: Vec<Model>,
 }
 
@@ -300,7 +323,7 @@ impl Provider {
     /// This provider's API key, or `None` when neither the environment
     /// nor `llmman.conf` has one. See [`key_for`].
     pub fn api_key(&self) -> Option<String> {
-        key_for(&self.id, &self.key_env)
+        key_for(&self.id, self.key_env.as_deref())
     }
 
     /// Appends an OpenAI route to this provider's base URL. See
@@ -308,11 +331,27 @@ impl Provider {
     pub fn url(&self, route: &str) -> String {
         rebase_url(&self.base_url, route)
     }
+
+    /// A provider as `llmman.conf` defines it. No models: the file names
+    /// an endpoint, not what it serves, and `cmd::serve` asks the
+    /// endpoint itself when a caller wants the list.
+    pub fn from_configured(conf: &crate::config::ConfiguredProvider) -> Self {
+        Self {
+            id: conf.id.clone(),
+            name: conf.name.clone(),
+            base_url: conf.base_url.clone(),
+            key_env: conf.key_env.clone(),
+            wire: conf.wire,
+            key_optional: true,
+            models: Vec::new(),
+        }
+    }
 }
 
 /// The API key for provider `id`: `var` from the environment, else the
 /// `[providers.<id>]` entry in `llmman.conf` (see [`crate::config`]).
-/// `None` when neither has one.
+/// `None` when neither has one — or when there is no variable to read
+/// and the file has nothing, the case for most configured providers.
 ///
 /// The environment wins, as it does for `aws` and `gh`: the file is the
 /// standing answer, an `export` the deliberate this-session-only
@@ -321,8 +360,11 @@ impl Provider {
 ///
 /// Free-standing because a `/llmman/providers` client learns only the id
 /// and the variable's *name* from the daemon, never a [`Provider`].
-pub fn key_for(id: &str, var: &str) -> Option<String> {
-    resolve_key(key_from_env(var), crate::config::provider_api_key(id))
+pub fn key_for(id: &str, var: Option<&str>) -> Option<String> {
+    resolve_key(
+        var.and_then(key_from_env),
+        crate::config::provider_api_key(id),
+    )
 }
 
 /// Split out so the precedence is testable without touching the process
@@ -346,12 +388,21 @@ fn key_from_env(var: &str) -> Option<String> {
 /// Both places llmman looks, named, for an error that fires because it
 /// found neither. One string so every such message agrees: a user told
 /// only about the variable would never learn the file exists.
-pub fn key_hint(id: &str, var: &str) -> String {
-    format!(
-        "set {var} in the environment, or add a [providers.{}] api_key to {}",
-        toml_key(id),
-        crate::config::user_path_display()
-    )
+pub fn key_hint(id: &str, var: Option<&str>) -> String {
+    match var {
+        Some(var) => format!(
+            "set {var} in the environment, or add a [providers.{}] api_key to {}",
+            toml_key(id),
+            crate::config::user_path_display()
+        ),
+        // A configured provider that names no variable: the file is the
+        // one place, so there is no "or".
+        None => format!(
+            "add an api_key to [providers.{}] in {}",
+            toml_key(id),
+            crate::config::user_path_display()
+        ),
+    }
 }
 
 /// `id` as a TOML key, quoted when it is not a bare one.
@@ -555,6 +606,46 @@ impl Catalog {
         );
         Ok(Self { providers })
     }
+
+    /// The providers `llmman.conf` defines, and nothing else — what a
+    /// machine that cannot reach models.dev still has (see [`catalog`]).
+    pub fn from_configured(configured: &[crate::config::ConfiguredProvider]) -> Self {
+        Self::default().with_configured(configured)
+    }
+
+    /// Adds the providers `llmman.conf` defines. One with a catalog id
+    /// shadows the catalog entry: the file is the user's deliberate
+    /// answer, and is also the only way to correct a catalog URL for a
+    /// network where it is wrong (a proxy in front of `api.openai.com`).
+    ///
+    /// A plaintext `base_url` with a key behind it is warned about here,
+    /// once per load, rather than refused as a catalog entry's would be:
+    /// the URL is the user's own, and `http://gpubox:8000` on a LAN is
+    /// the whole point — but a key on that wire is still a key on that
+    /// wire, and the file cannot say which the user weighed.
+    pub fn with_configured(mut self, configured: &[crate::config::ConfiguredProvider]) -> Self {
+        for conf in configured {
+            let provider = Provider::from_configured(conf);
+            if provider.base_url.starts_with("http://") && provider.api_key().is_some() {
+                eprintln!(
+                    "[llmman] warning: provider {} has an API key and a plain-http base_url \
+                     ({}); the key will cross the network in cleartext",
+                    provider.id, provider.base_url
+                );
+            }
+            if self
+                .providers
+                .insert(provider.id.clone(), provider)
+                .is_some()
+            {
+                crate::debug_log!(
+                    "provider catalog: {} from llmman.conf shadows the models.dev entry",
+                    conf.id
+                );
+            }
+        }
+        self
+    }
 }
 
 /// A models.dev catalog entry, narrowed to the fields llmman reads —
@@ -671,8 +762,9 @@ fn routable(id: &str, raw: RawProvider) -> Option<Provider> {
         id: id.to_string(),
         name: raw.name,
         base_url: base_url_of(base_url),
-        key_env,
+        key_env: Some(key_env),
         wire,
+        key_optional: false,
         // Sorted by id, since `models` came out of a BTreeMap.
         models: raw
             .models
@@ -729,12 +821,19 @@ static CATALOG: Mutex<Option<Cached>> = Mutex::new(None);
 /// The lock is held across the fetch, so concurrent callers wait for one
 /// load rather than racing several. Blocking: callers on an async runtime
 /// (`cmd::serve`) must go through `spawn_blocking`.
+///
+/// The providers `llmman.conf` defines are merged in on top (see
+/// [`Catalog::with_configured`]), and stand alone when models.dev cannot
+/// be loaded at all: a machine with no route out and a vLLM on the LAN
+/// is exactly where a defined provider is wanted, and must not be held
+/// hostage to a catalog it has no use for.
 pub fn catalog() -> anyhow::Result<Arc<Catalog>> {
     let mut cached = CATALOG.lock().unwrap_or_else(|e| e.into_inner());
     let live = cached
         .as_ref()
         .is_some_and(|(at, good_for, _)| at.elapsed() < *good_for);
     if !live {
+        let configured = crate::config::configured_providers();
         // A stale catalog is held only as long as a failure: what
         // produced it was a failed refresh, whatever it managed to
         // return. See Loaded.
@@ -742,8 +841,19 @@ pub fn catalog() -> anyhow::Result<Arc<Catalog>> {
             Ok(loaded) => (
                 Instant::now(),
                 loaded.good_for(),
-                Ok(Arc::new(loaded.into_catalog())),
+                Ok(Arc::new(loaded.into_catalog().with_configured(configured))),
             ),
+            Err(e) if !configured.is_empty() => {
+                eprintln!(
+                    "[llmman] using only the {} provider(s) defined in llmman.conf ({e:#})",
+                    configured.len()
+                );
+                (
+                    Instant::now(),
+                    RETRY_COOLDOWN,
+                    Ok(Arc::new(Catalog::from_configured(configured))),
+                )
+            }
             Err(e) => (Instant::now(), RETRY_COOLDOWN, Err(format!("{e:#}"))),
         });
     }
@@ -970,7 +1080,7 @@ mod tests {
         let p = catalog.get("openrouter").expect("openrouter is routable");
         assert_eq!(p.name, "OpenRouter");
         assert_eq!(p.base_url, "https://openrouter.ai/api/v1");
-        assert_eq!(p.key_env, "OPENROUTER_API_KEY");
+        assert_eq!(p.key_env.as_deref(), Some("OPENROUTER_API_KEY"));
         assert_eq!(p.wire, Wire::OpenAi);
         // Sorted by id; an unpriced model keeps `None`, not a zero.
         assert_eq!(
@@ -1015,14 +1125,14 @@ mod tests {
         );
         let anthropic = catalog.get("anthropic").expect("anthropic is routable");
         assert_eq!(anthropic.base_url, "https://api.anthropic.com/v1");
-        assert_eq!(anthropic.key_env, "ANTHROPIC_API_KEY");
+        assert_eq!(anthropic.key_env.as_deref(), Some("ANTHROPIC_API_KEY"));
         // Its own Messages API, never the OpenAI-compatibility shim.
         assert_eq!(anthropic.wire, Wire::Anthropic);
 
         // Three candidate variables in the catalog, one unambiguous
         // choice from the builtin.
         let google = catalog.get("google").expect("google is routable");
-        assert_eq!(google.key_env, "GEMINI_API_KEY");
+        assert_eq!(google.key_env.as_deref(), Some("GEMINI_API_KEY"));
         assert_eq!(google.wire, Wire::OpenAi);
     }
 
@@ -1174,7 +1284,11 @@ mod tests {
             );
             assert!(!p.base_url.ends_with('/'), "{}: {}", p.id, p.base_url);
             assert!(!p.base_url.contains("${"), "{}: {}", p.id, p.base_url);
-            assert!(!p.key_env.is_empty(), "{} has no key variable", p.id);
+            assert!(
+                p.key_env.as_deref().is_some_and(|v| !v.is_empty()),
+                "{} has no key variable",
+                p.id
+            );
         }
 
         // The providers someone actually reaches for, at the endpoints
@@ -1371,7 +1485,8 @@ mod tests {
             id: "groq".into(),
             name: "Groq".into(),
             base_url: "https://api.groq.com/openai/v1".into(),
-            key_env: "GROQ_API_KEY".into(),
+            key_env: Some("GROQ_API_KEY".into()),
+            key_optional: false,
             wire: Wire::OpenAi,
             models: vec![],
         };
@@ -1410,7 +1525,8 @@ mod tests {
             id: "test".into(),
             name: "Test".into(),
             base_url: "https://example.invalid/v1".into(),
-            key_env: "LLMMAN_TEST_PROVIDER_KEY_UNSET".into(),
+            key_env: Some("LLMMAN_TEST_PROVIDER_KEY_UNSET".into()),
+            key_optional: false,
             wire: Wire::OpenAi,
             models: vec![],
         };
@@ -1450,10 +1566,145 @@ mod tests {
     /// Both places, in one message.
     #[test]
     fn key_hint_names_the_variable_and_the_config_file() {
-        let hint = key_hint("openrouter", "OPENROUTER_API_KEY");
+        let hint = key_hint("openrouter", Some("OPENROUTER_API_KEY"));
         assert!(hint.contains("OPENROUTER_API_KEY"), "{hint}");
         assert!(hint.contains("[providers.openrouter]"), "{hint}");
         assert!(hint.contains("llmman.conf"), "{hint}");
+
+        // No variable to name: the file alone, and no dangling "or".
+        let hint = key_hint("gpubox", None);
+        assert!(hint.contains("[providers.gpubox]"), "{hint}");
+        assert!(hint.contains("llmman.conf"), "{hint}");
+        assert!(!hint.contains("environment"), "{hint}");
+    }
+
+    fn configured(id: &str, base_url: &str, wire: Wire) -> crate::config::ConfiguredProvider {
+        crate::config::ConfiguredProvider {
+            id: id.into(),
+            name: id.into(),
+            base_url: base_url.into(),
+            wire,
+            key_env: None,
+        }
+    }
+
+    /// A provider `llmman.conf` defines joins the catalog as a full
+    /// [`Provider`]: no models, no key demanded, plain `http` allowed —
+    /// none of which a catalog entry could get away with.
+    #[test]
+    fn configured_providers_join_the_catalog_with_key_optional() {
+        let catalog = catalog_from(
+            r#"{
+                "openrouter": {
+                    "id": "openrouter", "name": "OpenRouter",
+                    "api": "https://openrouter.ai/api/v1",
+                    "npm": "@openrouter/ai-sdk-provider",
+                    "env": ["OPENROUTER_API_KEY"],
+                    "models": { "m": {} }
+                }
+            }"#,
+        )
+        .with_configured(&[
+            configured("gpubox", "http://gpubox:8000/v1", Wire::OpenAi),
+            crate::config::ConfiguredProvider {
+                id: "relay".into(),
+                name: "Claude relay".into(),
+                base_url: "https://relay.example/v1".into(),
+                wire: Wire::Anthropic,
+                key_env: Some("RELAY_KEY".into()),
+            },
+        ]);
+
+        assert_eq!(catalog.len(), 3);
+        assert_eq!(
+            catalog.ids().collect::<Vec<_>>(),
+            ["gpubox", "openrouter", "relay"]
+        );
+
+        let gpubox = catalog.get("gpubox").unwrap();
+        assert_eq!(gpubox.base_url, "http://gpubox:8000/v1");
+        assert_eq!(gpubox.wire, Wire::OpenAi);
+        assert!(gpubox.key_optional);
+        assert_eq!(gpubox.key_env, None);
+        assert!(gpubox.models.is_empty());
+        assert_eq!(gpubox.api_key(), None);
+        assert_eq!(
+            gpubox.url("/v1/chat/completions"),
+            "http://gpubox:8000/v1/chat/completions"
+        );
+
+        let relay = catalog.get("relay").unwrap();
+        assert_eq!(relay.name, "Claude relay");
+        assert_eq!(relay.wire, Wire::Anthropic);
+        assert_eq!(relay.key_env.as_deref(), Some("RELAY_KEY"));
+        assert!(relay.key_optional);
+
+        // The catalog entry is as it was.
+        let openrouter = catalog.get("openrouter").unwrap();
+        assert!(!openrouter.key_optional);
+        assert_eq!(openrouter.models.len(), 1);
+    }
+
+    /// The file is the user's deliberate word, so it wins over the
+    /// catalog for the same id — the one way to point `openai` at a
+    /// proxy without renaming every integration's model.
+    #[test]
+    fn a_configured_provider_shadows_the_catalog_entry_with_its_id() {
+        let catalog = catalog_from(
+            r#"{
+                "openai": {
+                    "id": "openai", "name": "OpenAI",
+                    "npm": "@ai-sdk/openai", "env": ["OPENAI_API_KEY"],
+                    "models": { "gpt-5": {} }
+                }
+            }"#,
+        )
+        .with_configured(&[configured(
+            "openai",
+            "http://proxy.corp:4000/v1",
+            Wire::OpenAi,
+        )]);
+        assert_eq!(catalog.len(), 1);
+        let p = catalog.get("openai").unwrap();
+        assert_eq!(p.base_url, "http://proxy.corp:4000/v1");
+        assert!(p.key_optional);
+        assert!(
+            p.models.is_empty(),
+            "the catalog's models are not the proxy's"
+        );
+    }
+
+    /// With no models.dev at all — offline, or a first run with no cache
+    /// — the configured providers are still a catalog. That is the case
+    /// they exist for.
+    #[test]
+    fn configured_providers_stand_alone_without_the_catalog() {
+        let catalog = Catalog::from_configured(&[configured(
+            "gpubox",
+            "http://gpubox:8000/v1",
+            Wire::OpenAi,
+        )]);
+        assert_eq!(catalog.len(), 1);
+        assert!(catalog.get("gpubox").is_some());
+        assert!(Catalog::from_configured(&[]).is_empty());
+    }
+
+    /// `wire = "openai"` in the file is the same spelling the daemon's
+    /// API reports; anything else is a parse error, not a default.
+    #[test]
+    fn wire_deserializes_from_its_reported_name() {
+        #[derive(Deserialize)]
+        struct W {
+            wire: Wire,
+        }
+        let parse = |s: &str| toml::from_str::<W>(&format!("wire = {s:?}")).map(|w| w.wire);
+        assert_eq!(parse("openai").unwrap(), Wire::OpenAi);
+        assert_eq!(parse("anthropic").unwrap(), Wire::Anthropic);
+        assert!(parse("OpenAI").is_err());
+        assert!(parse("ollama").is_err());
+        for wire in [Wire::OpenAi, Wire::Anthropic] {
+            assert_eq!(parse(wire.as_str()).unwrap(), wire);
+        }
     }
 
     /// models.dev ships `wafer.ai`, and `[providers.wafer.ai]` is two
@@ -1462,9 +1713,9 @@ mod tests {
     #[test]
     fn key_hint_quotes_a_provider_id_that_is_not_a_bare_toml_key() {
         assert!(
-            key_hint("wafer.ai", "WAFER_API_KEY").contains(r#"[providers."wafer.ai"]"#),
+            key_hint("wafer.ai", Some("WAFER_API_KEY")).contains(r#"[providers."wafer.ai"]"#),
             "{}",
-            key_hint("wafer.ai", "WAFER_API_KEY")
+            key_hint("wafer.ai", Some("WAFER_API_KEY"))
         );
         assert_eq!(toml_key("openrouter"), "openrouter");
         assert_eq!(toml_key("z-ai"), "z-ai");


### PR DESCRIPTION
`--provider` only accepted models.dev catalog ids, so there was no way to route to an inference server on a host of your own (vLLM, llama-server, LM Studio, a proxy). A `[providers.<id>]` in `llmman.conf` that sets `base_url` now defines one:

```toml
[providers.gpubox]
base_url    = "http://gpubox:8000/v1"
wire        = "openai"          # default; or "anthropic"
api_key     = "..."             # optional
api_key_env = "GPUBOX_API_KEY"  # optional
name        = "GPU box"         # optional
```

```console
$ llmman config set providers.gpubox.base_url http://gpubox:8000/v1
$ llmman launch opencode --provider gpubox --model qwen3-coder
```

- Merged into the daemon's catalog, shadowing a catalog entry with the same id; `run`, `list`, `launch`, `--overflow-provider` all take it. Stands alone when models.dev is unreachable.
- Plain `http` and no key are allowed (the URL is the user's own, not fetched). Keyless requests send no credential header. A key over plain http is warned about by whichever process sends it.
- `base_url`/`wire` validated at parse time so `config set` refuses bad values; no userinfo, no `/` in ids.
- Models come from the endpoint's `GET /models` (OpenAI wire), not the file.
- An expired catalog is served while a background thread refreshes it, so no request waits on models.dev.
- CI: the flaky `upload-artifact` FinalizeArtifact 403 gets one retry.

Tested with `cargo test`/clippy/fmt, plus manually against a mock OpenAI server with and without a key.
