### PR TITLE
serve: extract config module

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -33,6 +33,7 @@ use crate::storage::OciStore;
 use crate::webui;
 
 mod aggregation;
+mod config;
 mod responses;
 
 // ---------------------------------------------------------------------------
@@ -136,266 +137,6 @@ pub struct ServeArgs {
     pub pull_bin: bool,
 }
 
-/// Context tokens requested for every backend this daemon spawns — read
-/// from `LLMMAN_CONTEXT_LENGTH` (an env var, not a `llmman serve` flag).
-/// Forwarded to llama-server as-is for generation models (0 meaning
-/// "trained context"); embedding models are always capped to their
-/// trained context. See [`initial_ctx_size`]. Not forwarded to vLLM
-/// when 0.
-///
-/// Unset or unparseable, this falls back to [`DEFAULT_CTX_SIZE`].
-fn context_length_from_env() -> Option<u32> {
-    parse_context_length(std::env::var("LLMMAN_CONTEXT_LENGTH").ok().as_deref())
-}
-
-/// [`context_length_from_env`]'s parsing, split out so it's testable
-/// without mutating the real process environment.
-fn parse_context_length(value: Option<&str>) -> Option<u32> {
-    value?.trim().parse().ok()
-}
-
-/// `--ctx-size` when `LLMMAN_CONTEXT_LENGTH` is unset: 256k regardless
-/// of VRAM, capped per model to its trained context (see
-/// [`initial_ctx_size`]). A load that then OOMs is retried halved (see
-/// [`next_ctx_size_after_oom`]) instead of guessing from memory up front.
-pub const DEFAULT_CTX_SIZE: u32 = 262144;
-
-/// Flash Attention mode requested for every `llama-server` this daemon
-/// spawns — read from `LLMMAN_FLASH_ATTENTION` (an env var, not a
-/// `llmman serve` flag, mirroring [`context_length_from_env`]). Forwarded
-/// verbatim as `--flash-attn <mode>`; unset leaves it off llama-server's
-/// own command line entirely, falling back to its own default (`auto`,
-/// which already enables it whenever the backend/model support it).
-fn flash_attention_from_env() -> Option<String> {
-    parse_flash_attention(std::env::var("LLMMAN_FLASH_ATTENTION").ok().as_deref())
-}
-
-/// [`flash_attention_from_env`]'s parsing, split out so it's testable
-/// without mutating the real process environment. Accepts llama-server's
-/// own vocabulary (`on`/`off`/`auto`) as well as the boolean spelling
-/// (`1`/`0`, `true`/`false`) Ollama documents for `OLLAMA_FLASH_ATTENTION`,
-/// since users porting a config from there would otherwise silently get
-/// llama-server's default instead of what they asked for.
-fn parse_flash_attention(value: Option<&str>) -> Option<String> {
-    let v = value?.trim();
-    if v.is_empty() {
-        return None;
-    }
-    Some(match v.to_ascii_lowercase().as_str() {
-        "1" | "true" | "yes" => "on".to_string(),
-        "0" | "false" | "no" => "off".to_string(),
-        other => other.to_string(),
-    })
-}
-
-/// KV-cache quantization type requested for every `llama-server` this
-/// daemon spawns — read from `LLMMAN_KV_CACHE_TYPE` (an env var, not a
-/// `llmman serve` flag, mirroring [`context_length_from_env`]). Forwarded
-/// as both `--cache-type-k` and `--cache-type-v`: llama-server takes
-/// those separately, but Ollama's `OLLAMA_KV_CACHE_TYPE` (the convention
-/// this mirrors) documents a single value applied to both, and there's no
-/// use case yet for setting K and V independently through this daemon.
-///
-/// One of `f16` (llama-server's own default), `q8_0`, or `q4_0` — the
-/// same set Ollama documents — trades output quality for a smaller
-/// KV-cache footprint at long context lengths. Not validated here;
-/// llama-server rejects an unsupported value itself, surfaced via
-/// `wait_for_ready`'s stderr-tail capture same as any other startup
-/// failure.
-fn kv_cache_type_from_env() -> Option<String> {
-    parse_kv_cache_type(std::env::var("LLMMAN_KV_CACHE_TYPE").ok().as_deref())
-}
-
-/// [`kv_cache_type_from_env`]'s parsing, split out so it's testable
-/// without mutating the real process environment.
-fn parse_kv_cache_type(value: Option<&str>) -> Option<String> {
-    let v = value?.trim();
-    (!v.is_empty()).then(|| v.to_string())
-}
-
-/// `--split-mode` value requested for every `llama-server` spawn — read
-/// from `LLMMAN_SCHED_SPREAD`, llmman's equivalent of Ollama's
-/// `OLLAMA_SCHED_SPREAD`. Truthy forwards `--split-mode layer` (spread
-/// across every GPU — already llama-server's own default, now explicit);
-/// falsey forwards `--split-mode none` (restrict to one GPU). Unset
-/// leaves llama-server's own default untouched.
-fn sched_spread_from_env() -> Option<&'static str> {
-    parse_sched_spread(std::env::var("LLMMAN_SCHED_SPREAD").ok().as_deref())
-}
-
-/// [`sched_spread_from_env`]'s parsing, split out so it's testable
-/// without mutating the real process environment.
-fn parse_sched_spread(value: Option<&str>) -> Option<&'static str> {
-    let v = value?.trim();
-    if v.is_empty() {
-        return None;
-    }
-    match v.to_ascii_lowercase().as_str() {
-        "1" | "true" | "yes" | "on" | "layer" => Some("layer"),
-        "0" | "false" | "no" | "off" | "none" => Some("none"),
-        _ => None,
-    }
-}
-
-/// `--parallel <n>` for every `llama-server` this daemon spawns (GGUF
-/// models only — vllm/mlx_lm.server handle concurrency their own way,
-/// with no equivalent flag), from `LLMMAN_NUM_PARALLEL`. Mirrors
-/// Ollama's `OLLAMA_NUM_PARALLEL`; unset leaves llama-server's own
-/// default of 1 untouched.
-fn num_parallel_from_env() -> Option<u32> {
-    parse_num_parallel(std::env::var("LLMMAN_NUM_PARALLEL").ok().as_deref())
-}
-
-/// `0` is rejected, same as llama-server's own `--parallel` validation.
-fn parse_num_parallel(value: Option<&str>) -> Option<u32> {
-    let n: u32 = value?.trim().parse().ok()?;
-    (n != 0).then_some(n)
-}
-
-/// `--threads <n>` for local `llama-server` spawns, `Some` only when a
-/// CPU limit binds. llama-server's own autodetection
-/// (`cpu_get_num_math()`) already picks the physical/math cores, so an
-/// unconstrained host passes nothing and leaves that choice alone. The
-/// derived value only corrects the case autodetection cannot see: a
-/// cgroup CPU quota, or a narrowed affinity mask, both carried by
-/// `std::thread::available_parallelism` (std walks /proc/self/cgroup
-/// and the ancestor chain itself, v1 and v2). A limit binds when
-/// `available_parallelism` is below the online CPU count; then that
-/// smaller value is passed. Accepted tradeoff: a quota between the
-/// physical-core and SMT-thread counts (e.g. --cpus=12 on an
-/// 8-core/16-thread host) passes 12 where autodetection would pick 8.
-/// Any read or parse failure returns `None`: fail closed to
-/// autodetection. `LLAMA_ARG_THREADS` set in the environment wins:
-/// llama-server reads it itself via plain env inheritance, so `None`
-/// here keeps that explicit choice untouched.
-fn threads_from_env_or_host() -> Option<u32> {
-    if std::env::var_os("LLAMA_ARG_THREADS").is_some() {
-        return None;
-    }
-    #[cfg(target_os = "linux")]
-    {
-        let allowed = std::thread::available_parallelism().ok()?.get() as u32;
-        let online = online_cpu_count()?;
-        (allowed < online).then_some(allowed)
-    }
-    #[cfg(not(target_os = "linux"))]
-    None
-}
-
-/// Online CPUs from /sys/devices/system/cpu/online, the baseline
-/// `available_parallelism` is compared against to decide whether a
-/// quota or affinity limit binds. `None` when the file is unreadable
-/// or malformed.
-#[cfg(target_os = "linux")]
-fn online_cpu_count() -> Option<u32> {
-    cpu_list_count(&std::fs::read_to_string("/sys/devices/system/cpu/online").ok()?)
-}
-
-/// CPU count from a kernel CPU list such as /sys/devices/system/cpu/online:
-/// comma-separated single IDs or inclusive ranges (`0-15`, `0,4-7`).
-/// `None` on empty or malformed content.
-#[cfg(target_os = "linux")]
-fn cpu_list_count(list: &str) -> Option<u32> {
-    let mut count: u32 = 0;
-    for part in list.trim().split(',') {
-        match part.split_once('-') {
-            Some((lo, hi)) => {
-                let (lo, hi): (u32, u32) = (lo.trim().parse().ok()?, hi.trim().parse().ok()?);
-                if lo > hi {
-                    return None;
-                }
-                count = count.checked_add(hi.checked_sub(lo)?.checked_add(1)?)?;
-            }
-            None => {
-                let _: u32 = part.trim().parse().ok()?;
-                count = count.checked_add(1)?;
-            }
-        }
-    }
-    (count > 0).then_some(count)
-}
-
-/// The `--ctx-size` value to actually forward to llama-server: `ctx_size`
-/// (the per-request context every other computation — retries, error
-/// messages, `LLMMAN_CONTEXT_LENGTH` itself — is expressed in) times
-/// `num_parallel`. llama-server splits one `--ctx-size` evenly across
-/// every `--parallel` slot rather than giving each its own full amount,
-/// so forwarding `ctx_size` unscaled would silently divide a request's
-/// real context by `num_parallel`; Ollama avoids exactly this by
-/// launching with `NumCtx * numParallel` (`llm/llama_server.go`).
-/// Callers should only ever pass a non-`None` `num_parallel` alongside
-/// a `Some` `ctx_size` — see `ensure_model`'s own `num_parallel`
-/// fallback, which drops it to `None` otherwise (nothing safe to scale
-/// against).
-fn backend_ctx_size(ctx_size: Option<u32>, num_parallel: Option<u32>) -> Option<u32> {
-    ctx_size.map(|c| c.saturating_mul(num_parallel.unwrap_or(1)))
-}
-
-/// `num_parallel` unless `ctx_size` is `None` (a high-VRAM host
-/// deferring to the model's own trained context, nothing safe to scale
-/// against — see `backend_ctx_size`'s doc comment), in which case
-/// `None`: forwarding `--parallel` unscaled would silently divide that
-/// trained context across slots instead.
-fn effective_num_parallel(ctx_size: Option<u32>, num_parallel: Option<u32>) -> Option<u32> {
-    ctx_size.and(num_parallel)
-}
-
-/// Matches Ollama's own default for `OLLAMA_MAX_QUEUE`.
-const DEFAULT_MAX_QUEUE: usize = 512;
-
-/// Maximum number of requests [`ensure_model`] admits at once before
-/// rejecting with a 503, from `LLMMAN_MAX_QUEUE` (mirrors Ollama's
-/// `OLLAMA_MAX_QUEUE`). See [`try_admit`].
-fn max_queue_from_env() -> usize {
-    parse_max_queue(std::env::var("LLMMAN_MAX_QUEUE").ok().as_deref())
-}
-
-/// Unlike most other `parse_*` functions here, `0` is a real value (see
-/// `try_admit_against`'s doc comment), not "unset".
-fn parse_max_queue(value: Option<&str>) -> usize {
-    match value.map(str::trim) {
-        Some(v) if !v.is_empty() => v.parse().unwrap_or(DEFAULT_MAX_QUEUE),
-        _ => DEFAULT_MAX_QUEUE,
-    }
-}
-
-/// Whether to serve `GET /metrics` at all, from `LLMMAN_METRICS`. Off
-/// unless the operator asked for it: the router has no authentication,
-/// `LLMMAN_HOST` can bind it beyond loopback, and a scrape reports
-/// version, route mix, model names and model churn. None of that should
-/// start answering because llmman was upgraded.
-fn metrics_enabled_from_env() -> bool {
-    parse_metrics_enabled(std::env::var("LLMMAN_METRICS").ok().as_deref())
-}
-
-/// [`metrics_enabled_from_env`]'s parsing, split out so it's testable
-/// without mutating the real process environment. `1` is what the README
-/// documents; the rest of the truthy set is here because every other
-/// boolean env var in this file accepts it, and a `LLMMAN_METRICS=true`
-/// that silently did nothing would be worse than the extra branch.
-fn parse_metrics_enabled(value: Option<&str>) -> bool {
-    matches!(
-        value.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
-        Some("1" | "true" | "yes" | "on")
-    )
-}
-
-/// Maximum number of models [`ensure_model`] keeps loaded at once, from
-/// `LLMMAN_MAX_LOADED_MODELS` (mirrors Ollama's `OLLAMA_MAX_LOADED_MODELS`,
-/// but as one flat daemon-wide total, not per-GPU — llmman has no
-/// per-model memory estimate to size a per-GPU figure against). `0` =
-/// unbounded. See [`enforce_max_loaded_models`].
-fn max_loaded_models_from_env() -> usize {
-    parse_max_loaded_models(std::env::var("LLMMAN_MAX_LOADED_MODELS").ok().as_deref())
-}
-
-fn parse_max_loaded_models(value: Option<&str>) -> usize {
-    value
-        .map(str::trim)
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(0)
-}
-
 /// Which local engine backs a resolved `ModelPath::SafeTensors`
 /// directory: `mlx_lm.server` (see `spawn_mlx_server`) when this host is
 /// Apple Silicon macOS (`crate::hostgpu::detect() == HostGpu::Metal`)
@@ -446,73 +187,6 @@ fn embedding_model_ctx(info: &crate::gguf::Info) -> Option<Option<u32>> {
     let arch = info.architecture()?;
     info.u64(&format!("{arch}.pooling_type"))?;
     Some(gguf_trained_ctx(info))
-}
-
-/// The `--ctx-size` a load starts from: `configured` capped to `trained`
-/// unless it's an `explicit` user value for a non-`embedding` model.
-/// llama-server allocates the KV cache at `--ctx-size` and only caps
-/// per-slot use to `n_ctx_train`, so an unclamped [`DEFAULT_CTX_SIZE`]
-/// would reserve 256k of KV for a 32k model. 0/`None` mean `trained`.
-fn initial_ctx_size(
-    configured: Option<u32>,
-    explicit: bool,
-    trained: Option<u32>,
-    embedding: bool,
-) -> Option<u32> {
-    let Some(trained) = trained else {
-        return configured;
-    };
-    if explicit && !embedding {
-        return configured;
-    }
-    Some(
-        configured
-            .filter(|n| *n > 0)
-            .map_or(trained, |n| n.min(trained)),
-    )
-}
-
-// ---------------------------------------------------------------------------
-// Out-of-memory auto-shrink retry (ensure_model) — mirrors Ollama's
-// reduceAutoNumCtxForLoadOOM: a chosen --ctx-size can still be too big
-// for actual free VRAM, so retry with it halved a few times instead of
-// failing the load outright.
-// ---------------------------------------------------------------------------
-
-/// Max halving retries for an OOM-looking llama-server load.
-const MAX_CTX_SHRINK_ATTEMPTS: u32 = 4;
-
-/// Floor below which a still-failing load is a hard failure, not
-/// something to keep shrinking.
-const MIN_CTX_SIZE_FOR_RETRY: u32 = 16384;
-
-/// Next `--ctx-size` to retry an OOM'd load with, or `None` if shrinking
-/// further wouldn't help (at/under the floor already).
-fn next_ctx_size_after_oom(current: u32) -> Option<u32> {
-    let next = (current / 2).max(MIN_CTX_SIZE_FOR_RETRY);
-    // `next < current`, not `!=`: below the floor, halving+max would
-    // otherwise suggest a *larger* ctx-size after an OOM.
-    (next < current).then_some(next)
-}
-
-/// True if `detail` (a failed load's stderr tail, or an error message)
-/// looks like a memory-allocation failure rather than some other startup
-/// error. Matched against known ggml/llama.cpp allocator log phrasings —
-/// deliberately specific rather than one broad substring, since
-/// misclassifying an unrelated failure as OOM would burn several slow
-/// retries before surfacing the real error.
-fn looks_like_oom(detail: &str) -> bool {
-    let d = detail.to_ascii_lowercase();
-    [
-        "failed to allocate",
-        "out of memory",
-        "not enough memory",
-        "insufficient memory",
-        "cudamalloc failed",
-        "std::bad_alloc",
-    ]
-    .iter()
-    .any(|needle| d.contains(needle))
 }
 
 // ---------------------------------------------------------------------------
@@ -3623,7 +3297,7 @@ async fn local_context_overflow(resp: Response) -> Result<Response, String> {
 /// options blob (OpenAI-compat, Anthropic, embeddings, preload).
 /// Precedence for the thread count a local llama-server ends up with:
 /// request option > `LLAMA_ARG_THREADS` > the derived `state.threads`
-/// (see [`threads_from_env_or_host`]) > llama-server's own
+/// (see [`config::threads_from_env_or_host`]) > llama-server's own
 /// autodetection. The request option is forwarded as `--threads`, and
 /// llama.cpp applies env before CLI, so that flag wins over
 /// `LLAMA_ARG_THREADS`; when the option is absent, `state.threads` is
@@ -3803,7 +3477,7 @@ async fn ensure_model(
     // attempt, not just the first — otherwise a retry's replacement
     // process could try to bind the same port the previous (failed,
     // possibly not-yet-fully-exited) one was still holding.
-    let mut ctx_size = initial_ctx_size(
+    let mut ctx_size = config::initial_ctx_size(
         state.0.ctx_size,
         state.0.ctx_size_explicit,
         trained_ctx,
@@ -3813,7 +3487,7 @@ async fn ensure_model(
     // A `None` ctx_size has nothing to scale — an unscaled --parallel
     // would divide the trained context across slots. Decided once so the
     // retries below can't start multiplying by it partway through.
-    let num_parallel = effective_num_parallel(ctx_size, state.0.num_parallel);
+    let num_parallel = config::effective_num_parallel(ctx_size, state.0.num_parallel);
     if state.0.num_parallel.is_some() && num_parallel.is_none() {
         eprintln!(
             "[llmman] {model_ref}: no explicit ctx-size to scale, ignoring LLMMAN_NUM_PARALLEL for this load"
@@ -3828,7 +3502,7 @@ async fn ensure_model(
         eprintln!("[llmman] loading {model_ref} on port {port}");
         // See backend_ctx_size's doc comment — the value actually
         // forwarded as --ctx-size, scaled up for num_parallel.
-        let scaled_ctx_size = backend_ctx_size(ctx_size, num_parallel);
+        let scaled_ctx_size = config::backend_ctx_size(ctx_size, num_parallel);
         // Resolved once here, then forwarded verbatim to whichever of
         // the two llama-server spawners this load ends up using — see
         // container::LlamaOptions.
@@ -3888,7 +3562,7 @@ async fn ensure_model(
             Ok(()) => break,
             Err(e) => {
                 let looks_oom = stderr_tail.is_some() // llama-server only
-                    && looks_like_oom(&e.to_string());
+                    && config::looks_like_oom(&e.to_string());
                 if !looks_oom {
                     return Err(e.into());
                 }
@@ -3935,9 +3609,9 @@ async fn ensure_model(
                 // Ollama's own numCtxAuto gate on
                 // reduceAutoNumCtxForLoadOOM).
                 let can_shrink =
-                    !state.0.ctx_size_explicit && shrink_attempts < MAX_CTX_SHRINK_ATTEMPTS;
+                    !state.0.ctx_size_explicit && shrink_attempts < config::MAX_CTX_SHRINK_ATTEMPTS;
                 let Some(next) = can_shrink
-                    .then(|| ctx_size.and_then(next_ctx_size_after_oom))
+                    .then(|| ctx_size.and_then(config::next_ctx_size_after_oom))
                     .flatten()
                 else {
                     return Err(e.into());
@@ -7976,7 +7650,7 @@ fn ollama_router() -> Router<AppState> {
 }
 
 /// `GET /metrics`, or nothing at all when `LLMMAN_METRICS` is unset —
-/// see [`metrics_enabled_from_env`]. Absent means a 404, the same answer
+/// see [`config::metrics_enabled_from_env`]. Absent means a 404, the same answer
 /// as any other path this daemon does not serve, so a disabled endpoint
 /// is not distinguishable from a build without one.
 ///
@@ -8085,7 +7759,7 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
 
     // The accelerator probe only weighs this node in aggregation, so
     // it's skipped without peers. spawn_blocking: it spawns a subprocess.
-    let ctx_size_explicit = context_length_from_env();
+    let ctx_size_explicit = config::context_length_from_env();
     let vram = if !peers.is_empty() {
         tokio::task::spawn_blocking(crate::hostgpu::detect_with_vram)
             .await
@@ -8094,7 +7768,7 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
     } else {
         0
     };
-    let ctx_size = ctx_size_explicit.or(Some(DEFAULT_CTX_SIZE));
+    let ctx_size = ctx_size_explicit.or(Some(config::DEFAULT_CTX_SIZE));
     let memory = crate::hostgpu::memory_bytes(vram);
     if !peers.is_empty() {
         eprintln!(
@@ -8109,7 +7783,7 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
     // explainable from the startup output. Only the local spawn path
     // consumes the derived value, so don't log it under --ociman (the
     // container arm deliberately ignores it).
-    let threads = threads_from_env_or_host();
+    let threads = config::threads_from_env_or_host();
     if let Some(n) = threads {
         if _args.ociman.is_none() {
             eprintln!("[llmman] llama-server gets --threads {n} (CPU quota/affinity limit below the online CPU count)");
@@ -8135,13 +7809,13 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         ctx_size,
         ctx_size_explicit: ctx_size_explicit.is_some(),
         hybrid_local_bytes: crate::hybrid::local_budget_bytes_from_env(ctx_size),
-        flash_attention: flash_attention_from_env(),
-        kv_cache_type: kv_cache_type_from_env(),
-        split_mode: sched_spread_from_env(),
-        num_parallel: num_parallel_from_env(),
+        flash_attention: config::flash_attention_from_env(),
+        kv_cache_type: config::kv_cache_type_from_env(),
+        split_mode: config::sched_spread_from_env(),
+        num_parallel: config::num_parallel_from_env(),
         threads,
-        max_queue: max_queue_from_env(),
-        max_loaded_models: max_loaded_models_from_env(),
+        max_queue: config::max_queue_from_env(),
+        max_loaded_models: config::max_loaded_models_from_env(),
         peers,
         memory,
         store_path,
@@ -8149,7 +7823,7 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         client: Client::new(),
     }));
 
-    let app = build_router(state.clone(), metrics_enabled_from_env());
+    let app = build_router(state.clone(), config::metrics_enabled_from_env());
 
     // Before the listener binds, so uptime counts from the daemon coming
     // up rather than from whenever something first scraped it.
@@ -10426,25 +10100,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_max_queue_defaults_to_ollamas_own_512_on_anything_unparseable() {
-        assert_eq!(parse_max_queue(None), 512);
-        assert_eq!(parse_max_queue(Some("")), 512);
-        assert_eq!(parse_max_queue(Some("garbage")), 512);
-        assert_eq!(parse_max_queue(Some("10")), 10);
-        // Unlike most other LLMMAN_*/parse_* pairs, an explicit "0" is a
-        // real value (disables the bound), not treated as unset.
-        assert_eq!(parse_max_queue(Some("0")), 0);
-    }
-
-    #[test]
-    fn parse_max_loaded_models_defaults_to_unbounded_on_anything_unparseable() {
-        assert_eq!(parse_max_loaded_models(None), 0);
-        assert_eq!(parse_max_loaded_models(Some("")), 0);
-        assert_eq!(parse_max_loaded_models(Some("garbage")), 0);
-        assert_eq!(parse_max_loaded_models(Some("3")), 3);
-    }
-
-    #[test]
     fn try_admit_rejects_once_the_cap_is_reached_and_releases_on_drop() {
         // A dedicated counter, not the real PENDING_REQUESTS — isolates
         // this from other tests running in parallel.
@@ -10600,20 +10255,6 @@ mod tests {
         drop(guard);
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert_eq!(state.0.manager.lock().await.pending_loads, 0);
-    }
-
-    #[test]
-    fn parse_metrics_enabled_accepts_the_truthy_spellings_and_nothing_else() {
-        for on in ["1", "true", "TRUE", "yes", "on", " 1 "] {
-            assert!(parse_metrics_enabled(Some(on)), "{on:?} should enable");
-        }
-        for off in ["0", "false", "no", "off", "", "  ", "2", "enabled"] {
-            assert!(!parse_metrics_enabled(Some(off)), "{off:?} should not");
-        }
-        assert!(
-            !parse_metrics_enabled(None),
-            "unset is the default, and the default is off"
-        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -11544,112 +11185,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_context_length_accepts_a_plain_number_and_rejects_everything_else() {
-        assert_eq!(parse_context_length(Some("32768")), Some(32768));
-        assert_eq!(parse_context_length(Some(" 32768 \n")), Some(32768));
-        assert_eq!(parse_context_length(Some("0")), Some(0));
-        assert_eq!(parse_context_length(None), None);
-        assert_eq!(parse_context_length(Some("")), None);
-        assert_eq!(parse_context_length(Some("not-a-number")), None);
-        assert_eq!(parse_context_length(Some("-1")), None);
-    }
-
-    #[test]
-    fn parse_flash_attention_accepts_llama_server_and_ollama_spellings() {
-        // llama-server's own vocabulary passes straight through.
-        assert_eq!(parse_flash_attention(Some("on")), Some("on".into()));
-        assert_eq!(parse_flash_attention(Some("off")), Some("off".into()));
-        assert_eq!(parse_flash_attention(Some("auto")), Some("auto".into()));
-        // Ollama's OLLAMA_FLASH_ATTENTION boolean spelling is translated.
-        assert_eq!(parse_flash_attention(Some("1")), Some("on".into()));
-        assert_eq!(parse_flash_attention(Some("true")), Some("on".into()));
-        assert_eq!(parse_flash_attention(Some("0")), Some("off".into()));
-        assert_eq!(parse_flash_attention(Some("false")), Some("off".into()));
-        // Case-insensitive, whitespace-tolerant.
-        assert_eq!(parse_flash_attention(Some(" ON \n")), Some("on".into()));
-        // Unset/empty leaves llama-server's own default untouched.
-        assert_eq!(parse_flash_attention(None), None);
-        assert_eq!(parse_flash_attention(Some("")), None);
-        assert_eq!(parse_flash_attention(Some("   ")), None);
-    }
-
-    #[test]
-    fn parse_kv_cache_type_trims_whitespace_and_treats_empty_as_unset() {
-        assert_eq!(parse_kv_cache_type(Some("q8_0")), Some("q8_0".into()));
-        assert_eq!(parse_kv_cache_type(Some(" q4_0 \n")), Some("q4_0".into()));
-        assert_eq!(parse_kv_cache_type(None), None);
-        assert_eq!(parse_kv_cache_type(Some("")), None);
-        assert_eq!(parse_kv_cache_type(Some("   ")), None);
-    }
-
-    #[test]
-    fn parse_sched_spread_maps_truthy_and_falsey_spellings_to_split_mode() {
-        for truthy in ["1", "true", "yes", "on", "layer", " ON \n"] {
-            assert_eq!(
-                parse_sched_spread(Some(truthy)),
-                Some("layer"),
-                "input {truthy:?}"
-            );
-        }
-        for falsey in ["0", "false", "no", "off", "none", " OFF \n"] {
-            assert_eq!(
-                parse_sched_spread(Some(falsey)),
-                Some("none"),
-                "input {falsey:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn parse_sched_spread_leaves_llama_servers_own_default_untouched_when_unset_or_unparseable() {
-        assert_eq!(parse_sched_spread(None), None);
-        assert_eq!(parse_sched_spread(Some("")), None);
-        assert_eq!(parse_sched_spread(Some("   ")), None);
-        assert_eq!(parse_sched_spread(Some("garbage")), None);
-    }
-
-    #[test]
-    fn parse_num_parallel_accepts_a_positive_integer() {
-        assert_eq!(parse_num_parallel(Some("4")), Some(4));
-        assert_eq!(parse_num_parallel(Some(" 1 ")), Some(1));
-    }
-
-    #[test]
-    fn parse_num_parallel_rejects_zero_and_unparseable_values() {
-        assert_eq!(parse_num_parallel(Some("0")), None);
-        assert_eq!(parse_num_parallel(None), None);
-        assert_eq!(parse_num_parallel(Some("")), None);
-        assert_eq!(parse_num_parallel(Some("-1")), None);
-        assert_eq!(parse_num_parallel(Some("garbage")), None);
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn cpu_list_count_counts_ids_and_inclusive_ranges() {
-        // (kernel CPU list, expected count)
-        let cases = [
-            ("0-15\n", Some(16)),
-            ("0", Some(1)),
-            ("0,4-7\n", Some(5)),
-            ("0-3,8-11\n", Some(8)),
-            // Malformed or empty content fails closed: the caller then
-            // passes no --threads and llama-server autodetects.
-            ("", None),
-            ("\n", None),
-            ("3-1", None),
-            ("0-x", None),
-            ("a", None),
-            ("0,,2", None),
-            // Range length would overflow u32; no kernel emits this.
-            ("0-4294967295", None),
-            ("0-4294967295,4", None),
-        ];
-        for (list, expected) in &cases {
-            assert_eq!(&cpu_list_count(list), expected, "list={list:?}");
-        }
-    }
-
-    #[test]
     fn vllm_max_model_len_uses_only_explicit_ctx_size() {
         assert_eq!(vllm_max_model_len(Some(4096), true), Some(4096));
         assert_eq!(vllm_max_model_len(Some(0), true), None);
@@ -11679,34 +11214,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn backend_ctx_size_scales_by_num_parallel_so_each_slot_keeps_the_full_context() {
-        // llama-server splits one --ctx-size evenly across every
-        // --parallel slot, so this must scale up to compensate —
-        // matching Ollama's own NumCtx * numParallel.
-        assert_eq!(backend_ctx_size(Some(4096), Some(4)), Some(16384));
-        assert_eq!(backend_ctx_size(Some(4096), Some(1)), Some(4096));
-        assert_eq!(backend_ctx_size(Some(4096), None), Some(4096));
-        assert_eq!(backend_ctx_size(None, Some(4)), None);
-        assert_eq!(backend_ctx_size(None, None), None);
-    }
-
-    #[test]
-    fn backend_ctx_size_saturates_instead_of_overflowing() {
-        assert_eq!(backend_ctx_size(Some(u32::MAX), Some(2)), Some(u32::MAX));
-    }
-
-    #[test]
-    fn effective_num_parallel_drops_to_none_without_a_ctx_size_to_scale() {
-        // Nothing to scale --parallel against, so don't forward it at
-        // all rather than let llama-server silently divide the model's
-        // own trained context across slots.
-        assert_eq!(effective_num_parallel(None, Some(4)), None);
-        assert_eq!(effective_num_parallel(Some(4096), Some(4)), Some(4));
-        assert_eq!(effective_num_parallel(Some(4096), None), None);
-        assert_eq!(effective_num_parallel(None, None), None);
-    }
-
     /// The GGUF test (ollama's own): a `{arch}.pooling_type` key marks an
     /// embedding model; both kinds report their trained context.
     #[test]
@@ -11721,43 +11228,6 @@ mod tests {
         assert_eq!(embedding_model_ctx(&embed_info), Some(Some(4096)));
         assert_eq!(gguf_trained_ctx(&chat_info), Some(4096));
         assert_eq!(gguf_trained_ctx(&embed_info), Some(4096));
-    }
-
-    #[test]
-    fn initial_ctx_size_caps_the_auto_default_at_the_trained_context() {
-        let auto = Some(DEFAULT_CTX_SIZE);
-        // Smaller trained context wins; larger leaves the default alone.
-        assert_eq!(
-            initial_ctx_size(auto, false, Some(32768), false),
-            Some(32768)
-        );
-        assert_eq!(initial_ctx_size(auto, false, Some(1 << 20), false), auto);
-        // No readable header: nothing to clamp against.
-        assert_eq!(initial_ctx_size(auto, false, None, false), auto);
-    }
-
-    #[test]
-    fn initial_ctx_size_forwards_an_explicit_value_unless_embedding() {
-        // A user's LLMMAN_CONTEXT_LENGTH is theirs to get wrong; 0 stays 0.
-        assert_eq!(
-            initial_ctx_size(Some(65536), true, Some(4096), false),
-            Some(65536)
-        );
-        assert_eq!(initial_ctx_size(Some(0), true, Some(4096), false), Some(0));
-        // Embedding models are capped regardless, and 0/None mean trained.
-        assert_eq!(
-            initial_ctx_size(Some(65536), true, Some(4096), true),
-            Some(4096)
-        );
-        assert_eq!(
-            initial_ctx_size(Some(2048), true, Some(4096), true),
-            Some(2048)
-        );
-        assert_eq!(
-            initial_ctx_size(Some(0), false, Some(4096), true),
-            Some(4096)
-        );
-        assert_eq!(initial_ctx_size(None, false, Some(4096), true), Some(4096));
     }
 
     /// `/api/embed` takes a string or an array of strings, and nothing
@@ -11951,55 +11421,6 @@ mod tests {
         assert!(!supports_context_shift("DeepSeek-V2.5:latest")); // case-insensitive
         assert!(supports_context_shift("qwen3.5:latest"));
         assert!(supports_context_shift("gpt-oss:20b"));
-    }
-
-    #[test]
-    fn next_ctx_size_after_oom_halves_from_the_default_down_to_the_floor() {
-        assert_eq!(next_ctx_size_after_oom(DEFAULT_CTX_SIZE), Some(131072));
-        assert_eq!(next_ctx_size_after_oom(131072), Some(65536));
-        assert_eq!(next_ctx_size_after_oom(65536), Some(32768));
-        assert_eq!(next_ctx_size_after_oom(32768), Some(16384));
-        // At (or below) the floor, no further shrink is offered.
-        assert_eq!(next_ctx_size_after_oom(16384), None);
-        assert_eq!(next_ctx_size_after_oom(8192), None);
-    }
-
-    #[test]
-    fn default_ctx_size_reaches_the_floor_within_the_shrink_budget() {
-        // 262144 -> 131072 -> 65536 -> 32768 -> 16384: exactly
-        // MAX_CTX_SHRINK_ATTEMPTS halvings, so the floor is reachable.
-        let mut ctx = DEFAULT_CTX_SIZE;
-        let mut attempts = 0;
-        while let Some(next) = next_ctx_size_after_oom(ctx) {
-            ctx = next;
-            attempts += 1;
-        }
-        assert_eq!(ctx, MIN_CTX_SIZE_FOR_RETRY);
-        assert!(attempts <= MAX_CTX_SHRINK_ATTEMPTS);
-    }
-
-    #[test]
-    fn looks_like_oom_matches_known_allocation_failure_phrasings() {
-        for msg in [
-            "ggml_backend_alloc_ctx_tensors_from_buft: failed to allocate CUDA0 buffer of size 123",
-            "llama_kv_cache: failed to allocate buffer for kv cache",
-            "CUDA error: out of memory",
-            "terminate called after throwing an instance of 'std::bad_alloc'",
-            "cudaMalloc failed: out of memory",
-        ] {
-            assert!(looks_like_oom(msg), "expected OOM match for {msg:?}");
-        }
-    }
-
-    #[test]
-    fn looks_like_oom_does_not_flag_unrelated_startup_failures() {
-        for msg in [
-            "error while loading shared libraries: libcuda.so.1: cannot open shared object file",
-            "error loading model: unknown architecture 'not-a-real-arch'",
-            "error: unknown argument: --not-a-real-flag",
-        ] {
-            assert!(!looks_like_oom(msg), "unexpected OOM match for {msg:?}");
-        }
     }
 
     /// Regression test for the Claude Code bug described on

--- a/src/cmd/serve/config.rs
+++ b/src/cmd/serve/config.rs
@@ -1,0 +1,594 @@
+//! `llmman serve` configuration — env-var parsing and `*_from_env` /
+//! `parse_*` helpers, plus the context-size (`initial_ctx_size`,
+//! `backend_ctx_size`, the OOM auto-shrink retry) arithmetic.
+//!
+//! Split out of `serve.rs` (see the tracking issue for the full
+//! `serve.rs` submodule split). These are pure functions with unit tests;
+//! moving them changes no runtime behaviour.
+
+/// Context tokens requested for every backend this daemon spawns — read
+/// from `LLMMAN_CONTEXT_LENGTH` (an env var, not a `llmman serve` flag).
+/// Forwarded to llama-server as-is for generation models (0 meaning
+/// "trained context"); embedding models are always capped to their
+/// trained context. See [`initial_ctx_size`]. Not forwarded to vLLM
+/// when 0.
+///
+/// Unset or unparseable, this falls back to [`DEFAULT_CTX_SIZE`].
+pub(super) fn context_length_from_env() -> Option<u32> {
+    parse_context_length(std::env::var("LLMMAN_CONTEXT_LENGTH").ok().as_deref())
+}
+
+/// [`context_length_from_env`]'s parsing, split out so it's testable
+/// without mutating the real process environment.
+fn parse_context_length(value: Option<&str>) -> Option<u32> {
+    value?.trim().parse().ok()
+}
+
+/// `--ctx-size` when `LLMMAN_CONTEXT_LENGTH` is unset: 256k regardless
+/// of VRAM, capped per model to its trained context (see
+/// [`initial_ctx_size`]). A load that then OOMs is retried halved (see
+/// [`next_ctx_size_after_oom`]) instead of guessing from memory up front.
+pub(super) const DEFAULT_CTX_SIZE: u32 = 262144;
+
+/// Flash Attention mode requested for every `llama-server` this daemon
+/// spawns — read from `LLMMAN_FLASH_ATTENTION` (an env var, not a
+/// `llmman serve` flag, mirroring [`context_length_from_env`]). Forwarded
+/// verbatim as `--flash-attn <mode>`; unset leaves it off llama-server's
+/// own command line entirely, falling back to its own default (`auto`,
+/// which already enables it whenever the backend/model support it).
+pub(super) fn flash_attention_from_env() -> Option<String> {
+    parse_flash_attention(std::env::var("LLMMAN_FLASH_ATTENTION").ok().as_deref())
+}
+
+/// [`flash_attention_from_env`]'s parsing, split out so it's testable
+/// without mutating the real process environment. Accepts llama-server's
+/// own vocabulary (`on`/`off`/`auto`) as well as the boolean spelling
+/// (`1`/`0`, `true`/`false`) Ollama documents for `OLLAMA_FLASH_ATTENTION`,
+/// since users porting a config from there would otherwise silently get
+/// llama-server's default instead of what they asked for.
+fn parse_flash_attention(value: Option<&str>) -> Option<String> {
+    let v = value?.trim();
+    if v.is_empty() {
+        return None;
+    }
+    Some(match v.to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" => "on".to_string(),
+        "0" | "false" | "no" => "off".to_string(),
+        other => other.to_string(),
+    })
+}
+
+/// KV-cache quantization type requested for every `llama-server` this
+/// daemon spawns — read from `LLMMAN_KV_CACHE_TYPE` (an env var, not a
+/// `llmman serve` flag, mirroring [`context_length_from_env`]). Forwarded
+/// as both `--cache-type-k` and `--cache-type-v`: llama-server takes
+/// those separately, but Ollama's `OLLAMA_KV_CACHE_TYPE` (the convention
+/// this mirrors) documents a single value applied to both, and there's no
+/// use case yet for setting K and V independently through this daemon.
+///
+/// One of `f16` (llama-server's own default), `q8_0`, or `q4_0` — the
+/// same set Ollama documents — trades output quality for a smaller
+/// KV-cache footprint at long context lengths. Not validated here;
+/// llama-server rejects an unsupported value itself, surfaced via
+/// `wait_for_ready`'s stderr-tail capture same as any other startup
+/// failure.
+pub(super) fn kv_cache_type_from_env() -> Option<String> {
+    parse_kv_cache_type(std::env::var("LLMMAN_KV_CACHE_TYPE").ok().as_deref())
+}
+
+/// [`kv_cache_type_from_env`]'s parsing, split out so it's testable
+/// without mutating the real process environment.
+fn parse_kv_cache_type(value: Option<&str>) -> Option<String> {
+    let v = value?.trim();
+    (!v.is_empty()).then(|| v.to_string())
+}
+
+/// `--split-mode` value requested for every `llama-server` spawn — read
+/// from `LLMMAN_SCHED_SPREAD`, llmman's equivalent of Ollama's
+/// `OLLAMA_SCHED_SPREAD`. Truthy forwards `--split-mode layer` (spread
+/// across every GPU — already llama-server's own default, now explicit);
+/// falsey forwards `--split-mode none` (restrict to one GPU). Unset
+/// leaves llama-server's own default untouched.
+pub(super) fn sched_spread_from_env() -> Option<&'static str> {
+    parse_sched_spread(std::env::var("LLMMAN_SCHED_SPREAD").ok().as_deref())
+}
+
+/// [`sched_spread_from_env`]'s parsing, split out so it's testable
+/// without mutating the real process environment.
+fn parse_sched_spread(value: Option<&str>) -> Option<&'static str> {
+    let v = value?.trim();
+    if v.is_empty() {
+        return None;
+    }
+    match v.to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" | "layer" => Some("layer"),
+        "0" | "false" | "no" | "off" | "none" => Some("none"),
+        _ => None,
+    }
+}
+
+/// `--parallel <n>` for every `llama-server` this daemon spawns (GGUF
+/// models only — vllm/mlx_lm.server handle concurrency their own way,
+/// with no equivalent flag), from `LLMMAN_NUM_PARALLEL`. Mirrors
+/// Ollama's `OLLAMA_NUM_PARALLEL`; unset leaves llama-server's own
+/// default of 1 untouched.
+pub(super) fn num_parallel_from_env() -> Option<u32> {
+    parse_num_parallel(std::env::var("LLMMAN_NUM_PARALLEL").ok().as_deref())
+}
+
+/// `0` is rejected, same as llama-server's own `--parallel` validation.
+fn parse_num_parallel(value: Option<&str>) -> Option<u32> {
+    let n: u32 = value?.trim().parse().ok()?;
+    (n != 0).then_some(n)
+}
+
+/// `--threads <n>` for local `llama-server` spawns, `Some` only when a
+/// CPU limit binds. llama-server's own autodetection
+/// (`cpu_get_num_math()`) already picks the physical/math cores, so an
+/// unconstrained host passes nothing and leaves that choice alone. The
+/// derived value only corrects the case autodetection cannot see: a
+/// cgroup CPU quota, or a narrowed affinity mask, both carried by
+/// `std::thread::available_parallelism` (std walks /proc/self/cgroup
+/// and the ancestor chain itself, v1 and v2). A limit binds when
+/// `available_parallelism` is below the online CPU count; then that
+/// smaller value is passed. Accepted tradeoff: a quota between the
+/// physical-core and SMT-thread counts (e.g. --cpus=12 on an
+/// 8-core/16-thread host) passes 12 where autodetection would pick 8.
+/// Any read or parse failure returns `None`: fail closed to
+/// autodetection. `LLAMA_ARG_THREADS` set in the environment wins:
+/// llama-server reads it itself via plain env inheritance, so `None`
+/// here keeps that explicit choice untouched.
+pub(super) fn threads_from_env_or_host() -> Option<u32> {
+    if std::env::var_os("LLAMA_ARG_THREADS").is_some() {
+        return None;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let allowed = std::thread::available_parallelism().ok()?.get() as u32;
+        let online = online_cpu_count()?;
+        (allowed < online).then_some(allowed)
+    }
+    #[cfg(not(target_os = "linux"))]
+    None
+}
+
+/// Online CPUs from /sys/devices/system/cpu/online, the baseline
+/// `available_parallelism` is compared against to decide whether a
+/// quota or affinity limit binds. `None` when the file is unreadable
+/// or malformed.
+#[cfg(target_os = "linux")]
+fn online_cpu_count() -> Option<u32> {
+    cpu_list_count(&std::fs::read_to_string("/sys/devices/system/cpu/online").ok()?)
+}
+
+/// CPU count from a kernel CPU list such as /sys/devices/system/cpu/online:
+/// comma-separated single IDs or inclusive ranges (`0-15`, `0,4-7`).
+/// `None` on empty or malformed content.
+#[cfg(target_os = "linux")]
+fn cpu_list_count(list: &str) -> Option<u32> {
+    let mut count: u32 = 0;
+    for part in list.trim().split(',') {
+        match part.split_once('-') {
+            Some((lo, hi)) => {
+                let (lo, hi): (u32, u32) = (lo.trim().parse().ok()?, hi.trim().parse().ok()?);
+                if lo > hi {
+                    return None;
+                }
+                count = count.checked_add(hi.checked_sub(lo)?.checked_add(1)?)?;
+            }
+            None => {
+                let _: u32 = part.trim().parse().ok()?;
+                count = count.checked_add(1)?;
+            }
+        }
+    }
+    (count > 0).then_some(count)
+}
+
+/// The `--ctx-size` value to actually forward to llama-server: `ctx_size`
+/// (the per-request context every other computation — retries, error
+/// messages, `LLMMAN_CONTEXT_LENGTH` itself — is expressed in) times
+/// `num_parallel`. llama-server splits one `--ctx-size` evenly across
+/// every `--parallel` slot rather than giving each its own full amount,
+/// so forwarding `ctx_size` unscaled would silently divide a request's
+/// real context by `num_parallel`; Ollama avoids exactly this by
+/// launching with `NumCtx * numParallel` (`llm/llama_server.go`).
+/// Callers should only ever pass a non-`None` `num_parallel` alongside
+/// a `Some` `ctx_size` — see `ensure_model`'s own `num_parallel`
+/// fallback, which drops it to `None` otherwise (nothing safe to scale
+/// against).
+pub(super) fn backend_ctx_size(ctx_size: Option<u32>, num_parallel: Option<u32>) -> Option<u32> {
+    ctx_size.map(|c| c.saturating_mul(num_parallel.unwrap_or(1)))
+}
+
+/// `num_parallel` unless `ctx_size` is `None` (a high-VRAM host
+/// deferring to the model's own trained context, nothing safe to scale
+/// against — see `backend_ctx_size`'s doc comment), in which case
+/// `None`: forwarding `--parallel` unscaled would silently divide that
+/// trained context across slots instead.
+pub(super) fn effective_num_parallel(
+    ctx_size: Option<u32>,
+    num_parallel: Option<u32>,
+) -> Option<u32> {
+    ctx_size.and(num_parallel)
+}
+
+/// Matches Ollama's own default for `OLLAMA_MAX_QUEUE`.
+const DEFAULT_MAX_QUEUE: usize = 512;
+
+/// Maximum number of requests [`super::ensure_model`] admits at once before
+/// rejecting with a 503, from `LLMMAN_MAX_QUEUE` (mirrors Ollama's
+/// `OLLAMA_MAX_QUEUE`). See [`super::try_admit`].
+pub(super) fn max_queue_from_env() -> usize {
+    parse_max_queue(std::env::var("LLMMAN_MAX_QUEUE").ok().as_deref())
+}
+
+/// Unlike most other `parse_*` functions here, `0` is a real value (see
+/// `try_admit_against`'s doc comment), not "unset".
+fn parse_max_queue(value: Option<&str>) -> usize {
+    match value.map(str::trim) {
+        Some(v) if !v.is_empty() => v.parse().unwrap_or(DEFAULT_MAX_QUEUE),
+        _ => DEFAULT_MAX_QUEUE,
+    }
+}
+
+/// Whether to serve `GET /metrics` at all, from `LLMMAN_METRICS`. Off
+/// unless the operator asked for it: the router has no authentication,
+/// `LLMMAN_HOST` can bind it beyond loopback, and a scrape reports
+/// version, route mix, model names and model churn. None of that should
+/// start answering because llmman was upgraded.
+pub(super) fn metrics_enabled_from_env() -> bool {
+    parse_metrics_enabled(std::env::var("LLMMAN_METRICS").ok().as_deref())
+}
+
+/// [`metrics_enabled_from_env`]'s parsing, split out so it's testable
+/// without mutating the real process environment. `1` is what the README
+/// documents; the rest of the truthy set is here because every other
+/// boolean env var in this file accepts it, and a `LLMMAN_METRICS=true`
+/// that silently did nothing would be worse than the extra branch.
+fn parse_metrics_enabled(value: Option<&str>) -> bool {
+    matches!(
+        value.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    )
+}
+
+/// Maximum number of models [`super::ensure_model`] keeps loaded at once, from
+/// `LLMMAN_MAX_LOADED_MODELS` (mirrors Ollama's `OLLAMA_MAX_LOADED_MODELS`,
+/// but as one flat daemon-wide total, not per-GPU — llmman has no
+/// per-model memory estimate to size a per-GPU figure against). `0` =
+/// unbounded. See [`super::enforce_max_loaded_models`].
+pub(super) fn max_loaded_models_from_env() -> usize {
+    parse_max_loaded_models(std::env::var("LLMMAN_MAX_LOADED_MODELS").ok().as_deref())
+}
+
+fn parse_max_loaded_models(value: Option<&str>) -> usize {
+    value
+        .map(str::trim)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0)
+}
+/// The `--ctx-size` a load starts from: `configured` capped to `trained`
+/// unless it's an `explicit` user value for a non-`embedding` model.
+/// llama-server allocates the KV cache at `--ctx-size` and only caps
+/// per-slot use to `n_ctx_train`, so an unclamped [`DEFAULT_CTX_SIZE`]
+/// would reserve 256k of KV for a 32k model. 0/`None` mean `trained`.
+pub(super) fn initial_ctx_size(
+    configured: Option<u32>,
+    explicit: bool,
+    trained: Option<u32>,
+    embedding: bool,
+) -> Option<u32> {
+    let Some(trained) = trained else {
+        return configured;
+    };
+    if explicit && !embedding {
+        return configured;
+    }
+    Some(
+        configured
+            .filter(|n| *n > 0)
+            .map_or(trained, |n| n.min(trained)),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Out-of-memory auto-shrink retry (ensure_model) — mirrors Ollama's
+// reduceAutoNumCtxForLoadOOM: a chosen --ctx-size can still be too big
+// for actual free VRAM, so retry with it halved a few times instead of
+// failing the load outright.
+// ---------------------------------------------------------------------------
+
+/// Max halving retries for an OOM-looking llama-server load.
+pub(super) const MAX_CTX_SHRINK_ATTEMPTS: u32 = 4;
+
+/// Floor below which a still-failing load is a hard failure, not
+/// something to keep shrinking.
+const MIN_CTX_SIZE_FOR_RETRY: u32 = 16384;
+
+/// Next `--ctx-size` to retry an OOM'd load with, or `None` if shrinking
+/// further wouldn't help (at/under the floor already).
+pub(super) fn next_ctx_size_after_oom(current: u32) -> Option<u32> {
+    let next = (current / 2).max(MIN_CTX_SIZE_FOR_RETRY);
+    // `next < current`, not `!=`: below the floor, halving+max would
+    // otherwise suggest a *larger* ctx-size after an OOM.
+    (next < current).then_some(next)
+}
+
+/// True if `detail` (a failed load's stderr tail, or an error message)
+/// looks like a memory-allocation failure rather than some other startup
+/// error. Matched against known ggml/llama.cpp allocator log phrasings —
+/// deliberately specific rather than one broad substring, since
+/// misclassifying an unrelated failure as OOM would burn several slow
+/// retries before surfacing the real error.
+pub(super) fn looks_like_oom(detail: &str) -> bool {
+    let d = detail.to_ascii_lowercase();
+    [
+        "failed to allocate",
+        "out of memory",
+        "not enough memory",
+        "insufficient memory",
+        "cudamalloc failed",
+        "std::bad_alloc",
+    ]
+    .iter()
+    .any(|needle| d.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_max_queue_defaults_to_ollamas_own_512_on_anything_unparseable() {
+        assert_eq!(parse_max_queue(None), 512);
+        assert_eq!(parse_max_queue(Some("")), 512);
+        assert_eq!(parse_max_queue(Some("garbage")), 512);
+        assert_eq!(parse_max_queue(Some("10")), 10);
+        // Unlike most other LLMMAN_*/parse_* pairs, an explicit "0" is a
+        // real value (disables the bound), not treated as unset.
+        assert_eq!(parse_max_queue(Some("0")), 0);
+    }
+
+    #[test]
+    fn parse_max_loaded_models_defaults_to_unbounded_on_anything_unparseable() {
+        assert_eq!(parse_max_loaded_models(None), 0);
+        assert_eq!(parse_max_loaded_models(Some("")), 0);
+        assert_eq!(parse_max_loaded_models(Some("garbage")), 0);
+        assert_eq!(parse_max_loaded_models(Some("3")), 3);
+    }
+
+    #[test]
+    fn parse_metrics_enabled_accepts_the_truthy_spellings_and_nothing_else() {
+        for on in ["1", "true", "TRUE", "yes", "on", " 1 "] {
+            assert!(parse_metrics_enabled(Some(on)), "{on:?} should enable");
+        }
+        for off in ["0", "false", "no", "off", "", "  ", "2", "enabled"] {
+            assert!(!parse_metrics_enabled(Some(off)), "{off:?} should not");
+        }
+        assert!(
+            !parse_metrics_enabled(None),
+            "unset is the default, and the default is off"
+        );
+    }
+
+    #[test]
+    fn parse_context_length_accepts_a_plain_number_and_rejects_everything_else() {
+        assert_eq!(parse_context_length(Some("32768")), Some(32768));
+        assert_eq!(parse_context_length(Some(" 32768 \n")), Some(32768));
+        assert_eq!(parse_context_length(Some("0")), Some(0));
+        assert_eq!(parse_context_length(None), None);
+        assert_eq!(parse_context_length(Some("")), None);
+        assert_eq!(parse_context_length(Some("not-a-number")), None);
+        assert_eq!(parse_context_length(Some("-1")), None);
+    }
+
+    #[test]
+    fn parse_flash_attention_accepts_llama_server_and_ollama_spellings() {
+        // llama-server's own vocabulary passes straight through.
+        assert_eq!(parse_flash_attention(Some("on")), Some("on".into()));
+        assert_eq!(parse_flash_attention(Some("off")), Some("off".into()));
+        assert_eq!(parse_flash_attention(Some("auto")), Some("auto".into()));
+        // Ollama's OLLAMA_FLASH_ATTENTION boolean spelling is translated.
+        assert_eq!(parse_flash_attention(Some("1")), Some("on".into()));
+        assert_eq!(parse_flash_attention(Some("true")), Some("on".into()));
+        assert_eq!(parse_flash_attention(Some("0")), Some("off".into()));
+        assert_eq!(parse_flash_attention(Some("false")), Some("off".into()));
+        // Case-insensitive, whitespace-tolerant.
+        assert_eq!(parse_flash_attention(Some(" ON \n")), Some("on".into()));
+        // Unset/empty leaves llama-server's own default untouched.
+        assert_eq!(parse_flash_attention(None), None);
+        assert_eq!(parse_flash_attention(Some("")), None);
+        assert_eq!(parse_flash_attention(Some("   ")), None);
+    }
+
+    #[test]
+    fn parse_kv_cache_type_trims_whitespace_and_treats_empty_as_unset() {
+        assert_eq!(parse_kv_cache_type(Some("q8_0")), Some("q8_0".into()));
+        assert_eq!(parse_kv_cache_type(Some(" q4_0 \n")), Some("q4_0".into()));
+        assert_eq!(parse_kv_cache_type(None), None);
+        assert_eq!(parse_kv_cache_type(Some("")), None);
+        assert_eq!(parse_kv_cache_type(Some("   ")), None);
+    }
+
+    #[test]
+    fn parse_sched_spread_maps_truthy_and_falsey_spellings_to_split_mode() {
+        for truthy in ["1", "true", "yes", "on", "layer", " ON \n"] {
+            assert_eq!(
+                parse_sched_spread(Some(truthy)),
+                Some("layer"),
+                "input {truthy:?}"
+            );
+        }
+        for falsey in ["0", "false", "no", "off", "none", " OFF \n"] {
+            assert_eq!(
+                parse_sched_spread(Some(falsey)),
+                Some("none"),
+                "input {falsey:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_sched_spread_leaves_llama_servers_own_default_untouched_when_unset_or_unparseable() {
+        assert_eq!(parse_sched_spread(None), None);
+        assert_eq!(parse_sched_spread(Some("")), None);
+        assert_eq!(parse_sched_spread(Some("   ")), None);
+        assert_eq!(parse_sched_spread(Some("garbage")), None);
+    }
+
+    #[test]
+    fn parse_num_parallel_accepts_a_positive_integer() {
+        assert_eq!(parse_num_parallel(Some("4")), Some(4));
+        assert_eq!(parse_num_parallel(Some(" 1 ")), Some(1));
+    }
+
+    #[test]
+    fn parse_num_parallel_rejects_zero_and_unparseable_values() {
+        assert_eq!(parse_num_parallel(Some("0")), None);
+        assert_eq!(parse_num_parallel(None), None);
+        assert_eq!(parse_num_parallel(Some("")), None);
+        assert_eq!(parse_num_parallel(Some("-1")), None);
+        assert_eq!(parse_num_parallel(Some("garbage")), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn cpu_list_count_counts_ids_and_inclusive_ranges() {
+        // (kernel CPU list, expected count)
+        let cases = [
+            ("0-15\n", Some(16)),
+            ("0", Some(1)),
+            ("0,4-7\n", Some(5)),
+            ("0-3,8-11\n", Some(8)),
+            // Malformed or empty content fails closed: the caller then
+            // passes no --threads and llama-server autodetects.
+            ("", None),
+            ("\n", None),
+            ("3-1", None),
+            ("0-x", None),
+            ("a", None),
+            ("0,,2", None),
+            // Range length would overflow u32; no kernel emits this.
+            ("0-4294967295", None),
+            ("0-4294967295,4", None),
+        ];
+        for (list, expected) in &cases {
+            assert_eq!(&cpu_list_count(list), expected, "list={list:?}");
+        }
+    }
+
+    #[test]
+    fn backend_ctx_size_scales_by_num_parallel_so_each_slot_keeps_the_full_context() {
+        // llama-server splits one --ctx-size evenly across every
+        // --parallel slot, so this must scale up to compensate —
+        // matching Ollama's own NumCtx * numParallel.
+        assert_eq!(backend_ctx_size(Some(4096), Some(4)), Some(16384));
+        assert_eq!(backend_ctx_size(Some(4096), Some(1)), Some(4096));
+        assert_eq!(backend_ctx_size(Some(4096), None), Some(4096));
+        assert_eq!(backend_ctx_size(None, Some(4)), None);
+        assert_eq!(backend_ctx_size(None, None), None);
+    }
+
+    #[test]
+    fn backend_ctx_size_saturates_instead_of_overflowing() {
+        assert_eq!(backend_ctx_size(Some(u32::MAX), Some(2)), Some(u32::MAX));
+    }
+
+    #[test]
+    fn effective_num_parallel_drops_to_none_without_a_ctx_size_to_scale() {
+        // Nothing to scale --parallel against, so don't forward it at
+        // all rather than let llama-server silently divide the model's
+        // own trained context across slots.
+        assert_eq!(effective_num_parallel(None, Some(4)), None);
+        assert_eq!(effective_num_parallel(Some(4096), Some(4)), Some(4));
+        assert_eq!(effective_num_parallel(Some(4096), None), None);
+        assert_eq!(effective_num_parallel(None, None), None);
+    }
+
+    #[test]
+    fn initial_ctx_size_caps_the_auto_default_at_the_trained_context() {
+        let auto = Some(DEFAULT_CTX_SIZE);
+        // Smaller trained context wins; larger leaves the default alone.
+        assert_eq!(
+            initial_ctx_size(auto, false, Some(32768), false),
+            Some(32768)
+        );
+        assert_eq!(initial_ctx_size(auto, false, Some(1 << 20), false), auto);
+        // No readable header: nothing to clamp against.
+        assert_eq!(initial_ctx_size(auto, false, None, false), auto);
+    }
+
+    #[test]
+    fn initial_ctx_size_forwards_an_explicit_value_unless_embedding() {
+        // A user's LLMMAN_CONTEXT_LENGTH is theirs to get wrong; 0 stays 0.
+        assert_eq!(
+            initial_ctx_size(Some(65536), true, Some(4096), false),
+            Some(65536)
+        );
+        assert_eq!(initial_ctx_size(Some(0), true, Some(4096), false), Some(0));
+        // Embedding models are capped regardless, and 0/None mean trained.
+        assert_eq!(
+            initial_ctx_size(Some(65536), true, Some(4096), true),
+            Some(4096)
+        );
+        assert_eq!(
+            initial_ctx_size(Some(2048), true, Some(4096), true),
+            Some(2048)
+        );
+        assert_eq!(
+            initial_ctx_size(Some(0), false, Some(4096), true),
+            Some(4096)
+        );
+        assert_eq!(initial_ctx_size(None, false, Some(4096), true), Some(4096));
+    }
+
+    #[test]
+    fn next_ctx_size_after_oom_halves_from_the_default_down_to_the_floor() {
+        assert_eq!(next_ctx_size_after_oom(DEFAULT_CTX_SIZE), Some(131072));
+        assert_eq!(next_ctx_size_after_oom(131072), Some(65536));
+        assert_eq!(next_ctx_size_after_oom(65536), Some(32768));
+        assert_eq!(next_ctx_size_after_oom(32768), Some(16384));
+        // At (or below) the floor, no further shrink is offered.
+        assert_eq!(next_ctx_size_after_oom(16384), None);
+        assert_eq!(next_ctx_size_after_oom(8192), None);
+    }
+
+    #[test]
+    fn default_ctx_size_reaches_the_floor_within_the_shrink_budget() {
+        // 262144 -> 131072 -> 65536 -> 32768 -> 16384: exactly
+        // MAX_CTX_SHRINK_ATTEMPTS halvings, so the floor is reachable.
+        let mut ctx = DEFAULT_CTX_SIZE;
+        let mut attempts = 0;
+        while let Some(next) = next_ctx_size_after_oom(ctx) {
+            ctx = next;
+            attempts += 1;
+        }
+        assert_eq!(ctx, MIN_CTX_SIZE_FOR_RETRY);
+        assert!(attempts <= MAX_CTX_SHRINK_ATTEMPTS);
+    }
+
+    #[test]
+    fn looks_like_oom_matches_known_allocation_failure_phrasings() {
+        for msg in [
+            "ggml_backend_alloc_ctx_tensors_from_buft: failed to allocate CUDA0 buffer of size 123",
+            "llama_kv_cache: failed to allocate buffer for kv cache",
+            "CUDA error: out of memory",
+            "terminate called after throwing an instance of 'std::bad_alloc'",
+            "cudaMalloc failed: out of memory",
+        ] {
+            assert!(looks_like_oom(msg), "expected OOM match for {msg:?}");
+        }
+    }
+
+    #[test]
+    fn looks_like_oom_does_not_flag_unrelated_startup_failures() {
+        for msg in [
+            "error while loading shared libraries: libcuda.so.1: cannot open shared object file",
+            "error loading model: unknown architecture 'not-a-real-arch'",
+            "error: unknown argument: --not-a-real-flag",
+        ] {
+            assert!(!looks_like_oom(msg), "unexpected OOM match for {msg:?}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

One slice of #429: move the env-var parsing and `*_from_env` / `parse_*` helpers, plus the context-size arithmetic (`initial_ctx_size`, `backend_ctx_size`, `effective_num_parallel`, and the OOM auto-shrink retry `next_ctx_size_after_oom` / `looks_like_oom`), out of `src/cmd/serve.rs` into a new `src/cmd/serve/config.rs`, following the existing `serve/aggregation.rs` / `serve/responses.rs` submodule pattern.

Pure move-code refactor — no behaviour changes. The diff is almost entirely moved lines.

## Changes

- New `src/cmd/serve/config.rs`:
  - env helpers: `context_length_from_env`, `flash_attention_from_env`, `kv_cache_type_from_env`, `sched_spread_from_env`, `num_parallel_from_env`, `threads_from_env_or_host` (+ `online_cpu_count`, `cpu_list_count`), `max_queue_from_env`, `max_loaded_models_from_env`, `metrics_enabled_from_env`
  - their `parse_*` companions and the `DEFAULT_CTX_SIZE` / `DEFAULT_MAX_QUEUE` / `MAX_CTX_SHRINK_ATTEMPTS` / `MIN_CTX_SIZE_FOR_RETRY` constants
  - ctx-size helpers: `backend_ctx_size`, `effective_num_parallel`, `initial_ctx_size`, `next_ctx_size_after_oom`, `looks_like_oom`
  - the corresponding unit tests, moved into a `#[cfg(test)] mod tests` in the new file
- `src/cmd/serve.rs`: added `mod config;` and qualified the moved call sites with `config::`. Functions only the submodule needs are `pub(super)`; everything else stays private.

Left in place (belongs to later slices, not config): `use_mlx_for_safetensors`, `supports_context_shift`, `gguf_trained_ctx`, `embedding_model_ctx`.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --lib --tests -- -D warnings` — clean
- `cargo build --bins` — succeeds
- `cargo test --lib` — 688 passed, 0 failed