### PR TITLE
Link safetensors cache files to OCI blobs

### DIFF
--- a/src/modelpack.rs
+++ b/src/modelpack.rs
@@ -688,14 +688,9 @@ fn extract_safetensors_dir(
             Err(e) => return Err(e).with_context(|| format!("remove {}", dest.display())),
         }
         let blob = raw_blob_path(store_path, layer)?;
-        let linked = link_or_symlink_file(&blob, &dest)
-            .with_context(|| format!("link {rel_path} from blob store"));
-        if let Err(e) = linked {
-            if !cached_layer_file_matches(&dest, layer.size) {
-                return Err(e);
-            }
-        }
-        eprintln!("[llmman] linked {rel_path}");
+        link_or_copy_file(&blob, &dest, layer.size)
+            .with_context(|| format!("cache {rel_path} from blob store"))?;
+        eprintln!("[llmman] cached {rel_path}");
     }
 
     let rel_paths: Vec<&str> = manifest
@@ -713,32 +708,58 @@ fn cached_layer_file_matches(dest: &Path, layer_size: u64) -> bool {
         .unwrap_or(false)
 }
 
-fn link_or_symlink_file(src: &Path, dest: &Path) -> anyhow::Result<()> {
-    match std::fs::hard_link(src, dest) {
-        Ok(()) => Ok(()),
-        Err(hardlink_error) => {
-            let src = src
-                .canonicalize()
-                .with_context(|| format!("canonicalize {}", src.display()))?;
-            symlink_file(&src, dest).with_context(|| {
+fn link_or_copy_file(src: &Path, dest: &Path, layer_size: u64) -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        match std::fs::hard_link(src, dest) {
+            Ok(()) => Ok(()),
+            Err(_) if cached_layer_file_matches(dest, layer_size) => Ok(()),
+            Err(hardlink_error) => copy_file_atomic(src, dest, layer_size).with_context(|| {
                 format!(
-                    "hardlink {} to {} failed: {hardlink_error}; symlink failed",
+                    "hardlink {} to {} failed: {hardlink_error}; copy failed",
                     src.display(),
                     dest.display()
                 )
-            })
+            }),
         }
+    }
+    #[cfg(not(unix))]
+    {
+        copy_file_atomic(src, dest, layer_size)
     }
 }
 
-#[cfg(unix)]
-fn symlink_file(src: &Path, dest: &Path) -> std::io::Result<()> {
-    std::os::unix::fs::symlink(src, dest)
+fn copy_file_atomic(src: &Path, dest: &Path, layer_size: u64) -> anyhow::Result<()> {
+    let tmp = cache_copy_temp_path(dest);
+    let result = (|| {
+        let copied = std::fs::copy(src, &tmp)
+            .with_context(|| format!("copy {} to {}", src.display(), tmp.display()))?;
+        if copied != layer_size {
+            anyhow::bail!("copied {copied} bytes, expected {layer_size}");
+        }
+        match std::fs::rename(&tmp, dest) {
+            Ok(()) => Ok(()),
+            Err(_) if cached_layer_file_matches(dest, layer_size) => Ok(()),
+            Err(e) => {
+                Err(e).with_context(|| format!("rename {} to {}", tmp.display(), dest.display()))
+            }
+        }
+    })();
+    if result.is_err() || tmp.exists() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    result
 }
 
-#[cfg(windows)]
-fn symlink_file(src: &Path, dest: &Path) -> std::io::Result<()> {
-    std::os::windows::fs::symlink_file(src, dest)
+fn cache_copy_temp_path(dest: &Path) -> PathBuf {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let mut tmp = dest.to_path_buf().into_os_string();
+    tmp.push(format!(
+        ".{}.{}.tmp",
+        std::process::id(),
+        COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    PathBuf::from(tmp)
 }
 
 #[cfg(test)]
@@ -1115,6 +1136,33 @@ mod tests {
             (dest_meta.dev(), dest_meta.ino()),
             (blob_meta.dev(), blob_meta.ino())
         );
+    }
+
+    #[test]
+    fn copy_file_atomic_replaces_dest_through_temp_file() {
+        let dir = std::env::temp_dir().join(format!(
+            "llmman-modelpack-copy-file-atomic-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let src = dir.join("blob");
+        let dest = dir.join("model.safetensors");
+        let weights = b"complete-weights-bytes";
+        std::fs::write(&src, weights).unwrap();
+        std::fs::write(&dest, b"trunc").unwrap();
+
+        copy_file_atomic(&src, &dest, weights.len() as u64).unwrap();
+
+        assert_eq!(std::fs::read(&dest).unwrap(), weights);
+        assert!(
+            std::fs::read_dir(&dir)
+                .unwrap()
+                .flatten()
+                .all(|e| !e.file_name().to_string_lossy().contains(".tmp")),
+            "copy temp file should not remain"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 
     #[test]

--- a/src/modelpack.rs
+++ b/src/modelpack.rs
@@ -677,20 +677,25 @@ fn extract_safetensors_dir(
             continue;
         }
         let dest = cache_dir.join(rel_path);
-        // exists() is not complete: a killed copy can leave a short dest.
-        if dest
-            .metadata()
-            .map(|m| m.is_file() && m.len() == layer.size)
-            .unwrap_or(false)
-        {
+        if cached_layer_file_matches(&dest, layer.size) {
             continue;
         }
 
         std::fs::create_dir_all(dest.parent().context("no parent")?)?;
-        let layer_hex = digest_hex(&layer.digest)?;
-        let blob = store_path.join("blobs").join("sha256").join(layer_hex);
-        std::fs::copy(&blob, &dest).with_context(|| format!("copy {rel_path} from blob store"))?;
-        eprintln!("[llmman] extracted {rel_path}");
+        match std::fs::remove_file(&dest) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e).with_context(|| format!("remove {}", dest.display())),
+        }
+        let blob = raw_blob_path(store_path, layer)?;
+        let linked = link_or_symlink_file(&blob, &dest)
+            .with_context(|| format!("link {rel_path} from blob store"));
+        if let Err(e) = linked {
+            if !cached_layer_file_matches(&dest, layer.size) {
+                return Err(e);
+            }
+        }
+        eprintln!("[llmman] linked {rel_path}");
     }
 
     let rel_paths: Vec<&str> = manifest
@@ -700,6 +705,40 @@ fn extract_safetensors_dir(
         .filter(|p| crate::sources::is_safe_relative_path(p))
         .collect();
     Ok(safetensors_model_dir(&cache_dir, &rel_paths))
+}
+
+fn cached_layer_file_matches(dest: &Path, layer_size: u64) -> bool {
+    dest.metadata()
+        .map(|m| m.is_file() && m.len() == layer_size)
+        .unwrap_or(false)
+}
+
+fn link_or_symlink_file(src: &Path, dest: &Path) -> anyhow::Result<()> {
+    match std::fs::hard_link(src, dest) {
+        Ok(()) => Ok(()),
+        Err(hardlink_error) => {
+            let src = src
+                .canonicalize()
+                .with_context(|| format!("canonicalize {}", src.display()))?;
+            symlink_file(&src, dest).with_context(|| {
+                format!(
+                    "hardlink {} to {} failed: {hardlink_error}; symlink failed",
+                    src.display(),
+                    dest.display()
+                )
+            })
+        }
+    }
+}
+
+#[cfg(unix)]
+fn symlink_file(src: &Path, dest: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(src, dest)
+}
+
+#[cfg(windows)]
+fn symlink_file(src: &Path, dest: &Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_file(src, dest)
 }
 
 #[cfg(test)]
@@ -1028,10 +1067,54 @@ mod tests {
         let digest = format!("sha256:{}", "bb".repeat(32));
         extract_safetensors_dir(store.root(), &cache, &digest, &manifest).unwrap();
         assert_eq!(std::fs::read(&dest).unwrap(), weights);
+    }
 
-        std::fs::remove_file(&blob).unwrap();
+    #[test]
+    fn extract_safetensors_dir_skips_dest_that_already_matches_layer_size() {
+        let weights = b"complete-weights-bytes";
+        let layer_hex = "aa".repeat(32);
+        let mut layer = descriptor(&format!("sha256:{layer_hex}"), "model.safetensors");
+        layer.media_type = "application/vnd.cncf.model.weight.v1.raw".into();
+        layer.size = weights.len() as u64;
+        let (store, manifest) = manifest_with(vec![layer]);
+
+        let cache = store.root().join("cache");
+        let dest = cache.join("bb".repeat(32)).join("model.safetensors");
+        std::fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        std::fs::write(&dest, weights).unwrap();
+
+        let digest = format!("sha256:{}", "bb".repeat(32));
         extract_safetensors_dir(store.root(), &cache, &digest, &manifest).unwrap();
         assert_eq!(std::fs::read(&dest).unwrap(), weights);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_safetensors_dir_links_dest_to_blob() {
+        use std::os::unix::fs::MetadataExt;
+
+        let weights = b"complete-weights-bytes";
+        let layer_hex = "aa".repeat(32);
+        let mut layer = descriptor(&format!("sha256:{layer_hex}"), "model.safetensors");
+        layer.media_type = "application/vnd.cncf.model.weight.v1.raw".into();
+        layer.size = weights.len() as u64;
+        let (store, manifest) = manifest_with(vec![layer]);
+
+        let blob = store.root().join("blobs").join("sha256").join(&layer_hex);
+        std::fs::create_dir_all(blob.parent().unwrap()).unwrap();
+        std::fs::write(&blob, weights).unwrap();
+
+        let cache = store.root().join("cache");
+        let dest = cache.join("bb".repeat(32)).join("model.safetensors");
+        let digest = format!("sha256:{}", "bb".repeat(32));
+        extract_safetensors_dir(store.root(), &cache, &digest, &manifest).unwrap();
+
+        let dest_meta = std::fs::metadata(&dest).unwrap();
+        let blob_meta = std::fs::metadata(&blob).unwrap();
+        assert_eq!(
+            (dest_meta.dev(), dest_meta.ino()),
+            (blob_meta.dev(), blob_meta.ino())
+        );
     }
 
     #[test]

--- a/src/storage/gc.rs
+++ b/src/storage/gc.rs
@@ -99,7 +99,7 @@ pub fn prune_blobs(
         if !is_older_than(&path, grace) {
             continue;
         }
-        let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+        let size = freed_file_size(&path);
         if let Err(e) = std::fs::remove_file(&path) {
             eprintln!("[llmman] couldn't remove unreferenced blob {name}: {e:#}");
             continue;
@@ -179,12 +179,29 @@ fn dir_size(dir: &Path) -> u64 {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return 0;
     };
-    entries
-        .flatten()
-        .filter_map(|e| e.metadata().ok())
-        .filter(|m| m.is_file())
-        .map(|m| m.len())
-        .sum()
+    entries.flatten().map(|e| freed_file_size(&e.path())).sum()
+}
+
+fn freed_file_size(path: &Path) -> u64 {
+    let Ok(meta) = std::fs::symlink_metadata(path) else {
+        return 0;
+    };
+    if meta.is_file() && !has_multiple_links(&meta) {
+        meta.len()
+    } else {
+        0
+    }
+}
+
+#[cfg(unix)]
+fn has_multiple_links(meta: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt as _;
+    meta.nlink() > 1
+}
+
+#[cfg(not(unix))]
+fn has_multiple_links(_meta: &std::fs::Metadata) -> bool {
+    false
 }
 
 /// Skips both the post-`rm` and startup GC sweeps when `LLMMAN_NOPRUNE` is
@@ -284,6 +301,30 @@ mod tests {
         assert!(!cache.join("bbbb").exists(), "orphan cache dir removed");
 
         std::fs::remove_dir_all(&cache).unwrap();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn prune_counts_hardlinked_blob_and_cache_bytes_once() {
+        let root = temp_dir("prune-hardlinked-cache");
+        let blobs = root.join("blobs").join("sha256");
+        let cache = root.join("cache");
+        std::fs::create_dir_all(&blobs).unwrap();
+        std::fs::create_dir_all(cache.join("bbbb")).unwrap();
+        let blob = blobs.join("aaaa");
+        let cache_file = cache.join("bbbb").join("model.safetensors");
+        let weights = b"complete-weights-bytes";
+        std::fs::write(&blob, weights).unwrap();
+        std::fs::hard_link(&blob, &cache_file).unwrap();
+
+        let live = HashSet::new();
+        let blob_stats = prune_blobs(&root, &live, Duration::ZERO).unwrap();
+        let cache_stats = prune_cache(&cache, &live, Duration::ZERO).unwrap();
+
+        assert_eq!(blob_stats.count, 1);
+        assert_eq!(cache_stats.count, 1);
+        assert_eq!(blob_stats.bytes + cache_stats.bytes, weights.len() as u64);
+        std::fs::remove_dir_all(&root).unwrap();
     }
 
     /// A corrupt (unparsable) manifest pointer file must abort the live-set


### PR DESCRIPTION
This PR is:

- To follow up on #449.
- To avoid copying safetensors weights into the cache.
- To link cache files to the existing OCI blob instead.

#449 made llmman stop trusting incomplete cache files.

This follow-up keeps that check, but changes the happy path from copying the weight file to linking it. That avoids storing the same multi-GB model weights twice while keeping the cache layout that vLLM and MLX expect.