### PR TITLE
Print help and exit 0 on a bare `llmman`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use llmman::{cmd, daemon, ffi, hostgpu};
 
 // ---------------------------------------------------------------------------
@@ -14,7 +14,7 @@ use llmman::{cmd, daemon, ffi, hostgpu};
 )]
 struct Cli {
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -104,7 +104,15 @@ fn main() {
     daemon::disable_std_handle_inheritance();
 
     let cli = Cli::parse_from(cmd::log::expand_count_shorthand(std::env::args_os()));
-    let result = match &cli.command {
+    // A bare `llmman` is a request for help, not a usage error: print it
+    // and exit 0 rather than clap's 2 (which winget's validator flags).
+    let Some(command) = &cli.command else {
+        Cli::command()
+            .print_help()
+            .expect("failed to write help to stdout");
+        return;
+    };
+    let result = match command {
         Commands::Launch(a) => cmd::launch::run(a),
         Commands::Run(a) => cmd::run::run(a),
         Commands::Build(a) => cmd::build::run(a),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,25 @@
+//! Cheap CLI checks that spawn the built binary; no model or network.
+
+use std::process::Command;
+
+fn llmman() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_llmman"))
+}
+
+/// A bare `llmman` prints help and exits 0 (clap's default for a missing
+/// subcommand is 2, which winget's package validator flags as an error).
+#[test]
+fn bare_invocation_prints_help_and_exits_0() {
+    let out = llmman().output().expect("spawn llmman");
+    assert!(out.status.success(), "exit status: {}", out.status);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Usage: llmman"), "stdout: {stdout}");
+    assert!(stdout.contains("launch"), "stdout: {stdout}");
+}
+
+/// An unknown subcommand is still a usage error.
+#[test]
+fn unknown_subcommand_exits_2() {
+    let out = llmman().arg("bogus").output().expect("spawn llmman");
+    assert_eq!(out.status.code(), Some(2));
+}


### PR DESCRIPTION
clap treats a missing subcommand as a usage error and exits 2. winget's
package validator runs the installed exe with no arguments and reports
that as ERROR_FILE_NOT_FOUND on every llmman PR (microsoft/winget-pkgs#430048).
A bare `llmman` is a request for help, so print it and exit 0; unknown
subcommands still exit 2.

Tested: new `tests/cli.rs` spawns the binary with no args (exit 0, help on stdout) and with an unknown subcommand (exit 2).