### PR TITLE
Generate images, video and audio from the web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,9 @@ your GPU if no `llama-server` is on `PATH`; safetensors by
 [`mlx-lm`](https://github.com/ml-explore/mlx-lm) on Apple Silicon. Tool
 calling, vision, structured output, embeddings (GGUF) and the Responses
 API (what Codex speaks) all work; there is a [web UI](docs/webui.md) at
-`/` (chat with any local or hosted model, and a terminal) and an optional
-Prometheus `/metrics`.
+`/` (chat with any local or hosted model, generate images, video and
+audio with a diffusion model, and a terminal) and an optional Prometheus
+`/metrics`.
 
 The full endpoint list and per-API notes are in [docs/api.md](docs/api.md);
 backend selection in [docs/backends.md](docs/backends.md); bind address,

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -13,19 +13,30 @@ The page has two modes, toggled at the top:
   loaded) and every hosted provider the daemon holds a usable key for
   (`/llmman/providers`; see [providers.md](providers.md)). Replies stream
   over `/v1/chat/completions`; a model's reasoning, when it emits any,
-  is shown collapsed above the answer. Local models that are not chat
-  models (image and video generation) are left out of the picker but
-  listed under *Models*. *Pull a model…* accepts any reference `llmman
-  pull` does — an OCI image, `hf.co/…`, `ms://…`, `ngc://…`, `s3://…`,
-  `gs://…` — and streams `/api/pull`'s progress.
+  is shown collapsed above the answer. *Pull a model…* accepts any
+  reference `llmman pull` does — an OCI image, `hf.co/…`, `ms://…`,
+  `ngc://…`, `s3://…`, `gs://…` — and streams `/api/pull`'s progress.
+
+  Diffusion models (`/api/show` capabilities `image`, `video` or `audio`
+  rather than `completion`) are listed under *Generate* in the same
+  picker. With one selected the composer generates instead, as `llmman
+  run` does: an Image / Video / Audio toggle picks what the prompt
+  becomes, and the settings button holds `run`'s flags — size, seconds,
+  steps, seed, guidance, negative prompt; blank is the model's default.
+  Images stream over `/v1/images/generations` with a step counter; a
+  video is one `/v1/videos` request and then its `content_url`; audio is
+  `/v1/audio/speech`. The result is the reply, with a Download button
+  that names the file as `run` does. Each prompt stands alone: a
+  diffusion model has no conversation. *Stop* abandons the request; a
+  video or audio generation already running finishes on the daemon.
 - **Shell** — a terminal on the machine running `llmman serve`, as the
   user running it: the login shell in a pty, bridged over a WebSocket at
   `/llmman/shell`. `llmman` itself is on `PATH` there, so `llmman launch
   claude --model …` or `llmman ps` work as they would in any terminal.
 
-Conversations are stored in the browser (IndexedDB), not by the daemon;
-*Settings* can export them as JSON or delete them. Theme follows the
-system unless set.
+Conversations and generated media are stored in the browser (IndexedDB),
+not by the daemon; *Settings* can export conversations as JSON (without
+the media) or delete them. Theme follows the system unless set.
 
 ## The shell's guard rails
 

--- a/webui/api.js
+++ b/webui/api.js
@@ -231,3 +231,86 @@ export async function chat({ model, messages, temperature, maxTokens, signal, on
   }
   return { finishReason };
 }
+
+// ---- Media generation ---------------------------------------------------
+//
+// A diffusion model answers on `/v1/images/generations`, `/v1/videos`
+// and `/v1/audio/speech`. Unset knobs are left out (the model's default).
+
+function blobFromBase64(b64, type) {
+  const bin = atob(b64);
+  const bytes = Uint8Array.from(bin, (c) => c.charCodeAt(0));
+  return new Blob([bytes], { type });
+}
+
+/** A response body as a Blob, typed `fallback` when the server sent no type. */
+async function typedBlob(response, fallback) {
+  const blob = await response.blob();
+  return blob.type ? blob : blob.slice(0, blob.size, fallback);
+}
+
+/** The knobs shared by the three routes, only those set; `omit` names the ones a route lacks. */
+function mediaFields({ width, height, steps, seed, cfgScale, negativePrompt, seconds }, omit = []) {
+  const body = {};
+  if (width > 0) body.width = Math.round(width);
+  if (height > 0) body.height = Math.round(height);
+  if (steps > 0) body.steps = Math.round(steps);
+  if (Number.isInteger(seed) && seed >= 0) body.seed = seed;
+  if (cfgScale > 0) body.cfg_scale = cfgScale;
+  if (negativePrompt?.trim()) body.negative_prompt = negativePrompt.trim();
+  if (seconds > 0) body.seconds = seconds;
+  for (const k of omit) delete body[k];
+  return body;
+}
+
+function imageResult(item) {
+  if (!item?.b64_json) throw new ApiError("the reply carried no image", 200);
+  return { blob: blobFromBase64(item.b64_json, "image/png"), revisedPrompt: item.revised_prompt || "" };
+}
+
+/**
+ * `POST /v1/images/generations`, streamed: `onProgress` gets `{step,
+ * total}` per denoising step. Resolves with `{blob, revisedPrompt}`.
+ */
+export async function generateImage({ model, prompt, signal, onProgress, ...opts }) {
+  const body = { model, prompt, stream: true, response_format: "b64_json", ...mediaFields(opts, ["seconds"]) };
+  const r = await postJson("v1/images/generations", body, { signal });
+  if (!(r.headers.get("content-type") || "").includes("text/event-stream")) {
+    return imageResult((await r.json()).data?.[0]); // a backend that does not stream
+  }
+  for await (const line of lines(r.body)) {
+    if (!line.startsWith("data:")) continue;
+    let ev;
+    try {
+      ev = JSON.parse(line.slice(5).trim());
+    } catch {
+      continue;
+    }
+    if (ev.type === "image_generation.progress") onProgress?.({ step: ev.step || 0, total: ev.total || 0 });
+    else if (ev.type === "image_generation.completed") return imageResult(ev);
+    else if (ev.type === "error") throw new ApiError(ev.error?.message || "image generation failed", 200);
+  }
+  throw new ApiError("the stream ended without an image", 200);
+}
+
+/** `POST /v1/videos` (synchronous), then `GET` its `content_url`. Resolves with `{blob, job}`. */
+export async function generateVideo({ model, prompt, fps, signal, ...opts }) {
+  const body = { model, prompt, stream: false, ...mediaFields(opts) };
+  if (fps > 0) body.fps = fps;
+  const job = await (await postJson("v1/videos", body, { signal })).json();
+  if (!job.content_url) {
+    const frames = job.n_frames || (job.frames || []).length;
+    throw new ApiError(`the server generated ${frames} frames but has no ffmpeg to mux an mp4`, 200);
+  }
+  // Relative, like every other path here, so a gateway prefix works.
+  const content = await fetch(String(job.content_url).replace(/^\/+/, ""), { signal });
+  if (!content.ok) throw await errorFrom(content);
+  return { blob: await typedBlob(content, "video/mp4"), job };
+}
+
+/** `POST /v1/audio/speech` (OpenAI's field is `input`). Resolves with `{blob}`, a wav. */
+export async function generateAudio({ model, prompt, signal, ...opts }) {
+  const body = { model, input: prompt, response_format: "wav", ...mediaFields(opts, ["width", "height"]) };
+  const r = await postJson("v1/audio/speech", body, { signal });
+  return { blob: await typedBlob(r, "audio/wav") };
+}

--- a/webui/app.css
+++ b/webui/app.css
@@ -411,6 +411,35 @@ code, pre, kbd { font-family: var(--font-mono); }
   white-space: pre-wrap;
 }
 
+/* Generated media */
+.media {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.4rem;
+  max-width: 100%;
+}
+.media img, .media video {
+  display: block;
+  max-width: 100%;
+  max-height: 70vh;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg-code);
+}
+.media video { width: min(100%, 48rem); }
+.media audio { display: block; width: min(100%, 28rem); }
+.media-caption {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}
+.media-progress {
+  flex: 1;
+  max-width: 14rem;
+}
+
 .thinking {
   font-family: var(--font-sans);
   margin-bottom: 0.75rem;
@@ -555,6 +584,31 @@ code, pre, kbd { font-family: var(--font-mono); }
 }
 .composer-left, .composer-right { display: flex; align-items: center; gap: 0.35rem; }
 
+/* Image / Video / Audio toggle */
+.kind-toggle {
+  display: inline-flex;
+  padding: 2px;
+  border-radius: 999px;
+  background: var(--bg-active);
+}
+.kind-toggle button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+.kind-toggle button svg { width: 0.95rem; height: 0.95rem; }
+.kind-toggle button:hover { color: var(--text); }
+.kind-toggle button[aria-pressed="true"] {
+  background: var(--bg-elevated);
+  color: var(--text-head);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+
 .model-btn {
   display: inline-flex;
   align-items: center;
@@ -695,7 +749,13 @@ code, pre, kbd { font-family: var(--font-mono); }
 .menu-foot-btn:hover { background: var(--bg-hover); color: var(--text); }
 .menu-foot-btn svg { width: 1rem; height: 1rem; }
 
-.prompt-settings { width: 22rem; max-width: calc(100vw - 2rem); padding: 0.85rem; display: flex; flex-direction: column; gap: 0.75rem; }
+.prompt-settings { width: 22rem; max-width: calc(100vw - 2rem); padding: 0.85rem; }
+.settings-chat, .settings-media { display: flex; flex-direction: column; gap: 0.75rem; }
+.settings-media .field-row > input { width: 8.5rem; }
+.size-pair { display: inline-flex; align-items: center; gap: 0.35rem; }
+.size-pair input { width: 5.2rem; }
+.settings-media[data-kind="audio"] .media-visual,
+.settings-media[data-kind="image"] .media-timed { display: none; }
 
 .field { display: flex; flex-direction: column; gap: 0.3rem; font-size: 0.88rem; }
 .field > span { color: var(--text-secondary); font-weight: 500; }
@@ -888,4 +948,8 @@ code, pre, kbd { font-family: var(--font-mono); }
   .topbar-title { display: none; }
   .greeting h1 { font-size: 1.6rem; }
   .msg-user .bubble { max-width: 95%; }
+  .composer-row { flex-wrap: wrap; gap: 0.35rem; }
+  .kind-toggle button span { display: none; }
+  .kind-toggle button { padding: 0.3rem 0.55rem; }
+  .model-btn { max-width: 11rem; }
 }

--- a/webui/app.js
+++ b/webui/app.js
@@ -255,7 +255,9 @@ function initSettingsDialog() {
 
   $("#export-chats").addEventListener("click", async () => {
     const all = await db.all();
-    const blob = new Blob([JSON.stringify(all, null, 2)], { type: "application/json" });
+    // Blobs have no JSON form; the Download button saves those.
+    const replacer = (_k, v) => (v instanceof Blob ? { type: v.type, size: v.size, omitted: true } : v);
+    const blob = new Blob([JSON.stringify(all, replacer, 2)], { type: "application/json" });
     const a = document.createElement("a");
     a.href = URL.createObjectURL(blob);
     a.download = `llmman-chats-${new Date().toISOString().slice(0, 10)}.json`;

--- a/webui/chat.js
+++ b/webui/chat.js
@@ -1,13 +1,15 @@
 // The conversation view: messages, composer, streaming replies. One
 // conversation (`current`) is open at a time and persisted after every
 // change; a streaming reply re-renders its markdown once per frame.
+// With a media generation model selected, each prompt becomes an image,
+// a video or an audio clip instead, shown inline as the reply.
 
 import * as api from "./api.js";
 import * as db from "./db.js";
 import * as models from "./models.js";
 import * as settings from "./settings.js";
 import { IncrementalRenderer } from "./markdown.js";
-import { $, toast, copyText, autosize, greeting, icon, iconButton, flashCopied } from "./util.js";
+import { $, $$, toast, copyText, autosize, greeting, icon, iconButton, flashCopied, formatBytes } from "./util.js";
 
 let current = null; // the open conversation, or null for a fresh one
 let streaming = null; // { abort: AbortController, node, message }
@@ -63,8 +65,13 @@ export function init() {
     stickToBottom = gap < 80;
   });
 
-  models.onChange(() => updateSendState());
+  models.onChange(() => {
+    updateSendState();
+    updateComposerMode();
+  });
   initPromptSettings();
+  initKindToggle();
+  updateComposerMode();
   updateGreeting();
   setInterval(updateGreeting, 60_000);
 }
@@ -90,6 +97,71 @@ function updateSendState() {
   send.disabled = !$("#prompt").value.trim() || !models.selected();
 }
 
+// ---- Media generation mode ----------------------------------------------
+//
+// The selected model's capabilities (from /api/show) are the kinds on
+// offer; the options live on the conversation under `media`.
+
+const MEDIA_DEFAULTS = { kind: "image", width: null, height: null, seconds: null, steps: null, seed: null, cfgScale: null, negativePrompt: "" };
+
+const PLACEHOLDERS = {
+  chat: "How can I help you today?",
+  image: "Describe the image to generate",
+  video: "Describe the video to generate",
+  audio: "Describe the sound to generate",
+};
+
+/** The media kinds the selected model generates; `[]` in chat mode. */
+function mediaKinds() {
+  return models.mediaCapabilities(models.selected());
+}
+
+/** `conv`'s media options (or the pending ones), with a kind the model offers. */
+function mediaOptions(conv = current, kinds = mediaKinds()) {
+  const opts = { ...MEDIA_DEFAULTS, ...(conv?.media ?? pendingSettings?.media ?? {}) };
+  if (kinds.length && !kinds.includes(opts.kind)) opts.kind = kinds[0];
+  return opts;
+}
+
+async function setMediaOptions(patch) {
+  await saveSettings({ media: { ...mediaOptions(), ...patch } });
+  updateComposerMode();
+}
+
+/** Onto the open conversation, or held for the next one. */
+async function saveSettings(patch) {
+  if (current) {
+    Object.assign(current, patch);
+    await persist();
+  } else {
+    pendingSettings = { ...pendingSettings, ...patch };
+  }
+}
+
+/** The kind toggle, placeholder and settings title follow the selected model. */
+function updateComposerMode() {
+  const kinds = mediaKinds();
+  const generating = kinds.length > 0;
+  const opts = mediaOptions(current, kinds);
+  $("#media-kind").classList.toggle("hidden", !generating);
+  for (const b of $$("#media-kind button")) {
+    const offered = kinds.includes(b.dataset.kind);
+    b.classList.toggle("hidden", !offered);
+    b.setAttribute("aria-pressed", String(offered && b.dataset.kind === opts.kind));
+  }
+  $("#prompt").placeholder = PLACEHOLDERS[generating ? opts.kind : "chat"];
+  const btn = $("#prompt-settings-btn");
+  btn.title = generating ? "Generation settings" : "Chat settings";
+  btn.setAttribute("aria-label", btn.title);
+  $("#settings-media").dataset.kind = opts.kind;
+}
+
+function initKindToggle() {
+  for (const b of $$("#media-kind button")) {
+    b.addEventListener("click", () => setMediaOptions({ kind: b.dataset.kind }));
+  }
+}
+
 // ---- Per-conversation settings popover --------------------------------
 
 function initPromptSettings() {
@@ -98,6 +170,15 @@ function initPromptSettings() {
   const sys = $("#system-prompt");
   const temp = $("#temperature");
   const max = $("#max-tokens");
+  const media = {
+    width: $("#media-width"),
+    height: $("#media-height"),
+    seconds: $("#media-seconds"),
+    steps: $("#media-steps"),
+    seed: $("#media-seed"),
+    cfgScale: $("#media-cfg"),
+    negativePrompt: $("#media-negative"),
+  };
   let open = false;
 
   const position = () => {
@@ -109,12 +190,17 @@ function initPromptSettings() {
   };
   const show = () => {
     open = true;
+    const generating = mediaKinds().length > 0;
+    $("#settings-chat").classList.toggle("hidden", generating);
+    $("#settings-media").classList.toggle("hidden", !generating);
+    const opts = mediaOptions();
+    for (const [k, input] of Object.entries(media)) input.value = opts[k] ?? "";
     sys.value = current?.systemPrompt ?? settings.get("systemPrompt") ?? "";
     temp.value = current?.temperature ?? "";
     max.value = current?.maxTokens ?? "";
     pop.classList.remove("hidden");
     position();
-    sys.focus();
+    (generating ? media.steps : sys).focus();
   };
   const hide = () => {
     open = false;
@@ -132,28 +218,37 @@ function initPromptSettings() {
   });
   window.addEventListener("resize", () => open && position());
 
+  // The inputs carry min/max/step; an invalid value is reported and not
+  // saved, so it never reaches a request.
+  const valid = (inputs) => {
+    const bad = inputs.find((i) => !i.checkValidity());
+    bad?.reportValidity();
+    return !bad;
+  };
+  const num = (input, int = false) => (input.value === "" ? null : int ? Math.floor(Number(input.value)) : Number(input.value));
+
   const save = async () => {
-    // The inputs carry min/max/step; an out-of-range value is reported
-    // and not saved, so it never reaches the request.
-    for (const input of [temp, max]) {
-      if (!input.checkValidity()) {
-        input.reportValidity();
-        return;
-      }
-    }
-    const patch = {
-      systemPrompt: sys.value,
-      temperature: temp.value === "" ? null : Number(temp.value),
-      maxTokens: max.value === "" ? null : Math.floor(Number(max.value)),
-    };
-    if (current) {
-      Object.assign(current, patch);
-      await persist();
-    } else {
-      pendingSettings = patch;
-    }
+    if (!valid([temp, max])) return;
+    await saveSettings({ systemPrompt: sys.value, temperature: num(temp), maxTokens: num(max, true) });
   };
   for (const input of [sys, temp, max]) input.addEventListener("change", save);
+
+  const saveMedia = async () => {
+    // Some backends need both dimensions or neither.
+    const half = (media.width.value === "") !== (media.height.value === "");
+    media.height.setCustomValidity(half ? "Set both width and height, or neither" : "");
+    if (!valid(Object.values(media))) return;
+    await setMediaOptions({
+      width: num(media.width, true),
+      height: num(media.height, true),
+      seconds: num(media.seconds),
+      steps: num(media.steps, true),
+      seed: num(media.seed, true),
+      cfgScale: num(media.cfgScale),
+      negativePrompt: media.negativePrompt.value,
+    });
+  };
+  for (const input of Object.values(media)) input.addEventListener("change", saveMedia);
 }
 
 let pendingSettings = null;
@@ -165,11 +260,13 @@ export function newConversation() {
   if (streaming) stop();
   current = null;
   pendingSettings = null;
+  releaseObjectUrls();
   $("#messages").replaceChildren();
   $("#view-chat").classList.add("empty");
   $("#topbar-title").textContent = "";
   $("#composer-status").textContent = "";
   stickToBottom = true;
+  updateComposerMode();
   $("#prompt").focus();
   changed();
 }
@@ -194,6 +291,7 @@ export async function open(id, stillWanted = () => true) {
   $("#view-chat").classList.remove("empty");
   $("#topbar-title").textContent = conv.title;
   stickToBottom = true;
+  updateComposerMode();
   requestAnimationFrame(scrollToBottom);
   changed();
   return true;
@@ -242,6 +340,7 @@ function ensureConversation(firstText) {
     systemPrompt: pendingSettings?.systemPrompt ?? settings.get("systemPrompt") ?? "",
     temperature: pendingSettings?.temperature ?? null,
     maxTokens: pendingSettings?.maxTokens ?? null,
+    media: pendingSettings?.media ?? null,
     messages: [],
   };
   pendingSettings = null;
@@ -287,29 +386,26 @@ async function submit() {
 /** Ask the model for the next assistant turn of `current`. */
 async function generate() {
   // Captured: the user can open another conversation mid-stream, and the
-  // cleanup below must land on this one.
+  // cleanup must land on this one.
   const conv = current;
   const model = conv.model || models.selected();
+  const generating = models.mediaCapabilities(model).length > 0;
+  // Mark the prompt: a generation prompt is not a chat turn (and a Retry
+  // may switch it either way).
+  const last = conv.messages.findLast((m) => m.role === "user");
+  if (last) last.generate = generating;
+  if (generating) return generateMedia(conv, model);
   const message = { role: "assistant", content: "", reasoning: "", model, at: Date.now() };
-  conv.messages.push(message);
-  const index = conv.messages.length - 1;
-  const node = renderMessage(message, index);
-  node.classList.add("streaming");
-  $("#messages").appendChild(node);
-  scrollToBottom();
-
-  const abort = new AbortController();
-  streaming = { abort, node, message };
-  updateSendState();
-
-  const status = node.querySelector(".msg-status");
+  const turn = beginTurn(conv, message);
+  const { node, status, abort } = turn;
   const remote = api.splitRemoteRef(model);
   status.textContent = !remote && !models.isLoaded(model) ? `Loading ${model}…` : "Thinking…";
-  const started = performance.now();
 
   const history = [];
   if (conv.systemPrompt?.trim()) history.push({ role: "system", content: conv.systemPrompt.trim() });
-  for (const m of conv.messages.slice(0, index)) {
+  for (const m of conv.messages.slice(0, turn.index)) {
+    // Media prompts and replies are not part of a chat.
+    if (m.generate || m.request) continue;
     if (m.role === "user" || (m.role === "assistant" && m.content)) {
       history.push({ role: m.role, content: m.content });
     }
@@ -354,33 +450,136 @@ async function generate() {
     });
     message.finishReason = result.finishReason;
     if (!remote) models.markLoaded(model, true);
-    if (conv === current) {
-      const secs = ((performance.now() - started) / 1000).toFixed(1);
-      $("#composer-status").textContent = `${models.displayName(model)} · ${secs}s`;
-    }
+    turn.done();
   } catch (e) {
-    if (e.name === "AbortError") message.stopped = true;
-    else message.error = e.message || String(e);
+    turn.fail(e);
   } finally {
     cancelAnimationFrame(frame);
     drain(true);
-    if (streaming?.message === message) streaming = null;
-    node.classList.remove("streaming");
-    status.textContent = "";
-    if (!message.content && !message.reasoning && message.stopped) {
-      // Nothing came back before the stop: drop the empty turn.
-      conv.messages.splice(index, 1);
-      node.remove();
-    } else {
-      if (!message.content && !message.reasoning && !message.error) {
-        message.error = "The model returned nothing.";
-      }
-      renderAssistantBody(node, message, false);
-    }
-    updateSendState();
-    await persist(conv);
-    if (conv === current && stickToBottom) scrollToBottom();
+    const empty = !message.content && !message.reasoning;
+    if (empty && !message.stopped && !message.error) message.error = "The model returned nothing.";
+    await endTurn(turn, empty && message.stopped);
   }
+}
+
+/**
+ * The media counterpart: the last user message is the prompt, the reply
+ * is one picture, clip or sound kept as a Blob on `message.media`.
+ */
+async function generateMedia(conv, model) {
+  const opts = mediaOptions(conv, models.mediaCapabilities(model));
+  const prompt = conv.messages.findLast((m) => m.role === "user")?.content || "";
+  const message = { role: "assistant", content: "", model, at: Date.now(), prompt, request: opts };
+  const turn = beginTurn(conv, message);
+  const { status, abort, started } = turn;
+
+  const fill = document.createElement("div");
+  fill.className = "bar-fill indeterminate";
+  const bar = document.createElement("div");
+  bar.className = "bar media-progress";
+  bar.appendChild(fill);
+  const text = document.createTextNode("");
+  status.replaceChildren(text, bar);
+  const loading = !models.isLoaded(model);
+  let steps = null; // {step, total} once the backend reports progress
+  const tick = () => {
+    if (steps?.total) {
+      text.textContent = `Generating ${opts.kind}… step ${steps.step}/${steps.total}`;
+      fill.classList.remove("indeterminate");
+      fill.style.width = `${Math.min(100, (100 * steps.step) / steps.total).toFixed(1)}%`;
+    } else {
+      const s = Math.floor((performance.now() - started) / 1000);
+      const verb = loading ? `Loading ${model}, then generating` : "Generating";
+      text.textContent = `${verb} ${opts.kind}… ${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+    }
+  };
+  tick();
+  const timer = setInterval(tick, 1000);
+
+  const request = { ...opts, model, prompt, signal: abort.signal };
+  try {
+    if (opts.kind === "video") {
+      const { blob, job } = await api.generateVideo(request);
+      const [w, h] = String(job.size || "").split("x").map(Number);
+      message.media = {
+        kind: "video",
+        blob,
+        width: w || null,
+        height: h || null,
+        seconds: Number(job.seconds) || null,
+        fps: job.fps || null,
+        hasAudio: job.has_audio ?? null,
+        revisedPrompt: job.revised_prompt || "",
+      };
+    } else if (opts.kind === "audio") {
+      const { blob } = await api.generateAudio(request);
+      message.media = { kind: "audio", blob, seconds: opts.seconds };
+    } else {
+      const onProgress = (p) => {
+        steps = p;
+        tick();
+      };
+      const { blob, revisedPrompt } = await api.generateImage({ ...request, onProgress });
+      message.media = { kind: "image", blob, revisedPrompt };
+    }
+    models.markLoaded(model, true);
+    turn.done();
+  } catch (e) {
+    turn.fail(e);
+  } finally {
+    clearInterval(timer);
+    status.replaceChildren();
+    await endTurn(turn, message.stopped);
+  }
+}
+
+/** Append `message` as the streaming assistant turn of `conv` and claim `streaming`. */
+function beginTurn(conv, message) {
+  conv.messages.push(message);
+  const index = conv.messages.length - 1;
+  const node = renderMessage(message, index);
+  node.classList.add("streaming");
+  $("#messages").appendChild(node);
+  scrollToBottom();
+  const abort = new AbortController();
+  streaming = { abort, node, message };
+  updateSendState();
+  const started = performance.now();
+  const model = message.model;
+  return {
+    conv,
+    message,
+    index,
+    node,
+    abort,
+    started,
+    status: node.querySelector(".msg-status"),
+    done() {
+      if (conv !== current) return;
+      const secs = ((performance.now() - started) / 1000).toFixed(1);
+      $("#composer-status").textContent = `${models.displayName(model)} · ${secs}s`;
+    },
+    fail(e) {
+      if (e.name === "AbortError") message.stopped = true;
+      else message.error = e.message || String(e);
+    },
+  };
+}
+
+/** Release `streaming`, render the final state (or drop the turn) and persist. */
+async function endTurn({ conv, message, index, node, status }, drop) {
+  if (streaming?.message === message) streaming = null;
+  node.classList.remove("streaming");
+  status.textContent = "";
+  if (drop) {
+    conv.messages.splice(index, 1);
+    node.remove();
+  } else {
+    renderAssistantBody(node, message, false);
+  }
+  updateSendState();
+  await persist(conv);
+  if (conv === current && stickToBottom) scrollToBottom();
 }
 
 export function stop() {
@@ -415,6 +614,7 @@ async function editFrom(index) {
       systemPrompt: keep.systemPrompt,
       temperature: keep.temperature,
       maxTokens: keep.maxTokens,
+      media: keep.media ?? null,
     };
     $("#view-chat").classList.add("empty");
     $("#topbar-title").textContent = "";
@@ -429,6 +629,7 @@ async function editFrom(index) {
 
 function renderAll() {
   const list = $("#messages");
+  releaseObjectUrls();
   list.replaceChildren();
   if (!current) return;
   current.messages.forEach((m, i) => list.appendChild(renderMessage(m, i)));
@@ -460,7 +661,12 @@ function renderMessage(message, index) {
   node.appendChild(status);
   const meta = document.createElement("div");
   meta.className = "msg-meta";
-  meta.appendChild(copyButton(message));
+  const copy = copyButton(message);
+  copy.classList.add("act-copy");
+  meta.appendChild(copy);
+  const save = iconButton("i-save", "Download", () => downloadMedia(message));
+  save.classList.add("act-download", "hidden");
+  meta.appendChild(save);
   meta.appendChild(iconButton("i-retry", "Retry", () => regenerateFrom(index)));
   const label = document.createElement("span");
   label.className = "msg-model";
@@ -490,8 +696,16 @@ function renderAssistantBody(node, message, live) {
       renderer: new IncrementalRenderer(content, { onCopy: (t) => copyText(t) }),
       thinking: null,
       collapsed: false,
+      media: null,
     };
     views.set(node, view);
+  }
+
+  if (message.media?.blob && !view.media) {
+    view.media = renderMedia(message);
+    view.body.insertBefore(view.media, view.content);
+    node.querySelector(".act-copy")?.classList.add("hidden");
+    node.querySelector(".act-download")?.classList.remove("hidden");
   }
 
   if (message.reasoning) {
@@ -542,6 +756,79 @@ function copyButton(message) {
   return iconButton("i-copy", "Copy", async (btn) => {
     if (await copyText(message.content)) flashCopied(btn);
   });
+}
+
+// ---- Generated media ---------------------------------------------------
+
+/** Object URLs for the media on screen; revoked whenever the list is rebuilt. */
+const objectUrls = new Map();
+function urlFor(blob) {
+  let url = objectUrls.get(blob);
+  if (!url) objectUrls.set(blob, (url = URL.createObjectURL(blob)));
+  return url;
+}
+function releaseObjectUrls() {
+  for (const url of objectUrls.values()) URL.revokeObjectURL(url);
+  objectUrls.clear();
+}
+
+/** The `<img>` / `<video>` / `<audio>` for a message's media, with a caption. */
+function renderMedia(message) {
+  const media = message.media;
+  const wrap = document.createElement("div");
+  wrap.className = `media media-${media.kind}`;
+  const caption = document.createElement("div");
+  caption.className = "media-caption";
+  const describe = () => {
+    const req = message.request || {};
+    const parts = [
+      media.width && media.height && `${media.width}×${media.height}`,
+      media.seconds && `${Number(media.seconds).toFixed(1).replace(/\.0$/, "")}s`,
+      media.fps && `${media.fps} fps`,
+      media.hasAudio && "with audio",
+      req.steps && `${req.steps} steps`,
+      Number.isInteger(req.seed) && `seed ${req.seed}`,
+      formatBytes(media.blob.size),
+    ];
+    caption.textContent = parts.filter(Boolean).join(" · ");
+  };
+  const el = document.createElement({ image: "img", video: "video", audio: "audio" }[media.kind]);
+  if (media.kind === "image") {
+    el.alt = message.prompt || "Generated image";
+    el.addEventListener("load", () => {
+      media.width ||= el.naturalWidth;
+      media.height ||= el.naturalHeight;
+      describe();
+    });
+  } else {
+    el.controls = true;
+    el.preload = "metadata";
+    el.playsInline = true;
+    el.addEventListener("loadedmetadata", () => {
+      if (Number.isFinite(el.duration)) media.seconds = el.duration;
+      describe();
+    });
+  }
+  el.src = urlFor(media.blob);
+  describe();
+  if (media.revisedPrompt) caption.title = `Prompt as enhanced by the model:\n${media.revisedPrompt}`;
+  wrap.append(el, caption);
+  return wrap;
+}
+
+/** Save as `<prompt slug>-<YYYYMMDD-HHMMSS>.<ext>`, the name `llmman run` uses. */
+function downloadMedia(message) {
+  const media = message.media;
+  if (!media?.blob) return;
+  const ext = { image: "png", video: "mp4", audio: "wav" }[media.kind];
+  const slug = (message.prompt || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 50);
+  const d = new Date(message.at || Date.now());
+  const p = (n) => String(n).padStart(2, "0");
+  const stamp = `${d.getFullYear()}${p(d.getMonth() + 1)}${p(d.getDate())}-${p(d.getHours())}${p(d.getMinutes())}${p(d.getSeconds())}`;
+  const a = document.createElement("a");
+  a.href = urlFor(media.blob);
+  a.download = `${slug || "image"}-${stamp}.${ext}`;
+  a.click();
 }
 
 function scrollToBottom() {

--- a/webui/db.js
+++ b/webui/db.js
@@ -1,7 +1,10 @@
 // Conversations in this browser's IndexedDB, one record each; the daemon
 // keeps none. A conversation:
 //   { id, title, model, createdAt, updatedAt, systemPrompt, temperature,
-//     maxTokens, messages: [{ role, content, reasoning?, model?, at }] }
+//     maxTokens, media?, messages: [{ role, content, reasoning?, model?, at,
+//     generate?, prompt?, request?, media?: { kind, blob, ... } }] }
+// The conversation's `media` is its generation options; a message's is the
+// generated picture, clip or sound, a Blob IndexedDB stores as is.
 
 const DB_NAME = "llmman";
 const DB_VERSION = 1;

--- a/webui/index.html
+++ b/webui/index.html
@@ -96,6 +96,18 @@
               <button class="icon-btn" id="prompt-settings-btn" title="Chat settings" aria-label="Chat settings">
                 <svg viewBox="0 0 24 24"><use href="#i-sliders"/></svg>
               </button>
+              <!-- With a media generation model: what the prompt becomes. -->
+              <div class="kind-toggle hidden" id="media-kind" role="group" aria-label="Output">
+                <button type="button" data-kind="image" aria-pressed="false" title="Generate an image">
+                  <svg viewBox="0 0 24 24"><use href="#i-image"/></svg><span>Image</span>
+                </button>
+                <button type="button" data-kind="video" aria-pressed="false" title="Generate a video">
+                  <svg viewBox="0 0 24 24"><use href="#i-video"/></svg><span>Video</span>
+                </button>
+                <button type="button" data-kind="audio" aria-pressed="false" title="Generate audio">
+                  <svg viewBox="0 0 24 24"><use href="#i-audio"/></svg><span>Audio</span>
+                </button>
+              </div>
             </div>
             <div class="composer-right">
               <button class="model-btn" id="model-btn" aria-haspopup="menu" aria-expanded="false">
@@ -126,20 +138,52 @@
         </div>
       </div>
 
-      <!-- Chat settings popover -->
+      <!-- Chat settings popover; media fields with a generation model. -->
       <div class="popover prompt-settings hidden" id="prompt-settings">
-        <label class="field">
-          <span>System prompt</span>
-          <textarea id="system-prompt" rows="4" placeholder="Optional instructions sent with every message in this conversation"></textarea>
-        </label>
-        <label class="field field-row">
-          <span>Temperature</span>
-          <input type="number" id="temperature" min="0" max="2" step="0.1" placeholder="model default">
-        </label>
-        <label class="field field-row">
-          <span>Max tokens</span>
-          <input type="number" id="max-tokens" min="1" step="1" placeholder="unlimited">
-        </label>
+        <div class="settings-chat" id="settings-chat">
+          <label class="field">
+            <span>System prompt</span>
+            <textarea id="system-prompt" rows="4" placeholder="Optional instructions sent with every message in this conversation"></textarea>
+          </label>
+          <label class="field field-row">
+            <span>Temperature</span>
+            <input type="number" id="temperature" min="0" max="2" step="0.1" placeholder="model default">
+          </label>
+          <label class="field field-row">
+            <span>Max tokens</span>
+            <input type="number" id="max-tokens" min="1" step="1" placeholder="unlimited">
+          </label>
+        </div>
+        <div class="settings-media hidden" id="settings-media">
+          <div class="field field-row media-visual" role="group" aria-labelledby="media-size-label">
+            <span id="media-size-label">Size</span>
+            <span class="size-pair">
+              <input type="number" id="media-width" min="32" max="4096" step="32" placeholder="768" aria-label="Width">
+              <span class="muted">×</span>
+              <input type="number" id="media-height" min="32" max="4096" step="32" placeholder="512" aria-label="Height">
+            </span>
+          </div>
+          <label class="field field-row media-timed">
+            <span>Seconds</span>
+            <input type="number" id="media-seconds" min="0.5" max="42" step="0.5" placeholder="model default">
+          </label>
+          <label class="field field-row">
+            <span>Steps</span>
+            <input type="number" id="media-steps" min="1" max="200" step="1" placeholder="model default">
+          </label>
+          <label class="field field-row">
+            <span>Seed</span>
+            <input type="number" id="media-seed" min="0" max="4294967295" step="1" placeholder="random">
+          </label>
+          <label class="field field-row">
+            <span>Guidance</span>
+            <input type="number" id="media-cfg" min="0" max="30" step="0.5" placeholder="model default">
+          </label>
+          <label class="field">
+            <span>Negative prompt</span>
+            <textarea id="media-negative" rows="2" placeholder="What to keep out (guidance above 1 applies it)"></textarea>
+          </label>
+        </div>
       </div>
     </section>
 
@@ -266,6 +310,10 @@
     <symbol id="i-dots" viewBox="0 0 24 24"><circle cx="6" cy="12" r="1.7" fill="currentColor"/><circle cx="12" cy="12" r="1.7" fill="currentColor"/><circle cx="18" cy="12" r="1.7" fill="currentColor"/></symbol>
     <symbol id="i-cloud" viewBox="0 0 24 24"><path d="M7 18a4 4 0 0 1-.5-8A6 6 0 0 1 18 9a4.5 4.5 0 0 1-.5 9H7z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/></symbol>
     <symbol id="i-chip" viewBox="0 0 24 24"><rect x="6" y="6" width="12" height="12" rx="2" fill="none" stroke="currentColor" stroke-width="1.8"/><path d="M9 2.5v3M15 2.5v3M9 18.5v3M15 18.5v3M2.5 9h3M2.5 15h3M18.5 9h3M18.5 15h3" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></symbol>
+    <symbol id="i-image" viewBox="0 0 24 24"><rect x="3.5" y="4.5" width="17" height="15" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.8"/><circle cx="9" cy="9.5" r="1.6" fill="currentColor"/><path d="M4.5 17.5l5-5 3.5 3.5 2.5-2.5 4 4" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" stroke-linecap="round"/></symbol>
+    <symbol id="i-video" viewBox="0 0 24 24"><rect x="3" y="6" width="13" height="12" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.8"/><path d="M16 10.5l5-3v9l-5-3z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/></symbol>
+    <symbol id="i-audio" viewBox="0 0 24 24"><path d="M4 10v4M8 7v10M12 4v16M16 8v8M20 10.5v3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
+    <symbol id="i-save" viewBox="0 0 24 24"><path d="M12 4v10M8 10.5l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/><path d="M4 15v3a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-3" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></symbol>
   </defs>
 </svg>
 

--- a/webui/models.js
+++ b/webui/models.js
@@ -50,7 +50,7 @@ export function displayName(ref) {
 export function isAvailable(ref) {
   const remote = api.splitRemoteRef(ref);
   if (remote) return state.providers.some((p) => p.id === remote.provider);
-  return state.local.some((m) => m.id === ref && chattable(m));
+  return state.local.some((m) => m.id === ref && usable(m));
 }
 
 export function isLoaded(ref) {
@@ -84,15 +84,16 @@ export async function refresh({ quiet = false } = {}) {
         }))
         .sort((a, b) => a.name.localeCompare(b.name));
       state.loadedAt = Date.now();
-      // First run with nothing chosen: pick a loaded chat model, else the
-      // first chat model, so the composer is usable immediately.
+      // Nothing chosen yet: a loaded chat model, else the first chat model,
+      // else a media model, so the composer is usable immediately.
       if (!state.selected || !knownRef(state.selected)) {
         const chat = state.local.filter(chattable);
-        const pick = chat.find((m) => m.loaded) || chat[0];
+        const pick = chat.find((m) => m.loaded) || chat[0] || state.local.find(generative);
         if (pick) select(pick.id);
         else if (state.selected && !knownRef(state.selected)) select("");
       } else {
         $("#model-btn-name").textContent = displayName(state.selected);
+        emit(); // the capabilities may be new (a restored selection)
       }
     } catch (e) {
       if (!quiet) toast(`Could not list models: ${e.message}`, "error");
@@ -104,10 +105,10 @@ export async function refresh({ quiet = false } = {}) {
 }
 
 /**
- * `/api/show` per local model, for its capabilities: a store holds image
- * and video generation models too, and the chat picker should not offer
- * those. Cached by reference across refreshes; a failure leaves `null`,
- * which counts as chattable rather than hiding a model on a hiccup.
+ * `/api/show` per local model, for its capabilities: chat models and
+ * media generation models are offered differently. Cached by reference; a
+ * failure leaves `null`, which counts as chattable rather than hiding a
+ * model on a hiccup.
  */
 const capabilityCache = new Map();
 async function annotateCapabilities(local) {
@@ -131,6 +132,27 @@ export function chattable(m) {
   return !m.capabilities || m.capabilities.includes("completion");
 }
 
+/** The media a local model generates, in the composer's order; `[]` for a chat model. */
+function mediaOf(m) {
+  return ["image", "video", "audio"].filter((k) => m.capabilities?.includes(k));
+}
+
+/** Whether a local model generates media rather than text. */
+function generative(m) {
+  return !chattable(m) && mediaOf(m).length > 0;
+}
+
+/** Whether the picker offers a local model at all. */
+function usable(m) {
+  return chattable(m) || generative(m);
+}
+
+/** The media kinds `ref` generates; `[]` for a chat model, a hosted one or an unknown ref. */
+export function mediaCapabilities(ref) {
+  const m = state.local.find((m) => m.id === ref);
+  return m && generative(m) ? mediaOf(m) : [];
+}
+
 /** Capabilities that are not chat, for a label: "image", "video", ... */
 function otherCapabilities(m) {
   return (m.capabilities || []).filter((c) => c !== "completion" && c !== "vision" && c !== "tools").join(" · ");
@@ -138,7 +160,7 @@ function otherCapabilities(m) {
 
 function knownRef(ref) {
   if (api.splitRemoteRef(ref)) return true; // provider models are checked lazily
-  return state.local.some((m) => m.id === ref && chattable(m));
+  return state.local.some((m) => m.id === ref && usable(m));
 }
 
 async function ensureProviderModels() {
@@ -237,6 +259,7 @@ function renderMenu() {
   body.replaceChildren();
 
   const chatModels = state.local.filter(chattable);
+  const mediaModels = state.local.filter(generative);
   const local = chatModels.filter((m) => match(m.id));
   body.appendChild(section("i-chip", "Local"));
   if (!local.length) {
@@ -244,8 +267,8 @@ function renderMenu() {
       emptyRow(
         chatModels.length
           ? "No local model matches."
-          : state.local.length
-            ? "No local chat models — the store has only image/video models."
+          : mediaModels.length
+            ? "No local chat models — the store has only media generation models."
             : "No local models yet — pull one below, or `llmman pull <ref>`.",
       ),
     );
@@ -261,9 +284,21 @@ function renderMenu() {
       }),
     );
   }
-  const others = state.local.filter((m) => !chattable(m)).length;
-  if (others && !q) {
-    body.appendChild(emptyRow(`${others} image/video model${others === 1 ? "" : "s"} not shown — see Models.`));
+
+  const media = mediaModels.filter((m) => match(m.id) || mediaOf(m).some(match));
+  if (media.length) {
+    body.appendChild(section("i-image", "Generate"));
+    for (const m of media) {
+      body.appendChild(
+        menuItem({
+          ref: m.id,
+          name: m.id,
+          sub: [mediaOf(m).join(" · "), m.loaded ? "loaded" : ""].filter(Boolean).join(" · "),
+          dot: m.loaded ? "ok" : "",
+          eject: m.loaded,
+        }),
+      );
+    }
   }
 
   for (const p of state.providers) {
@@ -441,7 +476,7 @@ async function startPull() {
     // What appeared is what was pulled; if it was already there, match
     // the reference as the daemon canonicalizes it.
     const local =
-      state.local.find((m) => !before.has(m.id) && chattable(m)) ||
+      state.local.find((m) => !before.has(m.id) && usable(m)) ||
       state.local.find((m) => sameModel(m.id, ref));
     if (local) select(local.id);
     $("#pull-dialog").close();
@@ -520,9 +555,10 @@ async function renderModelsDialog() {
     row.appendChild(size);
     const actions = document.createElement("span");
     actions.className = "actions";
-    if (!known || chattable(known)) {
+    if (!known || usable(known)) {
+      const use = known && generative(known) ? `Use to generate ${mediaOf(known).join("/")}` : "Use in chat";
       actions.appendChild(
-        iconButton("i-check", "Use in chat", () => {
+        iconButton("i-check", use, () => {
           select(m.name);
           $("#models-dialog").close();
         }),


### PR DESCRIPTION
The [blog post](https://llmmanorg.github.io/blog/image-audio-and-video-generation/) covers image, video and audio generation (#437), but the web UI hid diffusion models from its picker, so none of the three could be used from the page.

- Diffusion models (`/api/show` capabilities `image`/`video`/`audio`) are listed under **Generate** in the picker.
- With one selected, an **Image / Video / Audio** toggle appears (only the kinds the model supports) and the settings popover offers `llmman run`'s knobs: size, seconds, steps, seed, guidance, negative prompt.
- Images stream with a step counter; video is one `/v1/videos` job then its `content_url`; audio is `/v1/audio/speech`. The result renders inline with a Download button named as `run` names its files.
- Media is stored in IndexedDB as Blobs and left out of the JSON export.

Review comments addressed: width/height must be set together (vLLM-Omni), media turns are excluded from chat history, object URLs are revoked when the list is rebuilt, the toggle uses `aria-pressed` buttons rather than a fake radiogroup, seconds are capped at 42 (1025 frames at 24 fps). Not addressed: Stop cancelling a running video/audio generation on the daemon — that is backend work (the CLI has the same behaviour) and is noted in the docs.

Tested with Playwright against `LLMMAN_WEBUI_DIR=webui llmman serve`: request bodies for all three routes, the SSE progress path, IndexedDB round trip after reload, export, Stop/Retry, and real image generation end to end with `ai/cosmos3-edge`. Video and audio were mocked (`ltx-2.3` needs more memory than this machine has).
