### PR TITLE
Drop the caveats block from the Homebrew formula

### DIFF
--- a/packaging/homebrew/llmman.rb.in
+++ b/packaging/homebrew/llmman.rb.in
@@ -37,17 +37,6 @@ class Llmman < Formula
     bin.install Dir["llmman-*"].first => "llmman"
   end
 
-  def caveats
-    <<~EOS
-      llmman downloads a llama.cpp build matching your GPU on first use. To
-      get started:
-
-        llmman launch claude --model qwen3.8
-
-      Models and cached llama.cpp builds live under ~/.local/share/llmman.
-    EOS
-  end
-
   test do
     # CI writes this version into Cargo.toml before building, so the
     # binary reports it.


### PR DESCRIPTION
## Summary
- Remove the `caveats` block from `packaging/homebrew/llmman.rb.in`.
- The text it printed after `brew install` (`llmman launch claude --model qwen3.8`, the llama.cpp download on first use, the `~/.local/share/llmman` path) duplicates the README hero and Quick start sections that the formula's `homepage` already points at.

## Verification
- Nothing in `packaging/render.sh`, the CI "Check Homebrew formula" step, `publish-homebrew`, tests, or docs references `caveats`.
- The formula still satisfies every assertion in `ci.yml` (class, `version` line, three `url`s, three `sha256` lines).