### PR TITLE
Offer a model's own thinking levels to launched agents

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -58,6 +58,11 @@ chunk carries Ollama's counts and durations (`prompt_eval_count`,
 `llama-server` is started with `--embeddings` for it, so `/v1/embeddings`
 works too.
 
+`think` is `true`/`false` or a level (`minimal`, `low`, `medium`,
+`high`, `xhigh`, `max`), forwarded as llama-server's
+`chat_template_kwargs`. `/api/show` returns `capabilities` and, for a
+local model with one, `template`.
+
 `/api/create` supports `from` (alias a model) and `files` (GGUFs uploaded
 via `/api/blobs/{digest}`, as `ollama create` does). Modelfile fields such
 as `system` or `quantize` are refused with a 400: the GGUF's own chat
@@ -82,6 +87,12 @@ models get `max_completion_tokens` and lose the sampling overrides they
 refuse. `previous_response_id` is refused when `/v1/responses` has to be
 bridged through chat completions: nothing is stored to resolve it against.
 
+A local `/v1/chat/completions` with `reasoning_effort` also gets the
+`chat_template_kwargs` Ollama's `think` would (`none` →
+`enable_thinking: false`; a level → `enable_thinking: true` plus
+`reasoning_effort`), so it works on llama-server builds that do not read
+`reasoning_effort` themselves. The caller's own kwargs are kept.
+
 `/v1/audio/transcriptions` is likewise a pass-through. The model needs
 audio support (an `--mmproj` projector, supplied when the model image
 carries one). Bodies up to 200 MiB are accepted.
@@ -94,7 +105,8 @@ a local model or a provider on the `openai` wire the daemon translates
 it to a chat completion and the reply back: system-role turns fold into
 one leading system message, `tool_use`/`tool_result` become
 `tool_calls`/`role: "tool"`, tools and `tool_choice` become functions
-(names over 64 characters shortened and restored), `thinking` becomes
+(names over 64 characters shortened and restored), `thinking` and
+`output_config.effort` (Claude Code's `/effort`) become
 `reasoning_effort` and llama-server's `chat_template_kwargs`,
 `output_format` becomes `response_format`. Text,
 reasoning (as `thinking`) and tool input stream back as they arrive,

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -195,6 +195,26 @@ the request to a chat completion and the reply back, tool calls included.
 Providers that have the API (`openai`, `groq`, `openrouter`) are used
 natively; any other 4xx is relayed as-is.
 
+### Thinking
+
+Thinking depth is set from inside the integration and reaches the model
+as `reasoning_effort`: llama-server reads it natively (`none` turns
+thinking off; a level goes to the chat template), a provider gets it in
+its own form (see [wire formats](#wire-formats)). Nothing selected leaves
+the model's default.
+
+- `opencode`: variants read off the model's chat template (what `llmman
+  show` lists as `thinking`), cycled with `variant_cycle` (ctrl+t) or
+  `/variants`: `none`, each `reasoning_effort` level the template takes
+  (Qwen3.8: `low`, `medium`, `high`, `xhigh`), or `thinking` for a
+  template with only an `enable_thinking` switch (Gemma 4, Qwen3.5). A
+  provider's model gets `none`, `low`, `medium`, `high`.
+- `claude`: Claude Code's `/effort <low|medium|high|xhigh|max>`, sent as
+  spelled; a level the template rejects is a 400.
+- `codex`: `model_reasoning_effort`, e.g. `-- -c
+  model_reasoning_effort=high`; its `/model` picker lists only OpenAI's
+  catalog.
+
 ## Wire formats
 
 Each provider is spoken to in one of two wire formats, reported as

--- a/src/chat_template.rs
+++ b/src/chat_template.rs
@@ -1,0 +1,240 @@
+//! What a model's chat template lets a request choose about thinking,
+//! read off the template text: the `reasoning_effort` levels it compares
+//! against, whether it reads `enable_thinking`, whether it thinks at
+//! all. Qwen3.8 takes `low`/`medium`/`high`/`xhigh` and raises on
+//! anything else; gpt-oss reads `reasoning_effort` but names only its
+//! default; Qwen3.5 and Gemma 4 have just the switch; Llama 3 has none.
+//! `llmman launch` offers an integration exactly these (see
+//! `cmd::launch::opencode_variants`), never a level the model rejects.
+
+/// Every `reasoning_effort` level any template or provider spells,
+/// lowest first.
+pub const EFFORT_LEVELS: &[&str] = &["minimal", "low", "medium", "high", "xhigh", "max"];
+
+/// What a template that reads `reasoning_effort` without naming its
+/// choices is taken to accept: gpt-oss's three, which every provider
+/// takes too (see `cmd::serve::anthropic::portable_efforts`).
+pub const DEFAULT_EFFORT_LEVELS: &[&str] = &["low", "medium", "high"];
+
+/// A chat template's thinking controls.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ThinkingControls {
+    /// The template mentions thinking or reasoning at all. llama-server
+    /// can switch any such model off (`enable_thinking: false`, or an
+    /// empty think block where the template has no switch).
+    pub thinks: bool,
+    /// The template reads `enable_thinking`, so a kwarg turns thinking on
+    /// as well as off (Gemma 4 defaults it off).
+    pub enable_thinking: bool,
+    /// The `reasoning_effort` levels it distinguishes, lowest first; empty
+    /// when it reads none.
+    pub efforts: Vec<&'static str>,
+}
+
+impl ThinkingControls {
+    /// The choices to offer, in cycle order: `none` for a model that
+    /// thinks, then its levels, or `thinking` when a switch is all it has.
+    pub fn choices(&self) -> Vec<&'static str> {
+        if !self.thinks {
+            return Vec::new();
+        }
+        let mut choices = vec!["none"];
+        if !self.efforts.is_empty() {
+            choices.extend(&self.efforts);
+        } else if self.enable_thinking {
+            choices.push("thinking");
+        }
+        choices
+    }
+}
+
+/// Reads the thinking controls off `template`. Levels are the
+/// [`EFFORT_LEVELS`] quoted in a Jinja block that names
+/// `reasoning_effort` (or a variable derived from it); fewer than two
+/// named — gpt-oss's `default("medium")` alone — means
+/// [`DEFAULT_EFFORT_LEVELS`]. `none` is a switch, not a level.
+pub fn thinking_controls(template: &str) -> ThinkingControls {
+    let template = strip_comments(template);
+    let lower = template.to_ascii_lowercase();
+    let thinks = lower.contains("think") || lower.contains("reasoning");
+    if !thinks {
+        return ThinkingControls::default();
+    }
+    let enable_thinking = template.contains("enable_thinking");
+    let efforts = if template.contains("reasoning_effort") {
+        let named: Vec<&'static str> = EFFORT_LEVELS
+            .iter()
+            .copied()
+            .filter(|level| {
+                blocks(&template)
+                    .filter(|block| block.contains("reasoning_effort"))
+                    .any(|block| quoted_literals(block).any(|lit| lit == *level))
+            })
+            .collect();
+        if named.len() >= 2 {
+            named
+        } else {
+            DEFAULT_EFFORT_LEVELS.to_vec()
+        }
+    } else {
+        Vec::new()
+    };
+    ThinkingControls {
+        thinks,
+        enable_thinking,
+        efforts,
+    }
+}
+
+/// `template` without its `{# ... #}` comments.
+fn strip_comments(template: &str) -> String {
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(start) = rest.find("{#") {
+        out.push_str(&rest[..start]);
+        match rest[start..].find("#}") {
+            Some(end) => rest = &rest[start + end + 2..],
+            None => return out,
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Each `{% ... %}` and `{{ ... }}` of `template`, in order.
+fn blocks(template: &str) -> impl Iterator<Item = &str> {
+    let mut rest = template;
+    std::iter::from_fn(move || {
+        let start = rest.find("{%").into_iter().chain(rest.find("{{")).min()?;
+        let close = if rest[start..].starts_with("{%") {
+            "%}"
+        } else {
+            "}}"
+        };
+        let end = rest[start + 2..].find(close)?;
+        let block = &rest[start + 2..start + 2 + end];
+        rest = &rest[start + 2 + end + 2..];
+        Some(block)
+    })
+}
+
+/// The contents of every `'...'` and `"..."` in `text`, in order.
+fn quoted_literals(text: &str) -> impl Iterator<Item = &str> {
+    let mut rest = text;
+    std::iter::from_fn(move || {
+        let start = rest.find(['\'', '"'])?;
+        let quote = rest.as_bytes()[start] as char;
+        let after = &rest[start + 1..];
+        let end = after.find(quote)?;
+        rest = &after[end + 1..];
+        Some(&after[..end])
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Qwen3.8 as shipped in `docker.io/ai/qwen3.8`: `high` is an alias
+    /// for `xhigh`, so accepted too; the error message names levels only
+    /// inside one long string.
+    const QWEN3_8: &str = r#"
+{%- if enable_thinking is undefined or enable_thinking is true %}
+    {%- set resolved_reasoning_effort = reasoning_effort|default('xhigh') %}
+    {%- if resolved_reasoning_effort == 'high' %}
+        {%- set resolved_reasoning_effort = 'xhigh' %}
+    {%- endif %}
+    {%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}
+        {{- raise_exception('Unexpected reasoning effort ' ~ reasoning_effort ~ '. Supported types are xhigh (default), medium, and low.') }}
+    {%- endif %}
+{%- endif %}
+{%- if enable_thinking is defined and enable_thinking is false %}
+    {{- '<think>\n\n</think>\n\n' }}
+{%- endif %}
+"#;
+
+    #[test]
+    fn qwen3_8_names_its_levels_and_its_switch() {
+        let controls = thinking_controls(QWEN3_8);
+        assert_eq!(
+            controls,
+            ThinkingControls {
+                thinks: true,
+                enable_thinking: true,
+                efforts: vec!["low", "medium", "high", "xhigh"],
+            }
+        );
+        assert_eq!(
+            controls.choices(),
+            ["none", "low", "medium", "high", "xhigh"]
+        );
+        // Minified to one line, the same.
+        let one_line = QWEN3_8.replace('\n', "");
+        assert_eq!(thinking_controls(&one_line), controls);
+    }
+
+    /// gpt-oss reads `reasoning_effort` but names only its default.
+    #[test]
+    fn a_template_that_names_no_choices_gets_the_default_levels() {
+        let gpt_oss = r#"
+{%- if reasoning_effort is not defined %}{%- set reasoning_effort = "medium" %}{%- endif %}
+{{- "Reasoning: " + reasoning_effort + "\n\n" }}
+"#;
+        assert_eq!(
+            thinking_controls(gpt_oss).efforts,
+            DEFAULT_EFFORT_LEVELS.to_vec()
+        );
+    }
+
+    /// Qwen3.5, GLM-5, Gemma 4, Nemotron 3: `enable_thinking`, no levels.
+    #[test]
+    fn a_switch_alone_offers_off_and_on() {
+        let gemma4 = "{%- set enable_thinking = enable_thinking | default(false) -%}\
+                      {%- if enable_thinking -%}<|think|>{%- endif -%}";
+        let controls = thinking_controls(gemma4);
+        assert!(controls.enable_thinking && controls.efforts.is_empty());
+        assert_eq!(controls.choices(), ["none", "thinking"]);
+    }
+
+    /// Kimi K2.5, MiniMax M2.5: thinking with nothing a kwarg reads.
+    #[test]
+    fn thinking_without_a_kwarg_offers_only_off() {
+        let kimi =
+            "{%- if thinking is defined and thinking is false -%}<think></think>{%- endif -%}";
+        assert_eq!(thinking_controls(kimi).choices(), ["none"]);
+        let minimax = "{%- set reasoning_content = content.split('</think>')[0] -%}";
+        assert_eq!(thinking_controls(minimax).choices(), ["none"]);
+    }
+
+    /// Llama 3.1, Phi-4: no thinking anywhere — a comment mentioning it
+    /// does not count.
+    #[test]
+    fn a_plain_template_has_no_controls() {
+        let llama = "{# no thinking here #}{{- '<|start_header_id|>' + message['role'] }}";
+        assert_eq!(thinking_controls(llama), ThinkingControls::default());
+        assert!(thinking_controls(llama).choices().is_empty());
+        assert_eq!(thinking_controls(""), ThinkingControls::default());
+    }
+
+    /// Levels come out in cycle order, once each, without `none`, and
+    /// only from blocks that name the variable.
+    #[test]
+    fn levels_are_ordered_deduplicated_and_scoped_to_the_variables_blocks() {
+        let t = r#"{%- if reasoning_effort == "max" or reasoning_effort == "low" or reasoning_effort == "none" %}
+{%- if reasoning_effort == 'low' %}{%- set unrelated = 'high' %}"#;
+        assert_eq!(thinking_controls(t).efforts, vec!["low", "max"]);
+    }
+
+    #[test]
+    fn blocks_and_literals_are_walked_in_order() {
+        assert_eq!(
+            blocks("a {% if x %}b{{ y }}c {% end").collect::<Vec<_>>(),
+            [" if x ", " y "]
+        );
+        assert_eq!(
+            quoted_literals(r#"x in ('a', "b c") ~ 'd"#).collect::<Vec<_>>(),
+            ["a", "b c"]
+        );
+        assert_eq!(strip_comments("a{# b #}c{# open"), "ac");
+    }
+}

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -22,6 +22,7 @@ use std::process::Command;
 use anyhow::Context;
 use clap::Args;
 
+use crate::chat_template::ThinkingControls;
 use crate::daemon;
 use crate::providers;
 
@@ -81,6 +82,9 @@ pub fn run(args: &LaunchArgs) -> anyhow::Result<()> {
         "--overflow-model needs --model naming the local model to pair it with"
     );
 
+    // The local model's thinking controls (see `opencode_variants`); a
+    // provider's model has no template to read.
+    let mut thinking = None;
     let (model, api_key) = match provider {
         Some(provider) => {
             check_provider_supported(name)?;
@@ -123,7 +127,7 @@ pub fn run(args: &LaunchArgs) -> anyhow::Result<()> {
             // synchronously and with progress, before ever handing off to
             // the integration.
             if !model.is_empty() {
-                crate::daemon::ensure_model_pulled(&model)?;
+                thinking = crate::daemon::ensure_model_pulled(&model)?.thinking_controls();
             }
             match overflow {
                 // The hosted half is validated and keyed exactly as a
@@ -142,7 +146,7 @@ pub fn run(args: &LaunchArgs) -> anyhow::Result<()> {
         }
     };
 
-    launch(name, &model, &api_key, &args.extra_args)
+    launch(name, &model, &api_key, thinking.as_ref(), &args.extra_args)
 }
 
 // ---------------------------------------------------------------------------
@@ -505,10 +509,16 @@ fn find_integration_binary(i: &Integration) -> Option<PathBuf> {
 /// the integration's environment can do this; the ones that go through a
 /// config file on disk keep the placeholder rather than persist a
 /// credential, and need the key in the daemon's own environment.
-fn launch(name: &str, model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
+fn launch(
+    name: &str,
+    model: &str,
+    api_key: &str,
+    thinking: Option<&ThinkingControls>,
+    extra_args: &[String],
+) -> anyhow::Result<()> {
     match name.to_lowercase().as_str() {
         "claude" => launch_claude(model, api_key, extra_args),
-        "opencode" => launch_opencode(model, api_key, extra_args),
+        "opencode" => launch_opencode(model, api_key, thinking, extra_args),
         "codex" => launch_codex(model, api_key, extra_args),
         "cline" => launch_simple("cline", model, extra_args),
         "aider" => launch_aider(model, api_key, extra_args),
@@ -551,15 +561,59 @@ fn launch_claude(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::R
     )
 }
 
-/// opencode: pass a JSON config via OPENCODE_CONFIG_CONTENT pointing at our
-/// /v1 endpoint, matching exactly what ollama launch does.
-fn launch_opencode(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
+/// opencode: a JSON config via OPENCODE_CONFIG_CONTENT pointing at our
+/// /v1 endpoint, with the model's thinking variants.
+fn launch_opencode(
+    model: &str,
+    api_key: &str,
+    thinking: Option<&ThinkingControls>,
+    extra_args: &[String],
+) -> anyhow::Result<()> {
     let bin = find_opencode().ok_or_else(|| anyhow::anyhow!("opencode is not installed"))?;
 
     let effective_model = if model.is_empty() { "default" } else { model };
-    let config = opencode_config(effective_model, api_key);
+    let config = opencode_config(
+        &daemon::server(),
+        effective_model,
+        api_key,
+        &opencode_variants(thinking),
+    );
 
     exec_with_env(&bin, extra_args, &[("OPENCODE_CONFIG_CONTENT", &config)])
+}
+
+/// The choices offered when the model's template could not be read (a
+/// provider's model): thinking off, then the levels every wire accepts
+/// (`anthropic::portable_efforts`).
+const PORTABLE_THINKING_LEVELS: &[&str] = &["none", "low", "medium", "high"];
+
+/// opencode's `variants` for the model, in cycle order (`variant_cycle`,
+/// ctrl+t by default): the template's own choices (see
+/// [`ThinkingControls::choices`]), or [`PORTABLE_THINKING_LEVELS`] without
+/// a template. A model that does not think gets none. Each variant is the
+/// request options `@ai-sdk/openai-compatible` sends: `reasoningEffort`
+/// as `reasoning_effort`, other keys verbatim. opencode derives variants
+/// only for models it knows from models.dev, so without these a local
+/// model has nothing to cycle.
+fn opencode_variants(
+    thinking: Option<&ThinkingControls>,
+) -> Vec<(&'static str, serde_json::Value)> {
+    let choices = match thinking {
+        Some(controls) => controls.choices(),
+        None => PORTABLE_THINKING_LEVELS.to_vec(),
+    };
+    choices
+        .into_iter()
+        .map(|choice| {
+            let options = match choice {
+                "thinking" => {
+                    serde_json::json!({ "chat_template_kwargs": { "enable_thinking": true } })
+                }
+                level => serde_json::json!({ "reasoningEffort": level }),
+            };
+            (choice, options)
+        })
+        .collect()
 }
 
 /// `PATH`, then opencode's own installer target, `~/.opencode/bin`.
@@ -572,26 +626,84 @@ fn find_opencode() -> Option<PathBuf> {
     })
 }
 
-fn opencode_config(model: &str, api_key: &str) -> String {
-    let base_url = format!("{}/v1", daemon::server());
-    serde_json::json!({
-        "$schema": "https://opencode.ai/config.json",
-        "provider": {
-            "ollama": {
-                "npm": "@ai-sdk/openai-compatible",
-                "name": "Ollama",
-                "options": {
-                    "baseURL": base_url,
-                    "apiKey": api_key
+/// The `OPENCODE_CONFIG_CONTENT` for `model` at `server`. Structs rather
+/// than `json!`, whose map sorts keys: opencode cycles variants in the
+/// order listed. No variants leaves the key out.
+fn opencode_config(
+    server: &str,
+    model: &str,
+    api_key: &str,
+    variants: &[(&'static str, serde_json::Value)],
+) -> String {
+    use serde::ser::{SerializeMap, Serializer};
+
+    /// An object with runtime keys, in the order given.
+    fn entries<S: Serializer, V: serde::Serialize>(
+        entries: &[(&str, V)],
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(Some(entries.len()))?;
+        for (key, value) in entries {
+            map.serialize_entry(key, value)?;
+        }
+        map.end()
+    }
+
+    #[derive(serde::Serialize)]
+    struct Config<'a> {
+        #[serde(rename = "$schema")]
+        schema: &'static str,
+        provider: Providers<'a>,
+        model: String,
+    }
+    #[derive(serde::Serialize)]
+    struct Providers<'a> {
+        ollama: Provider<'a>,
+    }
+    #[derive(serde::Serialize)]
+    struct Provider<'a> {
+        npm: &'static str,
+        name: &'static str,
+        options: Options<'a>,
+        #[serde(serialize_with = "entries")]
+        models: [(&'a str, Model<'a>); 1],
+    }
+    #[derive(serde::Serialize)]
+    struct Options<'a> {
+        #[serde(rename = "baseURL")]
+        base_url: String,
+        #[serde(rename = "apiKey")]
+        api_key: &'a str,
+    }
+    #[derive(serde::Serialize)]
+    struct Model<'a> {
+        name: &'a str,
+        #[serde(serialize_with = "entries", skip_serializing_if = "<[_]>::is_empty")]
+        variants: &'a [(&'static str, serde_json::Value)],
+    }
+
+    let config = Config {
+        schema: "https://opencode.ai/config.json",
+        provider: Providers {
+            ollama: Provider {
+                npm: "@ai-sdk/openai-compatible",
+                name: "Ollama",
+                options: Options {
+                    base_url: format!("{server}/v1"),
+                    api_key,
                 },
-                "models": {
-                    model: { "name": model }
-                }
-            }
+                models: [(
+                    model,
+                    Model {
+                        name: model,
+                        variants,
+                    },
+                )],
+            },
         },
-        "model": format!("ollama/{model}")
-    })
-    .to_string()
+        model: format!("ollama/{model}"),
+    };
+    serde_json::to_string(&config).expect("opencode config serializes")
 }
 
 /// codex: set OPENAI_API_KEY=llmman and write ~/.codex/config.toml with the
@@ -1835,6 +1947,86 @@ model = \"gpt-5\"
     fn strip_legacy_llmman_profile_handles_the_table_at_end_of_file() {
         let existing = "[profiles.llmman]\nopenai_base_url = \"http://127.0.0.1:17434/v1\"\n";
         assert_eq!(strip_legacy_llmman_profile(existing), "");
+    }
+
+    /// The config points at the daemon's `/v1` and lists the variants in
+    /// the order given (a parsed `Value` would re-sort them).
+    #[test]
+    fn opencode_config_lists_the_variants_in_order() {
+        let variants = opencode_variants(None);
+        let text = opencode_config("http://127.0.0.1:17434", "qwen3.5:0.8b", "k", &variants);
+        let config: serde_json::Value = serde_json::from_str(&text).expect("valid JSON");
+        assert_eq!(config["$schema"], "https://opencode.ai/config.json");
+        assert_eq!(config["model"], "ollama/qwen3.5:0.8b");
+        let provider = &config["provider"]["ollama"];
+        assert_eq!(provider["npm"], "@ai-sdk/openai-compatible");
+        assert_eq!(provider["name"], "Ollama");
+        assert_eq!(provider["options"]["baseURL"], "http://127.0.0.1:17434/v1");
+        assert_eq!(provider["options"]["apiKey"], "k");
+        assert_eq!(provider["models"].as_object().map(|m| m.len()), Some(1));
+
+        let model = &provider["models"]["qwen3.5:0.8b"];
+        assert_eq!(model["name"], "qwen3.5:0.8b");
+        let written = model["variants"].as_object().expect("variants object");
+        assert_eq!(written.len(), variants.len());
+        for (name, options) in &variants {
+            assert_eq!(&written[*name], options, "variant {name}");
+        }
+        let positions: Vec<usize> = variants
+            .iter()
+            .map(|(name, _)| text.find(&format!("\"{name}\"")).expect(name))
+            .collect();
+        assert!(positions.windows(2).all(|w| w[0] < w[1]), "{text}");
+
+        let bare = opencode_config("http://h", "m", "k", &[]);
+        assert!(!bare.contains("variants"), "{bare}");
+    }
+
+    #[test]
+    fn opencode_config_escapes_the_model_name() {
+        let model = "we\"ird/mo\\del";
+        let config: serde_json::Value =
+            serde_json::from_str(&opencode_config("http://h", model, "k", &[]))
+                .expect("valid JSON");
+        assert_eq!(config["model"], format!("ollama/{model}"));
+        assert_eq!(config["provider"]["ollama"]["models"][model]["name"], model);
+    }
+
+    /// Each choice becomes the options that select it; no template means
+    /// the portable set, no thinking means no variants.
+    #[test]
+    fn opencode_variants_follow_the_templates_controls() {
+        let gemma4 = ThinkingControls {
+            thinks: true,
+            enable_thinking: true,
+            efforts: vec![],
+        };
+        assert_eq!(
+            opencode_variants(Some(&gemma4)),
+            [
+                ("none", serde_json::json!({ "reasoningEffort": "none" })),
+                (
+                    "thinking",
+                    serde_json::json!({ "chat_template_kwargs": { "enable_thinking": true } })
+                ),
+            ]
+        );
+        let qwen3_8 = ThinkingControls {
+            efforts: vec!["low", "xhigh"],
+            ..gemma4
+        };
+        assert_eq!(
+            opencode_variants(Some(&qwen3_8)),
+            [
+                ("none", serde_json::json!({ "reasoningEffort": "none" })),
+                ("low", serde_json::json!({ "reasoningEffort": "low" })),
+                ("xhigh", serde_json::json!({ "reasoningEffort": "xhigh" })),
+            ]
+        );
+        assert!(opencode_variants(Some(&ThinkingControls::default())).is_empty());
+        let fallback = opencode_variants(None);
+        assert_eq!(fallback.len(), PORTABLE_THINKING_LEVELS.len());
+        assert_eq!(fallback[0].0, "none");
     }
 
     #[test]

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -3502,6 +3502,7 @@ async fn handle_show(
             },
             // Nothing local to inspect.
             capabilities: Vec::new(),
+            template: None,
         }));
     }
     // Resolve the same way handle_pull stored it — otherwise a bare name
@@ -3526,6 +3527,12 @@ async fn handle_show(
     })?;
     let manifest = store.read_manifest(&desc.digest)?;
     let capabilities = crate::modelpack::capabilities(&store, &manifest);
+    let template = crate::modelpack::chat_template(
+        &store,
+        &state.0.store_path,
+        &state.0.cache_path,
+        &manifest,
+    );
     Ok(Json(OllamaShowResponse {
         model_info: serde_json::json!({ "digest": desc.digest, "size": desc.size }),
         details: OllamaModelDetails {
@@ -3535,6 +3542,7 @@ async fn handle_show(
             quantization_level: String::new(),
         },
         capabilities,
+        template,
     }))
 }
 
@@ -4933,6 +4941,40 @@ fn apply_default_repeat_penalty(req: &mut serde_json::Value) {
     }
 }
 
+/// Mirrors a local chat completion's `reasoning_effort` into the
+/// `chat_template_kwargs` llama-server's templates read, as
+/// `think_to_chat_template_kwargs` does for Ollama's `think`: `none` is
+/// thinking off, a level is thinking on at that depth. Recent
+/// llama-server reads `reasoning_effort` itself; older builds and vLLM
+/// read only the kwargs. The caller's own kwargs win key by key.
+/// [`provider_compat`] is the reverse, for a provider.
+fn apply_reasoning_effort(req: &mut serde_json::Value) {
+    let Some(effort) = req.get("reasoning_effort").and_then(|v| v.as_str()) else {
+        return;
+    };
+    let think = if effort == "none" {
+        serde_json::Value::Bool(false)
+    } else {
+        serde_json::Value::String(effort.to_string())
+    };
+    let Some(serde_json::Value::Object(kwargs)) = think_to_chat_template_kwargs(&Some(think))
+    else {
+        return;
+    };
+    let Some(o) = req.as_object_mut() else {
+        return;
+    };
+    let slot = o
+        .entry("chat_template_kwargs")
+        .or_insert_with(|| serde_json::json!({}));
+    let Some(existing) = slot.as_object_mut() else {
+        return;
+    };
+    for (key, value) in kwargs {
+        existing.entry(key).or_insert(value);
+    }
+}
+
 /// Shared setup for every plain OpenAI-passthrough route: parse just
 /// enough of the request to find `model`, make sure it's loaded, rewrite
 /// `model` to its canonical name (see `ensure_model`), and open an
@@ -5076,7 +5118,12 @@ async fn proxy_openai_generation_to(
             provider_compat(remote, &mut req)
         }
         Target::Remote(_) => strip_llama_fields(&mut req),
-        _ => apply_default_repeat_penalty(&mut req),
+        _ => {
+            apply_default_repeat_penalty(&mut req);
+            if llama_path == CHAT_COMPLETIONS_ROUTE {
+                apply_reasoning_effort(&mut req);
+            }
+        }
     }
     let streaming = req.get("stream").and_then(|v| v.as_bool()).unwrap_or(false);
     let body = Bytes::from(serde_json::to_vec(&req).context("re-serialize OpenAI request body")?);

--- a/src/cmd/serve/anthropic.rs
+++ b/src/cmd/serve/anthropic.rs
@@ -30,19 +30,21 @@ pub(super) const VERSION: &str = "2023-06-01";
 /// 4096 is the smallest ceiling of any Claude model.
 pub(super) const DEFAULT_MAX_TOKENS: u32 = 4096;
 
-/// Thinking budgets per OpenAI `reasoning_effort` level. The Messages API
-/// has only a token budget, spent from `max_tokens`.
-const THINKING_BUDGETS: [(&str, u32); 5] = [
+/// Thinking budgets per `reasoning_effort` level (every one of
+/// `crate::chat_template::EFFORT_LEVELS`, in its order). The Messages
+/// API has only a token budget, spent from `max_tokens`.
+const THINKING_BUDGETS: [(&str, u32); 6] = [
     ("minimal", 1024),
     ("low", 2048),
     ("medium", 8192),
     ("high", 16384),
+    ("xhigh", 24576),
     ("max", 32768),
 ];
 
 /// The levels every provider's `reasoning_effort` takes: Gemini's
 /// compatibility endpoint and OpenAI's o1 have no `minimal`, OpenAI no
-/// `max`.
+/// `max`, and `xhigh` only OpenAI's newest.
 pub(super) fn portable_efforts() -> &'static [(&'static str, u32)] {
     &THINKING_BUDGETS[1..4]
 }

--- a/src/cmd/serve/messages.rs
+++ b/src/cmd/serve/messages.rs
@@ -115,22 +115,30 @@ pub(super) fn from_messages_request(
     }
     // Providers read `reasoning_effort`; llama-server's templates read
     // `chat_template_kwargs`, which a provider-bound request loses.
-    match req.get("thinking").map(|t| &t["type"]) {
+    // `output_config.effort` (Claude Code's `/effort`) names the level
+    // outright and beats one guessed from `budget_tokens`; `adaptive`
+    // without one leaves the model's default.
+    let named = output_effort(req);
+    let effort = match req.get("thinking").map(|t| &t["type"]) {
         Some(Value::String(kind)) if kind == "enabled" => {
-            let effort = reasoning_effort(&req["thinking"]);
-            object.insert("reasoning_effort".to_string(), json!(effort));
-            object.insert(
-                "chat_template_kwargs".to_string(),
-                json!({ "enable_thinking": true, "reasoning_effort": effort }),
-            );
+            Some(named.unwrap_or_else(|| reasoning_effort(&req["thinking"])))
         }
+        Some(Value::String(kind)) if kind == "adaptive" => named,
         Some(Value::String(kind)) if kind == "disabled" => {
             object.insert(
                 "chat_template_kwargs".to_string(),
                 json!({ "enable_thinking": false }),
             );
+            None
         }
-        _ => {}
+        _ => None,
+    };
+    if let Some(effort) = effort {
+        object.insert("reasoning_effort".to_string(), json!(effort));
+        object.insert(
+            "chat_template_kwargs".to_string(),
+            json!({ "enable_thinking": true, "reasoning_effort": effort }),
+        );
     }
     if let Some(format) = req
         .get("output_format")
@@ -404,6 +412,20 @@ fn convert_tool_choice(
         }
         _ => None,
     })
+}
+
+/// The request's `output_config.effort`, when it is one of
+/// [`crate::chat_template::EFFORT_LEVELS`].
+fn output_effort(req: &Value) -> Option<&'static str> {
+    let effort = req
+        .get("output_config")
+        .and_then(|c| c.get("effort"))
+        .and_then(Value::as_str)?
+        .trim();
+    crate::chat_template::EFFORT_LEVELS
+        .iter()
+        .copied()
+        .find(|level| *level == effort)
 }
 
 /// An enabled `thinking` budget as the largest portable
@@ -1071,6 +1093,70 @@ mod tests {
         }));
         assert!(chat.get("reasoning_effort").is_none());
         assert!(chat.get("chat_template_kwargs").is_none());
+    }
+
+    /// Claude Code's `/effort` arrives as `output_config.effort` with
+    /// `thinking: adaptive`; it becomes `reasoning_effort` as spelled,
+    /// beats a `budget_tokens` guess, and an unknown spelling is dropped.
+    #[test]
+    fn output_config_effort_is_the_thinking_level() {
+        for level in crate::chat_template::EFFORT_LEVELS {
+            let chat = request(json!({
+                "model": "m",
+                "thinking": {"type": "adaptive"},
+                "output_config": {"effort": level},
+                "messages": [{"role": "user", "content": "hi"}]
+            }));
+            assert_eq!(chat["reasoning_effort"], *level, "effort {level}");
+            assert_eq!(
+                chat["chat_template_kwargs"],
+                json!({"enable_thinking": true, "reasoning_effort": level}),
+                "effort {level}"
+            );
+        }
+
+        // A 50000-token budget alone would be `high`.
+        let chat = request(json!({
+            "model": "m",
+            "thinking": {"type": "enabled", "budget_tokens": 50000},
+            "output_config": {"effort": "low"},
+            "messages": [{"role": "user", "content": "hi"}]
+        }));
+        assert_eq!(chat["reasoning_effort"], "low");
+        assert_eq!(
+            chat["chat_template_kwargs"],
+            json!({"enable_thinking": true, "reasoning_effort": "low"})
+        );
+
+        let chat = request(json!({
+            "model": "m",
+            "thinking": {"type": "disabled"},
+            "output_config": {"effort": "high"},
+            "messages": [{"role": "user", "content": "hi"}]
+        }));
+        assert!(chat.get("reasoning_effort").is_none());
+        assert_eq!(
+            chat["chat_template_kwargs"],
+            json!({"enable_thinking": false})
+        );
+
+        let chat = request(json!({
+            "model": "m",
+            "output_config": {"effort": "high"},
+            "messages": [{"role": "user", "content": "hi"}]
+        }));
+        assert!(chat.get("reasoning_effort").is_none());
+        assert!(chat.get("chat_template_kwargs").is_none());
+
+        let chat = request(json!({
+            "model": "m",
+            "thinking": {"type": "adaptive"},
+            "output_config": {"effort": "ultra"},
+            "messages": [{"role": "user", "content": "hi"}]
+        }));
+        assert!(chat.get("reasoning_effort").is_none());
+        assert!(chat.get("chat_template_kwargs").is_none());
+        assert!(chat.get("output_config").is_none());
     }
 
     #[test]

--- a/src/cmd/serve/tests.rs
+++ b/src/cmd/serve/tests.rs
@@ -756,6 +756,50 @@ fn provider_compat_translates_think_per_wire() {
     assert_eq!(with(&anthropic, off), Some("none".into()));
 }
 
+/// A local `reasoning_effort` becomes the `chat_template_kwargs` Ollama's
+/// `think` would; the caller's kwargs win; an unknown level changes nothing.
+#[test]
+fn apply_reasoning_effort_mirrors_it_into_template_kwargs() {
+    let with = |req: serde_json::Value| {
+        let mut req = req;
+        apply_reasoning_effort(&mut req);
+        req
+    };
+    assert_eq!(
+        with(serde_json::json!({ "model": "m", "reasoning_effort": "none" })),
+        serde_json::json!({
+            "model": "m", "reasoning_effort": "none",
+            "chat_template_kwargs": { "enable_thinking": false }
+        })
+    );
+    for level in crate::chat_template::EFFORT_LEVELS {
+        assert_eq!(
+            with(serde_json::json!({ "model": "m", "reasoning_effort": level })),
+            serde_json::json!({
+                "model": "m", "reasoning_effort": level,
+                "chat_template_kwargs": { "enable_thinking": true, "reasoning_effort": level }
+            }),
+            "{level}"
+        );
+    }
+    assert_eq!(
+        with(serde_json::json!({
+            "model": "m", "reasoning_effort": "high",
+            "chat_template_kwargs": { "enable_thinking": false }
+        })),
+        serde_json::json!({
+            "model": "m", "reasoning_effort": "high",
+            "chat_template_kwargs": { "enable_thinking": false, "reasoning_effort": "high" }
+        })
+    );
+    let unknown = serde_json::json!({ "model": "m", "reasoning_effort": "verbose" });
+    assert_eq!(with(unknown.clone()), unknown);
+    let absent = serde_json::json!({ "model": "m", "chat_template_kwargs": { "a": 1 } });
+    assert_eq!(with(absent.clone()), absent);
+    let not_a_string = serde_json::json!({ "model": "m", "reasoning_effort": 3 });
+    assert_eq!(with(not_a_string.clone()), not_a_string);
+}
+
 /// OpenAI's reasoning models take `max_completion_tokens` and reject
 /// sampling overrides; its other models reject `reasoning_effort`.
 /// Other providers are left alone beyond the llama.cpp fields.

--- a/src/cmd/serve/types.rs
+++ b/src/cmd/serve/types.rs
@@ -155,22 +155,20 @@ pub(super) fn format_to_response_format(
 
 /// Translates Ollama's `think` request field into the
 /// `chat_template_kwargs` llama-server actually reads. `true`/`false` →
-/// `{"enable_thinking": <bool>}`. A string level (`"low"`/`"medium"`/
-/// `"high"`/`"max"`) → `{"enable_thinking": true, "reasoning_effort":
-/// <level>}`, the jinja variable gpt-oss's and DeepSeek-V4's own
-/// templates read for reasoning depth. Anything else is a no-op.
+/// `{"enable_thinking": <bool>}`. A string level (one of
+/// [`crate::chat_template::EFFORT_LEVELS`]) → `{"enable_thinking": true,
+/// "reasoning_effort": <level>}`, the jinja variable gpt-oss's, Qwen3.8's
+/// and DeepSeek-V4's own templates read for reasoning depth. Anything
+/// else is a no-op.
 pub(super) fn think_to_chat_template_kwargs(
     think: &Option<serde_json::Value>,
 ) -> Option<serde_json::Value> {
     match think {
         Some(serde_json::Value::Bool(b)) => Some(serde_json::json!({ "enable_thinking": b })),
-        // Only forward the four levels llama-server's own templates
-        // actually understand — an unrecognized level (a typo, a future
-        // Ollama addition, ...) is left a no-op rather than forwarded
-        // verbatim, so the template's own default applies instead of
-        // silently misbehaving on an unsupported reasoning_effort value.
+        // An unrecognized level is a no-op, not forwarded verbatim, so
+        // the template's own default applies.
         Some(serde_json::Value::String(level))
-            if matches!(level.trim(), "low" | "medium" | "high" | "max") =>
+            if crate::chat_template::EFFORT_LEVELS.contains(&level.trim()) =>
         {
             Some(serde_json::json!({
                 "enable_thinking": true,
@@ -301,6 +299,10 @@ pub(super) struct OllamaShowResponse {
     /// Ollama's `api.ShowResponse.Capabilities`; see
     /// `crate::modelpack::capabilities`.
     pub(super) capabilities: Vec<String>,
+    /// Ollama's `api.ShowResponse.Template` (see
+    /// `crate::modelpack::chat_template`); absent when there is none.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) template: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1073,9 +1075,9 @@ mod tests {
 
     /// Ported from ollama's openai/openai_test.go
     /// (TestFromChatRequest_ReasoningEffort): a boolean `think` maps to
-    /// `enable_thinking`, and a string thinking level
-    /// ("low"/"medium"/"high"/"max") additionally maps to
-    /// `reasoning_effort` — the jinja variable gpt-oss's and
+    /// `enable_thinking`, and a string thinking level (any of
+    /// `chat_template::EFFORT_LEVELS`) additionally maps to
+    /// `reasoning_effort` — the jinja variable gpt-oss's, Qwen3.8's and
     /// DeepSeek-V4's own chat templates read.
     #[test]
     fn think_to_chat_template_kwargs_maps_booleans_and_reasoning_levels() {
@@ -1087,7 +1089,7 @@ mod tests {
             think_to_chat_template_kwargs(&Some(serde_json::json!(false))),
             Some(serde_json::json!({ "enable_thinking": false }))
         );
-        for level in ["low", "medium", "high", "max"] {
+        for level in crate::chat_template::EFFORT_LEVELS {
             assert_eq!(
                 think_to_chat_template_kwargs(&Some(serde_json::json!(level))),
                 Some(serde_json::json!({
@@ -1097,10 +1099,11 @@ mod tests {
                 "string level {level:?}"
             );
         }
-        // Anything other than the four known levels is a no-op — an
-        // unrecognized value shouldn't be forwarded to the template
-        // verbatim (see think_to_chat_template_kwargs's own comment).
-        for not_a_level in ["", "  ", "verbose", "LOW"] {
+        // Anything other than a known level is a no-op — an unrecognized
+        // value shouldn't be forwarded to the template verbatim (see
+        // think_to_chat_template_kwargs's own comment). `none` is a
+        // switch, not a level: Ollama spells that `think: false`.
+        for not_a_level in ["", "  ", "verbose", "LOW", "none"] {
             assert_eq!(
                 think_to_chat_template_kwargs(&Some(serde_json::json!(not_a_level))),
                 None,

--- a/src/cmd/show.rs
+++ b/src/cmd/show.rs
@@ -10,13 +10,11 @@
 //! model file itself (GGUF metadata) or its `config.json`/
 //! `tokenizer_config.json` (safetensors).
 
-use std::io::Read;
 use std::path::Path;
 
 use clap::Args;
 
 use crate::modelpack::{resolve_model, ModelPath};
-use crate::storage::oci::Descriptor;
 use crate::storage::OciStore;
 
 #[derive(Args, Debug)]
@@ -76,13 +74,6 @@ pub fn run(args: &ShowArgs) -> anyhow::Result<()> {
         }
         ModelPath::Gguf(..) | ModelPath::Diffusion(_) => None,
     };
-    let tokenizer_config = match &resolved {
-        ModelPath::SafeTensors(dir) | ModelPath::Omni(dir) => {
-            read_json_file(&dir.join("tokenizer_config.json"))
-        }
-        ModelPath::Gguf(..) | ModelPath::Diffusion(_) => None,
-    };
-
     // Any single-focus flag suppresses the full summary and prints just
     // that one thing, matching `ollama show --license`/`--template`/
     // `--parameters`'s own behavior.
@@ -93,8 +84,9 @@ pub fn run(args: &ShowArgs) -> anyhow::Result<()> {
         }
         return Ok(());
     }
+    let template = || crate::modelpack::chat_template(&store, &store_path, &cache_path, &manifest);
     if args.template {
-        match chat_template(gguf_info.as_ref(), tokenizer_config.as_ref()) {
+        match template() {
             Some(text) => println!("{}", text.trim_end()),
             None => println!("(no chat template found)"),
         }
@@ -150,13 +142,17 @@ pub fn run(args: &ShowArgs) -> anyhow::Result<()> {
         }
     }
 
-    if chat_template(gguf_info.as_ref(), tokenizer_config.as_ref()).is_some() {
+    if let Some(template) = template() {
         println!();
         println!("Template");
         println!(
             "    (present — use `llmman show --template {}` to view it)",
             args.model
         );
+        let choices = crate::chat_template::thinking_controls(&template).choices();
+        if !choices.is_empty() {
+            println!("    thinking             {}", choices.join(", "));
+        }
     }
 
     if let Some(annotations) = &manifest.annotations {
@@ -258,24 +254,6 @@ fn format_value(v: &crate::gguf::Value) -> String {
     }
 }
 
-/// The model's chat template, if one can be found — GGUF's
-/// `tokenizer.chat_template` key, or (for safetensors) a
-/// `tokenizer_config.json`'s own `chat_template` field.
-fn chat_template(
-    gguf_info: Option<&crate::gguf::Info>,
-    tokenizer_config: Option<&serde_json::Value>,
-) -> Option<String> {
-    if let Some(info) = gguf_info {
-        if let Some(t) = info.str("tokenizer.chat_template") {
-            return Some(t.to_string());
-        }
-    }
-    tokenizer_config?
-        .get("chat_template")?
-        .as_str()
-        .map(str::to_string)
-}
-
 /// Finds and reads a manifest layer that looks like a license file
 /// (`LICENSE`, `LICENSE.txt`, `LICENSE.md`, case-insensitive) — or, for a
 /// GGUF file, falls back to any `general.license*` metadata string.
@@ -297,7 +275,7 @@ fn find_license(
             .unwrap_or(filepath)
             .to_lowercase();
         if base == "license" || base.starts_with("license.") {
-            if let Ok(text) = read_layer_text(store, layer) {
+            if let Ok(text) = crate::modelpack::read_layer_text(store, layer) {
                 return Some(text);
             }
         }
@@ -309,29 +287,6 @@ fn find_license(
     info.str("general.license")
         .or_else(|| info.str("general.license.name"))
         .map(str::to_string)
-}
-
-/// Reads a manifest layer's text content — transparently un-tarring it if
-/// it's a single-file tar (as every layer `llmman build` produces is —
-/// see `storage::oci::classify_model_layer`'s own doc comment), or else
-/// treating the whole blob as raw text (as HuggingFace/cloud-source pulls
-/// store un-archived doc/config blobs — see
-/// [`crate::sources::classify_file`]).
-fn read_layer_text(store: &OciStore, layer: &Descriptor) -> anyhow::Result<String> {
-    let blob = store.read_blob(&layer.digest)?;
-    if blob.len() >= 512 {
-        let mut archive = tar::Archive::new(std::io::Cursor::new(&blob));
-        if let Ok(entries) = archive.entries() {
-            for entry in entries.flatten() {
-                let mut entry = entry;
-                let mut s = String::new();
-                if entry.read_to_string(&mut s).is_ok() && !s.is_empty() {
-                    return Ok(s);
-                }
-            }
-        }
-    }
-    Ok(String::from_utf8_lossy(&blob).into_owned())
 }
 
 fn read_json_file(path: &Path) -> Option<serde_json::Value> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -997,15 +997,26 @@ pub fn stream_progress_with(path: &str, reference: &str) -> anyhow::Result<Optio
     Ok(pushed_digest)
 }
 
-/// The part of Ollama's `api.ShowResponse` that `llmman run` reads.
+/// The part of Ollama's `api.ShowResponse` that `llmman run` and
+/// `llmman launch` read.
 #[derive(Debug, Default, Deserialize)]
 pub struct ShowResponse {
     /// `"completion"`, `"vision"`, … — see `crate::modelpack::capabilities`.
     #[serde(default)]
     pub capabilities: Vec<String>,
+    /// The model's chat template, if any (see `crate::modelpack::chat_template`).
+    #[serde(default)]
+    pub template: Option<String>,
 }
 
 impl ShowResponse {
+    /// The template's thinking controls; `None` without a template.
+    pub fn thinking_controls(&self) -> Option<crate::chat_template::ThinkingControls> {
+        self.template
+            .as_deref()
+            .map(crate::chat_template::thinking_controls)
+    }
+
     /// Ollama's `RunHandler`: `opts.MultiModal` = vision or audio.
     pub fn multimodal(&self) -> bool {
         self.capabilities

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "256"]
 
+pub mod chat_template;
 pub mod cmd;
 pub mod config;
 pub mod container;

--- a/src/modelpack.rs
+++ b/src/modelpack.rs
@@ -205,15 +205,10 @@ fn extract_gguf_layer(
     }
 
     // Otherwise extract from tar layer.
-    let cached_dir = cache_path.join(layer_hex);
-    if cached_dir.exists() {
-        for e in std::fs::read_dir(&cached_dir)?.flatten() {
-            let p = e.path();
-            if p.extension().and_then(|e| e.to_str()) == Some("gguf") {
-                return Ok(p);
-            }
-        }
+    if let Some(p) = cached_gguf(cache_path, layer_hex) {
+        return Ok(p);
     }
+    let cached_dir = cache_path.join(layer_hex);
     std::fs::create_dir_all(&cached_dir)?;
     let blob = store
         .read_blob(&layer.digest)
@@ -365,6 +360,92 @@ pub fn capabilities(store: &OciStore, manifest: &crate::storage::oci::Manifest) 
         caps.push(CAPABILITY_VISION.to_string());
     }
     caps
+}
+
+/// Ollama's `api.ShowResponse.Template`: the model's chat template, read
+/// without extracting anything (a read-only `/api/show` must not copy a
+/// checkout into the cache). A GGUF's `tokenizer.chat_template`, from
+/// the blob as stored or a tar layer already extracted; else a
+/// checkout's `chat_template.jinja`, or `tokenizer_config.json`'s
+/// `chat_template` (the `default` of Transformers' named templates).
+pub fn chat_template(
+    store: &OciStore,
+    store_path: &Path,
+    cache_path: &Path,
+    manifest: &crate::storage::oci::Manifest,
+) -> Option<String> {
+    if let Some((primary, _)) = gguf_layers(manifest) {
+        let path = raw_blob_path(store_path, primary)
+            .ok()
+            .filter(|p| blob_is_gguf(p))
+            .or_else(|| cached_gguf(cache_path, digest_hex(&primary.digest).ok()?))?;
+        return crate::gguf::read_info(&path)
+            .ok()?
+            .str("tokenizer.chat_template")
+            .map(str::to_string);
+    }
+    let file = |name: &str| {
+        manifest
+            .layers
+            .iter()
+            .find(|l| {
+                layer_filepath(l)
+                    .and_then(|p| Path::new(p).file_name())
+                    .is_some_and(|f| f == name)
+            })
+            .and_then(|l| read_layer_text(store, l).ok())
+    };
+    if let Some(jinja) = file("chat_template.jinja") {
+        return Some(jinja);
+    }
+    let config: serde_json::Value = serde_json::from_str(&file("tokenizer_config.json")?).ok()?;
+    let named_default = |entry: &serde_json::Value| {
+        entry.get("name").and_then(serde_json::Value::as_str) == Some("default")
+    };
+    match config.get("chat_template")? {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Object(named) => named.get("default")?.as_str().map(str::to_string),
+        serde_json::Value::Array(named) => named
+            .iter()
+            .find(|e| named_default(e))
+            .or_else(|| named.first())?
+            .get("template")?
+            .as_str()
+            .map(str::to_string),
+        _ => None,
+    }
+}
+
+/// A manifest layer's text: the one file of a single-file tar layer (as
+/// `llmman build` writes), else the blob itself (as HuggingFace and cloud
+/// pulls store docs and configs).
+pub fn read_layer_text(
+    store: &OciStore,
+    layer: &crate::storage::oci::Descriptor,
+) -> anyhow::Result<String> {
+    use std::io::Read as _;
+    let blob = store.read_blob(&layer.digest)?;
+    if blob.len() >= 512 {
+        let mut archive = tar::Archive::new(std::io::Cursor::new(&blob));
+        if let Ok(entries) = archive.entries() {
+            for mut entry in entries.flatten() {
+                let mut s = String::new();
+                if entry.read_to_string(&mut s).is_ok() && !s.is_empty() {
+                    return Ok(s);
+                }
+            }
+        }
+    }
+    Ok(String::from_utf8_lossy(&blob).into_owned())
+}
+
+/// The GGUF a tar layer was already extracted to, if any.
+fn cached_gguf(cache_path: &Path, layer_hex: &str) -> Option<PathBuf> {
+    std::fs::read_dir(cache_path.join(layer_hex))
+        .ok()?
+        .flatten()
+        .map(|e| e.path())
+        .find(|p| p.extension().and_then(|e| e.to_str()) == Some("gguf"))
 }
 
 /// The manifest's primary GGUF layer and its companion mmproj layer, if


### PR DESCRIPTION
Fixes #453

With a local model, opencode had no thinking levels to cycle (it only derives variants for models it knows from models.dev) and Claude Code's `/effort` was a no-op (the Messages bridge ignored `output_config.effort`).

A fixed set won't do: `docker.io/ai/qwen3.8`'s template raises on any level but `low`/`medium`/`high`/`xhigh`, gpt-oss names none, Qwen3.5/GLM/Gemma 4 have only an `enable_thinking` switch, Llama 3 has none.

- `src/chat_template.rs`: reads a template's thinking controls (levels quoted in Jinja blocks naming `reasoning_effort`, `enable_thinking`, thinks at all). Validated against Qwen3.8, gpt-oss, Qwen3/3.5, GLM-4.7/5, Gemma 4, Nemotron 3, Kimi K2.5, MiniMax M2.5, Llama 3.1, Phi-4.
- `/api/show` returns `template` (as Ollama's), read from the stored blobs without extracting; `llmman show` lists the choices as `thinking`.
- `llmman launch opencode` writes those as ordered `variants`: `none` + levels, or `none` + `thinking` for switch-only templates; none for a non-thinking model; portable `none/low/medium/high` for a provider's model.
- Claude Code: `output_config.effort` → `reasoning_effort`. Local chat completions: `reasoning_effort` mirrored into `chat_template_kwargs` as Ollama's `think` is. `xhigh`/`minimal` join the level vocabulary.
- Codex left alone: its picker lists only OpenAI's catalog; `model_reasoning_effort` already flows through.

Verified live: qwen3.8 → `none, low, medium, high, xhigh`; gemma4 / qwen3.5 (GGUF and safetensors) → `none, thinking`; opencode 1.18.30 puts the variant options on the wire as configured. fmt/clippy/899 unit tests pass.
