### PR TITLE
fix(runtime): give the backend container the daemon's CPU limit

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -65,6 +65,13 @@ On Linux, `--runtime docker` (or `podman`) runs `llama-server` from the
 for the host, suffixed with the pinned release.
 `CUDA_VISIBLE_DEVICES` and friends are forwarded into the container.
 
+The container is a sibling of the daemon, not part of its cgroup, so a
+CPU limit on `llmman serve` is forwarded: when one binds (cgroup quota or
+affinity mask), the container gets `--cpus <n>` and `llama-server` the
+matching `--threads <n>` (a quota alone would leave it autodetecting a
+thread per host core and throttling). No limit, no flags. An explicit
+`LLAMA_ARG_THREADS` still wins. vLLM containers get the same `--cpus`.
+
 Each of those images is also published with llmman in it, as
 `docker.io/ai/llmman:<tag>` (`latest` is `server`) and `<tag>-<llmman
 version>`, built from [`packaging/Dockerfile`](../packaging/Dockerfile) on

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -47,11 +47,10 @@ only when the stored models should be deleted as well.
 uses llmman's default local backend, so the `llama-server` child shares the
 service's cgroup and llmman can derive its thread count from that limit.
 
-This differs from `llmman serve --runtime docker` or `--runtime podman`: those
-modes create a separate backend container, and the service's CPU quota is not
-forwarded to it yet ([#324](https://github.com/llmmanorg/llmman/issues/324)). If
-you adapt this example to use a container runtime, set `LLAMA_ARG_THREADS` explicitly or
-apply a CPU limit to the backend container separately.
+With `--runtime docker` or `--runtime podman` the backend runs in a separate
+container, a sibling of the service. The service's limit is forwarded to it as
+`--cpus`, with a matching `--threads` for `llama-server`; an unconstrained
+daemon starts an unconstrained container, and `LLAMA_ARG_THREADS` still wins.
 
 ## Customizing the gateway
 

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -54,11 +54,12 @@ use backend::{
 pub use backend::{GPU_VISIBLE_DEVICE_VARS, LLAMA_CPP_ENV_PASSTHROUGH_VARS};
 pub use config::DEFAULT_CTX_SIZE;
 use config::{
-    backend_ctx_size, context_length_from_env, effective_num_parallel, embedding_model_ctx,
-    flash_attention_from_env, gguf_trained_ctx, initial_ctx_size, kv_cache_type_from_env,
-    looks_like_oom, max_loaded_models_from_env, max_queue_from_env, metrics_enabled_from_env,
-    next_ctx_size_after_oom, num_parallel_from_env, sched_spread_from_env, supports_context_shift,
-    threads_from_env_or_host, tls_from_env, MAX_CTX_SHRINK_ATTEMPTS,
+    backend_ctx_size, container_cpu_limit, context_length_from_env, effective_num_parallel,
+    embedding_model_ctx, flash_attention_from_env, gguf_trained_ctx, initial_ctx_size,
+    kv_cache_type_from_env, looks_like_oom, max_loaded_models_from_env, max_queue_from_env,
+    metrics_enabled_from_env, next_ctx_size_after_oom, num_parallel_from_env,
+    sched_spread_from_env, supports_context_shift, threads_from_env_or_host, tls_from_env,
+    MAX_CTX_SHRINK_ATTEMPTS,
 };
 use ollama::{
     handle_blob_head, handle_blob_upload, handle_copy, handle_create, handle_delete, handle_embed,
@@ -234,10 +235,12 @@ struct Inner {
     // See num_parallel_from_env's doc comment.
     num_parallel: Option<u32>,
     // See threads_from_env_or_host's doc comment. Resolved once at
-    // startup (this daemon's cgroup doesn't change per load) and passed
-    // to every *local* spawn_llama_server call from ensure_model's OOM
-    // retry loop.
+    // startup and passed to every llama-server spawn.
     threads: Option<u32>,
+    // See container_cpu_limit's doc comment: the backend container's
+    // `--cpus`. Snapshotted with `threads` so a later cgroup change
+    // cannot leave the two disagreeing.
+    cpu_limit: Option<f64>,
     // See max_queue_from_env's doc comment; enforced by try_admit.
     max_queue: usize,
     // See max_loaded_models_from_env's doc comment.
@@ -1858,8 +1861,8 @@ async fn local_context_overflow(resp: Response) -> Result<Response, String> {
 /// per-request ctx change, the option only takes effect on a fresh
 /// load: the `check_running` short-circuits below reuse an
 /// already-running instance as-is, never reloading it for a different
-/// thread count. Under a container runtime it is ignored along with the derived
-/// value; see `container::LlamaOptions::threads` for why.
+/// thread count. A backend container gets the same `--threads`, plus
+/// the daemon's CPU limit as `--cpus`; see `container::run_args`.
 async fn ensure_model(
     state: &AppState,
     model_ref: &str,
@@ -2072,6 +2075,7 @@ async fn ensure_model(
             // See ensure_model's `request_threads` doc comment for the
             // full precedence chain this `.or` implements.
             threads: request_threads.or(state.0.threads),
+            cpus: state.0.cpu_limit,
         };
         // Every piped child gets an output tail for crash reasons; only
         // llama-server ones join the OOM retry loop below, whose
@@ -2080,8 +2084,6 @@ async fn ensure_model(
         let mut oom_retryable = false;
         let max_model_len = vllm_max_model_len(ctx_size, state.0.ctx_size_explicit);
         process = match (&model_path, state.0.runtime.ociman()) {
-            // container::spawn ignores llama_opts.threads; see that
-            // field's doc comment.
             (ModelPath::Gguf(path, mmproj), Some(ociman)) => {
                 let mut child = crate::container::spawn(
                     ociman,
@@ -2111,6 +2113,7 @@ async fn ensure_model(
                     &state.0.cache_path,
                     state.0.llama_cpp_version.as_deref(),
                     port,
+                    state.0.cpu_limit,
                 )?;
                 stderr_tail = Some(tail_child_output(&mut child));
                 oom_retryable = true;
@@ -2131,6 +2134,7 @@ async fn ensure_model(
                     dir,
                     state.0.vllm_version.as_deref(),
                     port,
+                    state.0.cpu_limit,
                     |model_dir, host| {
                         vllm_serve_args(model_dir, host, port, model_ref, max_model_len)
                     },
@@ -2147,6 +2151,7 @@ async fn ensure_model(
                     dir,
                     state.0.vllm_version.as_deref(),
                     port,
+                    state.0.cpu_limit,
                     |model_dir, host| {
                         vllm_omni_serve_args_from_env(model_dir, host, port, model_ref)
                     },
@@ -4973,18 +4978,17 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         );
     }
 
-    // See threads_from_env_or_host's doc comment. Resolved once here
-    // rather than per load, and logged so a surprising thread count is
-    // explainable from the startup output. Only the local spawn path
-    // consumes the derived value, so don't log it under a container
-    // runtime (that arm deliberately ignores it).
+    // Resolved once and logged, so a surprising thread count or
+    // container limit is explainable from the startup output.
+    let cpu_limit = container_cpu_limit();
     let threads = threads_from_env_or_host();
     if let Some(n) = threads {
-        if runtime.ociman().is_none() {
-            eprintln!("[llmman] llama-server gets --threads {n} (CPU quota/affinity limit below the online CPU count)");
-        }
+        eprintln!("[llmman] llama-server gets --threads {n} (CPU quota/affinity limit below the online CPU count)");
     } else if std::env::var_os("LLAMA_ARG_THREADS").is_some() {
         eprintln!("[llmman] LLAMA_ARG_THREADS set: leaving llama-server thread count to it");
+    }
+    if let (Some(n), Some(_)) = (cpu_limit, runtime.ociman()) {
+        eprintln!("[llmman] backend container gets --cpus {n} (this daemon's own CPU limit)");
     }
 
     // Before anything binds, so a misconfiguration fails at exec.
@@ -5033,6 +5037,7 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         split_mode: sched_spread_from_env(),
         num_parallel: num_parallel_from_env(),
         threads,
+        cpu_limit,
         max_queue: max_queue_from_env(),
         max_loaded_models: max_loaded_models_from_env(),
         peers,

--- a/src/cmd/serve/backend.rs
+++ b/src/cmd/serve/backend.rs
@@ -108,6 +108,8 @@ pub(super) async fn spawn_llama_server(
         embeddings,
         batch_size,
         threads,
+        // A local child shares the daemon's cgroup already.
+        cpus: _,
     } = opts;
     let mut cmd = tokio::process::Command::new(bin);
     cmd.args([

--- a/src/cmd/serve/config.rs
+++ b/src/cmd/serve/config.rs
@@ -123,26 +123,29 @@ fn parse_num_parallel(value: Option<&str>) -> Option<u32> {
     (n != 0).then_some(n)
 }
 
-/// `--threads <n>` for local `llama-server` spawns, `Some` only when a
-/// CPU limit binds. llama-server's own autodetection
-/// (`cpu_get_num_math()`) already picks the physical/math cores, so an
-/// unconstrained host passes nothing and leaves that choice alone. The
-/// derived value only corrects the case autodetection cannot see: a
-/// cgroup CPU quota, or a narrowed affinity mask, both carried by
-/// `std::thread::available_parallelism` (std walks /proc/self/cgroup
-/// and the ancestor chain itself, v1 and v2). A limit binds when
-/// `available_parallelism` is below the online CPU count; then that
-/// smaller value is passed. Accepted tradeoff: a quota between the
-/// physical-core and SMT-thread counts (e.g. --cpus=12 on an
-/// 8-core/16-thread host) passes 12 where autodetection would pick 8.
-/// Any read or parse failure returns `None`: fail closed to
-/// autodetection. `LLAMA_ARG_THREADS` set in the environment wins:
-/// llama-server reads it itself via plain env inheritance, so `None`
-/// here keeps that explicit choice untouched.
+/// `--threads <n>` for every `llama-server` this daemon spawns, `Some`
+/// only when a CPU limit binds ([`host_cpu_limit`]). Unconstrained,
+/// llama-server's own autodetection (`cpu_get_num_math()`) already
+/// picks the math cores; the derived value only corrects what it
+/// cannot see: a cgroup quota or a narrowed affinity mask. Accepted
+/// tradeoff: a quota between the physical-core and SMT-thread counts
+/// (`--cpus=12` on 8c/16t) passes 12 where autodetection would pick 8.
+/// `LLAMA_ARG_THREADS` set wins: `None` here, llama-server reads it
+/// itself (in a container, via `LLAMA_CPP_ENV_PASSTHROUGH_VARS`).
 pub(super) fn threads_from_env_or_host() -> Option<u32> {
     if std::env::var_os("LLAMA_ARG_THREADS").is_some() {
         return None;
     }
+    host_cpu_limit()
+}
+
+/// This daemon's effective CPU limit in whole CPUs, `Some(n)` only when
+/// one binds: `std::thread::available_parallelism` — min(affinity,
+/// cgroup quota), floored, at least 1; std walks the cgroup ancestor
+/// chain itself, v1 and v2 — below the online CPU count from
+/// /sys/devices/system/cpu/online. Any read failure is `None`: fail
+/// closed. Linux only.
+pub(super) fn host_cpu_limit() -> Option<u32> {
     #[cfg(target_os = "linux")]
     {
         let allowed = std::thread::available_parallelism().ok()?.get() as u32;
@@ -151,6 +154,62 @@ pub(super) fn threads_from_env_or_host() -> Option<u32> {
     }
     #[cfg(not(target_os = "linux"))]
     None
+}
+
+/// The backend container's `--cpus`: this daemon's cgroup v2 quota as a
+/// fraction (the tightest `cpu.max` on its own chain, so `0.5` stays
+/// `0.5`), capped by its affinity mask; without a v2 quota, the
+/// whole-CPU [`host_cpu_limit`] (a cgroup v1 quota is floored). `Some`
+/// only when it binds. Needed even when `LLAMA_ARG_THREADS` owns the
+/// thread count.
+pub(super) fn container_cpu_limit() -> Option<f64> {
+    #[cfg(target_os = "linux")]
+    {
+        let online = online_cpu_count()?;
+        let limit = match cgroup_v2_cpu_quota() {
+            Some(q) => q.min(f64::from(affinity_cpu_count().unwrap_or(online))),
+            None => f64::from(host_cpu_limit()?),
+        };
+        (limit < f64::from(online)).then_some(limit)
+    }
+    #[cfg(not(target_os = "linux"))]
+    None
+}
+
+/// CPUs in this process's affinity mask, from `Cpus_allowed_list` in
+/// /proc/self/status.
+#[cfg(target_os = "linux")]
+fn affinity_cpu_count() -> Option<u32> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    let list = status
+        .lines()
+        .find_map(|l| l.strip_prefix("Cpus_allowed_list:"))?;
+    cpu_list_count(list)
+}
+
+/// The tightest `cpu.max` quota, in CPUs, from this process's cgroup v2
+/// node up to the root; `None` without one.
+#[cfg(target_os = "linux")]
+fn cgroup_v2_cpu_quota() -> Option<f64> {
+    let cgroup = std::fs::read_to_string("/proc/self/cgroup").ok()?;
+    let rel = cgroup.lines().find_map(|l| l.strip_prefix("0::"))?.trim();
+    let root = std::path::Path::new("/sys/fs/cgroup");
+    root.join(rel.trim_start_matches('/'))
+        .ancestors()
+        .take_while(|d| d.starts_with(root))
+        .filter_map(|d| std::fs::read_to_string(d.join("cpu.max")).ok())
+        .filter_map(|s| parse_cpu_max(&s))
+        .reduce(f64::min)
+}
+
+/// `cpu.max`'s `<quota> <period>` in microseconds as CPUs; `max <period>`
+/// (unlimited) or malformed content is `None`.
+#[cfg(target_os = "linux")]
+fn parse_cpu_max(content: &str) -> Option<f64> {
+    let mut parts = content.split_whitespace();
+    let quota: f64 = parts.next()?.parse().ok()?;
+    let period: f64 = parts.next()?.parse().ok()?;
+    (quota > 0.0 && period > 0.0).then(|| quota / period)
 }
 
 /// Online CPUs from /sys/devices/system/cpu/online, the baseline
@@ -547,6 +606,17 @@ mod tests {
         ];
         for (list, expected) in &cases {
             assert_eq!(&cpu_list_count(list), expected, "list={list:?}");
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_cpu_max_reads_quota_over_period_and_treats_max_as_unlimited() {
+        assert_eq!(parse_cpu_max("200000 100000\n"), Some(2.0));
+        assert_eq!(parse_cpu_max("50000 100000\n"), Some(0.5));
+        assert_eq!(parse_cpu_max("150000 100000"), Some(1.5));
+        for bad in ["max 100000\n", "", "100000", "0 100000", "100000 0", "x y"] {
+            assert_eq!(parse_cpu_max(bad), None, "{bad:?}");
         }
     }
 

--- a/src/cmd/serve/tests.rs
+++ b/src/cmd/serve/tests.rs
@@ -2017,6 +2017,7 @@ fn test_inner(store_path: PathBuf) -> Inner {
         split_mode: None,
         num_parallel: None,
         threads: None,
+        cpu_limit: None,
         // usize::MAX, not 0 — 0 now means "admit almost nothing"
         // (see try_admit_against's doc comment), and no test here
         // calls ensure_model (the only caller of try_admit) directly

--- a/src/container.rs
+++ b/src/container.rs
@@ -505,19 +505,20 @@ pub struct LlamaOptions<'a> {
     /// needs a whole input in one ubatch.
     pub batch_size: Option<u32>,
 
-    /// `--threads <n>`: a request's Ollama `options.num_thread` when
-    /// set, else the derived host-limit value, which is `Some` only
-    /// when a CPU limit (cgroup quota or affinity) binds; see
-    /// `cmd::serve::ensure_model`'s `request_threads` parameter and
-    /// `cmd::serve::config::threads_from_env_or_host`. Deliberately ignored by
-    /// [`spawn`], whichever source it came from: the derived value
-    /// describes the daemon's cgroup, which says nothing about the
-    /// limits of the fresh container llama-server runs in, and a
-    /// request's num_thread counts host cores the container may not
-    /// have either, so both stay local-spawn-only until container CPU
-    /// limits are plumbed deliberately. An explicit LLAMA_ARG_THREADS
-    /// still reaches the container via LLAMA_CPP_ENV_PASSTHROUGH_VARS.
+    /// `--threads <n>`: a request's Ollama `options.num_thread`, else the
+    /// derived host-limit value (see `cmd::serve::ensure_model`'s
+    /// `request_threads` and `cmd::serve::config::threads_from_env_or_host`).
+    /// Forwarded into the container too, since `cpus` gives it the same
+    /// CPU budget the value was derived from. An explicit
+    /// LLAMA_ARG_THREADS leaves this `None` and reaches the container via
+    /// LLAMA_CPP_ENV_PASSTHROUGH_VARS instead.
     pub threads: Option<u32>,
+
+    /// `--cpus <n>` on the container: the daemon's own CPU limit, `Some`
+    /// only when one binds (see `cmd::serve::config::container_cpu_limit`).
+    /// Snapshotted at startup together with `threads`, so the two
+    /// always agree.
+    pub cpus: Option<f64>,
 }
 
 /// Callers must stop this gracefully (SIGTERM, not the default
@@ -542,6 +543,53 @@ pub fn spawn(
     llama_cpp_version: Option<&str>,
     opts: LlamaOptions<'_>,
 ) -> Result<tokio::process::Child> {
+    let backend = detect_backend();
+    let image = backend.image_ref(llama_cpp_version);
+    eprintln!(
+        "[llmman] {}: detected {:?}, using image {:?}",
+        ociman.binary(),
+        backend,
+        image
+    );
+    let (model_dir, model_file) = mount_split(model_path, "model")?;
+    let mmproj = mmproj_path.map(|p| mount_split(p, "mmproj")).transpose()?;
+    let args = llama_run_args(
+        backend,
+        image,
+        &model_dir,
+        &model_file,
+        mmproj.as_ref().map(|(d, f)| (d.as_str(), f.as_str())),
+        crate::cmd::serve::LLAMA_CPP_ENV_PASSTHROUGH_VARS,
+        opts,
+    );
+    run(ociman, args)
+}
+
+/// A file's bind-mount source directory (see [`mount_source`]) and its
+/// UTF-8 file name, for `-v <dir>:/x:ro` plus `/x/<file>`.
+fn mount_split(path: &Path, what: &str) -> Result<(String, String)> {
+    let dir = path
+        .parent()
+        .with_context(|| format!("{what} path has no parent directory"))?;
+    let file = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .with_context(|| format!("{what} path has no valid UTF-8 filename"))?;
+    Ok((mount_source(dir)?, file.to_owned()))
+}
+
+/// [`spawn`]'s argv, split out so the flags are testable without an
+/// engine. `mmproj` is the mmproj's `(mount dir, file name)`, mounted
+/// as its own `/mmproj` volume.
+fn llama_run_args(
+    backend: GpuBackend,
+    image: String,
+    model_dir: &str,
+    model_file: &str,
+    mmproj: Option<(&str, &str)>,
+    passthrough_vars: &[&str],
+    opts: LlamaOptions<'_>,
+) -> Vec<String> {
     let LlamaOptions {
         port,
         ctx_size,
@@ -552,45 +600,16 @@ pub fn spawn(
         num_parallel,
         embeddings,
         batch_size,
-        // See the field's doc comment: neither the derived value nor a
-        // request's num_thread describes the container's own CPU limits.
-        threads: _,
+        threads,
+        cpus,
     } = opts;
-    let backend = detect_backend();
-    let image = backend.image_ref(llama_cpp_version);
-    eprintln!(
-        "[llmman] {}: detected {:?}, using image {:?}",
-        ociman.binary(),
-        backend,
-        image
-    );
-
-    let model_dir = model_path
-        .parent()
-        .context("model path has no parent directory")?;
-    let model_file = model_path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .context("model path has no valid UTF-8 filename")?;
-    let model_dir = mount_source(model_dir)?;
-
-    let mut args = run_args(
-        backend.engine_args(),
-        port,
-        crate::cmd::serve::LLAMA_CPP_ENV_PASSTHROUGH_VARS,
-    );
+    let mut args = run_args(backend.engine_args(), port, passthrough_vars, cpus);
     args.push("-v".into());
     args.push(format!("{model_dir}:/models:ro"));
-    let mmproj_file = mmproj_path
-        .map(|p| -> Result<&str> {
-            let dir = p.parent().context("mmproj path has no parent directory")?;
-            args.push("-v".into());
-            args.push(format!("{}:/mmproj:ro", mount_source(dir)?));
-            p.file_name()
-                .and_then(|n| n.to_str())
-                .context("mmproj path has no valid UTF-8 filename")
-        })
-        .transpose()?;
+    if let Some((dir, _)) = mmproj {
+        args.push("-v".into());
+        args.push(format!("{dir}:/mmproj:ro"));
+    }
     args.push(image);
     args.extend([
         "-m".into(),
@@ -600,9 +619,9 @@ pub fn spawn(
         "--host".into(),
         "0.0.0.0".into(),
     ]);
-    if let Some(mmproj_file) = mmproj_file {
+    if let Some((_, file)) = mmproj {
         args.push("--mmproj".into());
-        args.push(format!("/mmproj/{mmproj_file}"));
+        args.push(format!("/mmproj/{file}"));
     }
     if let Some(n) = ctx_size {
         args.push("--ctx-size".into());
@@ -643,17 +662,36 @@ pub fn spawn(
         args.push("-ub".into());
         args.push(n.to_string());
     }
-
-    run(ociman, args)
+    // Pairs with `--cpus` (see run_args): a quota alone leaves
+    // autodetection starting a thread per host core.
+    if let Some(n) = threads {
+        args.push("--threads".into());
+        args.push(n.to_string());
+    }
+    args
 }
 
 /// The `run` prefix every container here starts with: attached with an
-/// init, the port published, the GPU passed through (`engine_args`), and
-/// the GPU-visibility env vars plus the engine's own `passthrough_vars`
+/// init, the port published, the daemon's CPU limit forwarded as
+/// `--cpus` (`cpus`), the GPU passed through (`engine_args`), and the
+/// GPU-visibility env vars plus the engine's own `passthrough_vars`
 /// forwarded (`docker run` does not inherit the environment). `-e NAME`
 /// without a value: the engine copies it from our environment, so a
 /// secret (`VLLM_API_KEY`) never appears in argv or the debug log.
-fn run_args(engine_args: Vec<String>, port: u16, passthrough_vars: &[&str]) -> Vec<String> {
+///
+/// `cpus`: the container is a sibling of the daemon in its own cgroup
+/// (under dockerd or the rootless user slice), so a quota on `llmman
+/// serve` never reaches it on its own, and all of the CPU work would
+/// run unlimited behind a capped proxy (llmmanorg/llmman#324). `None`
+/// (no limit binds) adds nothing. It is a CFS quota even when the
+/// daemon's limit is an affinity mask: the budget is what matters, and
+/// it is the one form both engines share.
+fn run_args(
+    engine_args: Vec<String>,
+    port: u16,
+    passthrough_vars: &[&str],
+    cpus: Option<f64>,
+) -> Vec<String> {
     let mut args: Vec<String> = vec![
         "run".into(),
         "--rm".into(),
@@ -662,6 +700,10 @@ fn run_args(engine_args: Vec<String>, port: u16, passthrough_vars: &[&str]) -> V
         "-p".into(),
         format!("127.0.0.1:{port}:{port}"),
     ];
+    if let Some(n) = cpus {
+        args.push("--cpus".into());
+        args.push(n.to_string());
+    }
     args.extend(engine_args);
     for var in crate::cmd::serve::GPU_VISIBLE_DEVICE_VARS
         .iter()
@@ -689,6 +731,7 @@ pub fn spawn_vllm(
     model_dir: &Path,
     vllm_version: Option<&str>,
     port: u16,
+    cpus: Option<f64>,
     serve_args: impl FnOnce(&str, &str) -> Vec<String>,
 ) -> Result<tokio::process::Child> {
     let (backend, arch) = VllmBackend::detect()?;
@@ -713,7 +756,9 @@ pub fn spawn_vllm(
         })
         .collect();
     let vllm_vars: Vec<&str> = vllm_vars.iter().map(String::as_str).collect();
-    let args = vllm_run_args(backend, image, &model_dir, port, &vllm_vars, serve_args);
+    let args = vllm_run_args(
+        backend, image, &model_dir, port, &vllm_vars, cpus, serve_args,
+    );
     run(ociman, args)
 }
 
@@ -736,9 +781,10 @@ fn vllm_run_args(
     model_dir: &str,
     port: u16,
     passthrough_vars: &[&str],
+    cpus: Option<f64>,
     serve_args: impl FnOnce(&str, &str) -> Vec<String>,
 ) -> Vec<String> {
-    let mut args = run_args(backend.engine_args(), port, passthrough_vars);
+    let mut args = run_args(backend.engine_args(), port, passthrough_vars, cpus);
     args.extend([
         "-v".into(),
         format!("{model_dir}:/models:ro"),
@@ -777,6 +823,7 @@ pub fn spawn_mediagen(
     cache_path: &Path,
     llama_cpp_version: Option<&str>,
     port: u16,
+    cpus: Option<f64>,
 ) -> Result<tokio::process::Child> {
     let backend = detect_backend();
     let image = backend.image_ref(llama_cpp_version);
@@ -798,7 +845,7 @@ pub fn spawn_mediagen(
         crate::cmd::serve::MEDIAGEN_ENV_PASSTHROUGH_VARS,
     ]
     .concat();
-    let mut args = run_args(backend.engine_args(), port, &passthrough);
+    let mut args = run_args(backend.engine_args(), port, &passthrough, cpus);
     args.extend([
         "-v".into(),
         format!("{exe}:/usr/local/bin/llmman:ro"),
@@ -1158,6 +1205,7 @@ mod tests {
             "/cache/abc/model",
             8000,
             &[],
+            None,
             |dir, host| {
                 vec![
                     "serve".into(),
@@ -1198,16 +1246,84 @@ mod tests {
     fn run_args_forward_only_the_requested_passthrough_vars() {
         const VAR: &str = "LLMMAN_TEST_RUN_ARGS_PASSTHROUGH";
         std::env::set_var(VAR, "1");
-        let args = run_args(vec![], 8080, &[]);
+        let args = run_args(vec![], 8080, &[], None);
         assert_eq!(
             &args[..6],
             &["run", "--rm", "--init", "-t", "-p", "127.0.0.1:8080:8080"]
         );
         assert!(!args.contains(&VAR.to_string()), "{args:?}");
-        let args = run_args(vec![], 8080, &[VAR]);
+        let args = run_args(vec![], 8080, &[VAR], None);
         assert!(args.windows(2).any(|w| w == ["-e", VAR]), "{args:?}");
         // The value stays out of argv (it may be a secret).
         assert!(!args.iter().any(|a| a.starts_with(&format!("{VAR}="))));
+    }
+
+    #[test]
+    fn cpus_is_forwarded_as_a_run_flag_only_when_a_limit_binds() {
+        let args = run_args(vec![], 8080, &[], None);
+        assert!(!args.contains(&"--cpus".to_string()), "{args:?}");
+        let args = run_args(vec!["--gpus".into(), "all".into()], 8080, &[], Some(2.0));
+        let cpus = args.iter().position(|a| a == "--cpus").unwrap();
+        assert_eq!(args[cpus + 1], "2");
+        // A `run` flag: before the engine args, image and engine argv.
+        assert!(cpus < args.iter().position(|a| a == "--gpus").unwrap());
+        // A fractional cgroup quota is kept, not rounded to a whole CPU.
+        let args = run_args(vec![], 8080, &[], Some(0.5));
+        assert!(args.windows(2).any(|w| w == ["--cpus", "0.5"]), "{args:?}");
+    }
+
+    #[test]
+    fn llama_container_gets_cpus_before_the_image_and_threads_after() {
+        let opts = |threads, cpus| LlamaOptions {
+            port: 8080,
+            ctx_size: None,
+            flash_attention: None,
+            kv_cache_type: None,
+            context_shift: true,
+            split_mode: None,
+            num_parallel: None,
+            embeddings: false,
+            batch_size: None,
+            threads,
+            cpus,
+        };
+        let image = "ghcr.io/ggml-org/llama.cpp:server";
+        let argv = |o| {
+            llama_run_args(
+                GpuBackend::Cpu,
+                image.into(),
+                "/cache/blobs",
+                "sha256-abc",
+                None,
+                &[],
+                o,
+            )
+        };
+        let args = argv(opts(Some(2), Some(2.0)));
+        let at = |flag: &str| args.iter().position(|a| a == flag).unwrap();
+        assert!(at("--cpus") < at(image), "{args:?}");
+        assert!(at(image) < at("--threads"), "{args:?}");
+        assert_eq!(args[at("--cpus") + 1], "2");
+        assert_eq!(args[at("--threads") + 1], "2");
+        let args = argv(opts(None, None));
+        assert!(
+            !args.iter().any(|a| a == "--cpus" || a == "--threads"),
+            "{args:?}"
+        );
+    }
+
+    #[test]
+    fn vllm_containers_get_cpus_too() {
+        let args = vllm_run_args(
+            VllmBackend::Cpu,
+            "docker.io/vllm/vllm-openai-cpu:latest-x86_64".into(),
+            "/cache/abc/model",
+            8000,
+            &[],
+            Some(3.0),
+            |dir, host| vec!["serve".into(), dir.into(), "--host".into(), host.into()],
+        );
+        assert!(args.windows(2).any(|w| w == ["--cpus", "3"]), "{args:?}");
     }
 
     /// Exercises real end-to-end backend detection (via


### PR DESCRIPTION
Fixes #324.

A `--runtime docker|podman` container is a sibling of the daemon, not part of its cgroup, so a CPU limit on `llmman serve` never reached it. Reproduced on main with the daemon in a 2-CPU scope: no CPU flag in the `docker run` argv, container `cpu.max` = `max`, `n_threads = 20`.

## Change

- `container_cpu_limit()`: the fractional cgroup v2 `cpu.max` on the daemon's own chain (`0.5` stays `0.5`) capped by the affinity mask, else the whole-CPU `host_cpu_limit()` split out of `threads_from_env_or_host`. Snapshotted once at startup on `Inner` next to `threads`, so the two can't drift.
- `run_args` forwards it as `--cpus` for every container (llama.cpp, vLLM, Omni, mediagen).
- `container::spawn` forwards `LlamaOptions::threads` as `--threads`; its argv is now built by a pure `llama_run_args` (like `vllm_run_args`) so this is unit-tested.

Both halves are needed: `--cpus` is a CFS quota, not a cpuset, so a quota alone leaves llama-server autodetecting a thread per *host* core (#322 one level down). podman, CPU image, `ai/qwen3.5:0.8b`:

| container | tok/s |
|---|---|
| no flags (main) | ~21 |
| `--cpus 2` only | ~2 |
| `--cpus 2 --threads 2` (this PR) | ~63 |

No limit: no new flags, argv unchanged. `LLAMA_ARG_THREADS` still wins the thread count; the container still gets `--cpus`.

## Verified

`fmt`, `clippy -D warnings`, tests. End to end (20-core host, cgroup v2, Docker 29.2.1, rootless Podman 4.9.3), one completion each:

| daemon | argv | container `cpu.max` | `n_threads` |
|---|---|---|---|
| `--runtime docker`, 200% | `--cpus 2 … --threads 2` | `200000 100000` | 2 |
| `--runtime podman`, 300% | `--cpus 3 … --threads 3` | `300000 100000` | 3 |
| `--runtime podman`, 150% | `--cpus 1.5 … --threads 1` | `150000 100000` | 1 |
| `--runtime podman`, 200%, `LLAMA_ARG_THREADS=5` | `--cpus 2 -e LLAMA_ARG_THREADS` | `200000 100000` | 5 |
| `--runtime podman`, 800% + `taskset -c 0,1` | `--cpus 2 … --threads 2` | — | 2 |
| `--runtime podman`, no quota | neither | `max 100000` | 20 |