### PR TITLE
Stop the multipart test tripping on a boundary that spells bad

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -11184,7 +11184,10 @@ mod tests {
         ]);
         let filtered = String::from_utf8(filtered).unwrap();
         assert!(filtered.contains("name=\"ok_1\""));
-        assert!(!filtered.contains("bad"), "{filtered}");
+        // Look for the field, not the bare word: the boundary is hex from
+        // the clock and does spell "bad" now and then.
+        assert!(!filtered.contains("name=\"bad\""), "{filtered}");
+        assert!(!filtered.contains("X: y"), "{filtered}");
         // a value containing the would-be boundary forces a different one
         let (_, ct2) = multipart_form(&[("prompt".to_string(), format!("x{boundary}y"))]);
         assert_ne!(ct2, content_type);


### PR DESCRIPTION
The boundary `multipart_form` builds is hex from the clock, so now and then it spells "bad", and the test's `!filtered.contains("bad")` fails on the boundary rather than the field it meant to check. Failed on the aarch64 Linux job of #457. The assertion now looks for the field name, and also checks the injected header line is gone.